### PR TITLE
ci(github): add quality gate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  quality-gate:
+    name: Quality Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run quality gate
+        run: pnpm run ci

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pnpm test:e2e
 Full local CI-equivalent check:
 
 ```bash
-pnpm ci
+pnpm run ci
 ```
 
 The scaffold intentionally contains only the application shell, architecture folders, and tooling. Repository analysis, reviewer assessment, persistence, auth, and deployment integrations are tracked as separate issues.


### PR DESCRIPTION
## Scope

Closes #5. Adds the GitHub Actions quality gate workflow for pull requests and pushes to `main`.

## Non-Goals

- Does not add commit-msg hooks (#7)
- Does not add unsafe type escape guard (#6)
- Does not configure branch protection in GitHub UI
- Does not configure Vercel deployment (#45)

## Test Evidence

Commands run locally:

```text
pnpm install --frozen-lockfile
pnpm run ci
```

Local command passed.

## Architecture And Docs

- Follows `docs/architecture.md` CI gate direction
- Updates README to use `pnpm run ci` for the package script

## Type Safety

No runtime code or type assertions changed.

## Risk And Rollback

Primary risk is GitHub runner dependency setup, especially Playwright browser install. Roll back by reverting the workflow commit.

## Dependencies

No new dependencies.