### PR TITLE
test(type-safety): guard unsafe type escapes

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-commit:
+  commands:
+    type-escape-check:
+      run: pnpm run type-escape:check

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
     "start": "next start",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
+    "type-escape:check": "node scripts/check-type-escapes.mjs",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "typecheck": "rm -rf .next/types .next/dev/types && NODE_ENV=development next typegen && tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:e2e": "playwright test --pass-with-no-tests",
-    "check": "pnpm lint && pnpm format:check && pnpm typecheck && pnpm test",
+    "check": "pnpm run type-escape:check && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test",
     "ci": "pnpm check && pnpm build && pnpm test:e2e"
   },
   "dependencies": {

--- a/scripts/check-type-escapes.mjs
+++ b/scripts/check-type-escapes.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const sourceExtensions = new Set([".cts", ".mts", ".ts", ".tsx"]);
+const ignoredDirectoryNames = new Set([
+  ".git",
+  ".next",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "test-results",
+]);
+const ignoredFileNames = new Set([
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+]);
+const defaultIgnoredRelativePaths = new Set([
+  "test/fixtures/type-escapes/rejected",
+]);
+const marker = "type-escape:";
+const markerLookbackLineCount = 3;
+const anyKeyword = "any";
+const patternLabel = (parts) => parts.join(" ");
+
+const forbiddenPatterns = [
+  {
+    name: patternLabel(["as", anyKeyword]),
+    regex: /\bas\s+any\b/g,
+  },
+  {
+    name: patternLabel([":", anyKeyword]),
+    regex: new RegExp(`:\\s*${anyKeyword}\\b`, "g"),
+  },
+  {
+    name: `<${anyKeyword}>`,
+    regex: new RegExp(`<\\s*${anyKeyword}\\s*>`, "g"),
+  },
+  {
+    name: patternLabel(["as", "unknown", "as"]),
+    regex: /\bas\s+unknown\s+as\b/g,
+  },
+];
+
+const args = process.argv.slice(2);
+const root = process.cwd();
+const explicitTargets = args.length > 0;
+const targets = explicitTargets ? args : ["."];
+const files = [];
+
+for (const target of targets) {
+  await collectFiles(path.resolve(root, target), explicitTargets);
+}
+
+const violations = [];
+
+for (const filePath of files) {
+  const text = await readFile(filePath, "utf8");
+  violations.push(...findViolations(filePath, text));
+}
+
+if (violations.length > 0) {
+  console.error("Unsafe TypeScript type escapes found:");
+  for (const violation of violations) {
+    const relativePath = path.relative(root, violation.filePath);
+    console.error(
+      `- ${relativePath}:${violation.line}:${violation.column} ${violation.pattern}`,
+    );
+  }
+  console.error(
+    `Add a nearby '${marker}' comment only for validated boundary-adapter exceptions.`,
+  );
+  process.exitCode = 1;
+}
+
+async function collectFiles(targetPath, includeDefaultFixtureExamples) {
+  const targetStat = await stat(targetPath);
+
+  if (targetStat.isDirectory()) {
+    const entries = await readdir(targetPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(targetPath, entry.name);
+      if (shouldIgnorePath(entryPath, entry, includeDefaultFixtureExamples)) {
+        continue;
+      }
+      await collectFiles(entryPath, includeDefaultFixtureExamples);
+    }
+    return;
+  }
+
+  if (targetStat.isFile() && shouldScanFile(targetPath)) {
+    files.push(targetPath);
+  }
+}
+
+function shouldIgnorePath(entryPath, entry, includeDefaultFixtureExamples) {
+  if (entry.isDirectory() && ignoredDirectoryNames.has(entry.name)) {
+    return true;
+  }
+
+  if (entry.isFile() && ignoredFileNames.has(entry.name)) {
+    return true;
+  }
+
+  if (includeDefaultFixtureExamples) {
+    return false;
+  }
+
+  return defaultIgnoredRelativePaths.has(toRelativePath(entryPath));
+}
+
+function shouldScanFile(filePath) {
+  return sourceExtensions.has(path.extname(filePath));
+}
+
+function findViolations(filePath, text) {
+  const maskedText = maskCommentsAndStrings(text);
+  const rawLines = text.split(/\r?\n/);
+  const found = [];
+
+  for (const pattern of forbiddenPatterns) {
+    for (const match of maskedText.matchAll(pattern.regex)) {
+      if (typeof match.index !== "number") {
+        continue;
+      }
+
+      const location = locationForIndex(maskedText, match.index);
+      if (hasNearbyMarker(rawLines, location.line)) {
+        continue;
+      }
+
+      found.push({
+        filePath,
+        line: location.line,
+        column: location.column,
+        pattern: pattern.name,
+      });
+    }
+  }
+
+  return found.sort((first, second) => {
+    if (first.line !== second.line) {
+      return first.line - second.line;
+    }
+    return first.column - second.column;
+  });
+}
+
+function maskCommentsAndStrings(text) {
+  let masked = "";
+  let index = 0;
+  let state = "code";
+  let quote = "";
+
+  while (index < text.length) {
+    const current = text[index] ?? "";
+    const next = text[index + 1] ?? "";
+
+    if (state === "lineComment") {
+      if (current === "\n") {
+        state = "code";
+        masked += current;
+      } else {
+        masked += " ";
+      }
+      index += 1;
+      continue;
+    }
+
+    if (state === "blockComment") {
+      if (current === "*" && next === "/") {
+        masked += "  ";
+        index += 2;
+        state = "code";
+      } else {
+        masked += current === "\n" ? "\n" : " ";
+        index += 1;
+      }
+      continue;
+    }
+
+    if (state === "string") {
+      if (current === "\\") {
+        masked += current === "\n" ? "\n" : " ";
+        if (next !== "") {
+          masked += next === "\n" ? "\n" : " ";
+        }
+        index += 2;
+        continue;
+      }
+
+      if (current === quote) {
+        masked += " ";
+        index += 1;
+        state = "code";
+        quote = "";
+        continue;
+      }
+
+      masked += current === "\n" ? "\n" : " ";
+      index += 1;
+      continue;
+    }
+
+    if (current === "/" && next === "/") {
+      masked += "  ";
+      index += 2;
+      state = "lineComment";
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      masked += "  ";
+      index += 2;
+      state = "blockComment";
+      continue;
+    }
+
+    if (current === "'" || current === '"' || current === "`") {
+      masked += " ";
+      index += 1;
+      state = "string";
+      quote = current;
+      continue;
+    }
+
+    masked += current;
+    index += 1;
+  }
+
+  return masked;
+}
+
+function locationForIndex(text, matchIndex) {
+  let line = 1;
+  let lastLineStart = 0;
+
+  for (let index = 0; index < matchIndex; index += 1) {
+    if (text[index] === "\n") {
+      line += 1;
+      lastLineStart = index + 1;
+    }
+  }
+
+  return {
+    line,
+    column: matchIndex - lastLineStart + 1,
+  };
+}
+
+function hasNearbyMarker(lines, oneBasedLineNumber) {
+  const lineIndex = oneBasedLineNumber - 1;
+  const firstLineIndex = Math.max(0, lineIndex - markerLookbackLineCount);
+  const candidateLines = lines.slice(firstLineIndex, lineIndex + 1);
+  return candidateLines.some((line) => isMarkerComment(line));
+}
+
+function isMarkerComment(line) {
+  const markerIndex = line.indexOf(marker);
+  if (markerIndex === -1) {
+    return false;
+  }
+
+  const beforeMarker = line.slice(0, markerIndex);
+  return (
+    beforeMarker.includes("//") ||
+    beforeMarker.includes("/*") ||
+    beforeMarker.includes("*")
+  );
+}
+
+function toRelativePath(filePath) {
+  return path.relative(root, filePath).split(path.sep).join("/");
+}

--- a/test/fixtures/type-escapes/allowed/boundary-adapter.ts
+++ b/test/fixtures/type-escapes/allowed/boundary-adapter.ts
@@ -1,0 +1,17 @@
+declare const externalValue: unknown;
+
+// type-escape: upstream adapter validates this payload before it reaches the domain
+const adapterPayload = externalValue as any;
+
+// type-escape: legacy browser callback has no useful generic signature
+const callbackPayload: any = externalValue;
+
+// type-escape: generated SDK type hole is checked by the boundary adapter
+const anglePayload = <any>externalValue;
+
+// type-escape: third-party library cannot express this branded test fixture
+const doubleAssertedPayload = externalValue as unknown as {
+  readonly id: string;
+};
+
+export { adapterPayload, anglePayload, callbackPayload, doubleAssertedPayload };

--- a/test/fixtures/type-escapes/rejected/string-marker.ts
+++ b/test/fixtures/type-escapes/rejected/string-marker.ts
@@ -1,0 +1,6 @@
+declare const value: unknown;
+
+const misleadingMarker = "type-escape:";
+const escaped = value as any;
+
+export { escaped, misleadingMarker };

--- a/test/fixtures/type-escapes/rejected/unsafe-cases.ts
+++ b/test/fixtures/type-escapes/rejected/unsafe-cases.ts
@@ -1,0 +1,8 @@
+declare const value: unknown;
+
+const asserted = value as any;
+const annotated: any = value;
+const angleAsserted = <any>value;
+const doubleAsserted = value as unknown as { readonly name: string };
+
+export { angleAsserted, annotated, asserted, doubleAsserted };

--- a/test/type-escapes/check-type-escapes.test.ts
+++ b/test/type-escapes/check-type-escapes.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const scriptPath = path.join(repoRoot, "scripts/check-type-escapes.mjs");
+
+function runGuard(targets: ReadonlyArray<string> = []) {
+  return spawnSync(process.execPath, [scriptPath, ...targets], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+describe("unsafe type escape guard", () => {
+  it("passes documented boundary-adapter exceptions", () => {
+    const result = runGuard(["test/fixtures/type-escapes/allowed"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("rejects unsafe escapes without a nearby marker", () => {
+    const result = runGuard(["test/fixtures/type-escapes/rejected"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("unsafe-cases.ts");
+    expect(result.stderr).toContain("string-marker.ts");
+    expect(result.stderr).toContain(["as", "any"].join(" "));
+    expect(result.stderr).toContain([":", "any"].join(" "));
+    expect(result.stderr).toContain("<" + "any" + ">");
+    expect(result.stderr).toContain(["as", "unknown", "as"].join(" "));
+  });
+
+  it("excludes rejected example fixtures during the default repository scan", () => {
+    const result = runGuard();
+
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #6

## Scope
- Add a dependency-free TypeScript type escape guard for `as any`, `: any`, `<any>`, and `as unknown as`.
- Require rare boundary-adapter exceptions to use a nearby `type-escape:` comment marker.
- Wire the guard into `pnpm check` and a minimal Lefthook pre-commit command.
- Cover allowed boundary-adapter fixtures, rejected unsafe fixtures, and misleading string markers.

## Non-goals
- Commit message enforcement remains issue #7.
- Broader hook/CI policy changes stay in their own issues.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
