### PR TITLE
ci(commits): enforce conventional messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
 
+      - name: Check PR title
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/check-commit-message.ts --message "$PR_TITLE"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,20 @@ pnpm dev
 Quality gates:
 
 ```bash
+pnpm type-escape:check
 pnpm lint
 pnpm format:check
 pnpm typecheck
 pnpm test
 pnpm build
 pnpm test:e2e
+```
+
+Commit and PR title validation:
+
+```bash
+pnpm run commit-message:check -- --message "feat(chat): model conversations"
+pnpm exec lefthook install
 ```
 
 Full local CI-equivalent check:
@@ -60,3 +68,4 @@ pnpm run ci
 The scaffold intentionally contains only the application shell, architecture folders, and tooling. Repository analysis, reviewer assessment, persistence, auth, and deployment integrations are tracked as separate issues.
 
 See [docs/development-plan.md](docs/development-plan.md) for the milestone and issue plan.
+See [docs/commit-messages.md](docs/commit-messages.md) for commit and PR title standards.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -353,6 +353,8 @@ Mechanical enforcement:
 - Prefer squashing PRs with a high-signal Conventional Commit title and body
 - Reject vague subjects such as `update stuff`, `fix`, `changes`, or `wip`
 
+See [commit-messages.md](commit-messages.md) for the full standard, examples, and local validation commands.
+
 ## Zod Strategy
 
 Use Zod heavily, but deliberately.

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -1,0 +1,81 @@
+# Commit Messages
+
+Use Conventional Commits for every commit subject and PR title. Squash merges should keep the PR title as the final commit subject.
+
+## Subject Format
+
+```text
+<type>(optional-scope): <imperative summary>
+```
+
+Accepted types:
+- `feat`
+- `fix`
+- `docs`
+- `test`
+- `refactor`
+- `perf`
+- `build`
+- `ci`
+- `chore`
+- `revert`
+
+Scopes are optional but encouraged when they add useful context. Prefer stable domain and tooling scopes such as `domain`, `evidence`, `reviewer`, `scoring`, `report`, `chat`, `ui`, `ci`, `docs`, and `type-safety`.
+
+Subject rules:
+- Keep the subject to 72 characters or fewer
+- Use imperative mood
+- Do not end the subject with a period
+- Avoid vague summaries such as `fix`, `changes`, `update`, `stuff`, or `wip`
+
+## Commit Body
+
+Non-trivial commits should include a body. When committing from the command line, use a second `-m`:
+
+```bash
+git commit -m "feat(chat): model targeted follow-up conversations" \
+  -m "Add conversation targets for report dimensions, findings, caveats, and evidence items. This keeps chat context explicit before persistence and auth are introduced."
+```
+
+The body should explain:
+- Why the change exists
+- Important tradeoffs or constraints
+- Test, migration, or rollout implications when relevant
+
+Do not repeat the subject in the body.
+
+## Examples
+
+Acceptable:
+
+```text
+feat(chat): model targeted follow-up conversations
+fix(report): preserve evidence citations
+docs(architecture): define enforcement model
+test(type-safety): guard unsafe type escapes
+ci(github): validate pull request titles
+```
+
+Unacceptable:
+
+```text
+update stuff
+fix
+changes
+style(ui): adjust page
+docs: define commit standards.
+feat(BadScope): add thing
+```
+
+## Enforcement
+
+Local validation:
+
+```bash
+pnpm run commit-message:check -- --message "feat(chat): model conversations"
+pnpm run commit-message:check -- --file .git/COMMIT_EDITMSG
+```
+
+Lefthook runs the same validator in the `commit-msg` hook.
+
+CI validates PR titles with the same script so squash-merge titles follow the same standard.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,3 +2,8 @@ pre-commit:
   commands:
     type-escape-check:
       run: pnpm run type-escape:check
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: pnpm run commit-message:check -- --file {1}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "repo-analyzer-green",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "packageManager": "pnpm@10.29.3",
   "engines": {
     "node": "24.x",
@@ -13,7 +14,8 @@
     "start": "next start",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
-    "type-escape:check": "node scripts/check-type-escapes.mjs",
+    "type-escape:check": "node scripts/check-type-escapes.ts",
+    "commit-message:check": "node scripts/check-commit-message.ts",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "typecheck": "rm -rf .next/types .next/dev/types && NODE_ENV=development next typegen && tsc --noEmit",

--- a/scripts/check-commit-message.ts
+++ b/scripts/check-commit-message.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const allowedTypes = new Set([
+  "feat",
+  "fix",
+  "docs",
+  "test",
+  "refactor",
+  "perf",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+]);
+
+const vagueSummaries = new Set([
+  "change",
+  "changes",
+  "fix",
+  "misc",
+  "stuff",
+  "update",
+  "updates",
+  "wip",
+]);
+
+const subjectPattern =
+  /^(?<type>[a-z]+)(?:\((?<scope>[a-z0-9][a-z0-9-]*(?:\/[a-z0-9][a-z0-9-]*)*)\))?(?<breaking>!)?: (?<summary>.+)$/u;
+const maxSubjectLength = 72;
+
+type MessageSource = {
+  readonly message: string;
+};
+
+type ValidationResult = {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+};
+
+const result = await readMessage();
+const validation = validateCommitMessage(result.message);
+
+if (!validation.valid) {
+  console.error("Invalid commit message subject:");
+  for (const error of validation.errors) {
+    console.error(`- ${error}`);
+  }
+  console.error("");
+  console.error("Expected: <type>(optional-scope): <imperative summary>");
+  console.error("Example: feat(chat): model targeted follow-up conversations");
+  console.error(
+    `Accepted types: ${Array.from(allowedTypes).sort().join(", ")}`,
+  );
+  process.exitCode = 1;
+}
+
+async function readMessage(): Promise<MessageSource> {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    return {
+      message: await readFromStdin(),
+    };
+  }
+
+  const fileFlagIndex = args.indexOf("--file");
+  if (fileFlagIndex !== -1) {
+    const filePath = args[fileFlagIndex + 1];
+    if (filePath === undefined || filePath === "") {
+      failUsage("--file requires a path");
+    }
+
+    return {
+      message: await readFile(filePath, "utf8"),
+    };
+  }
+
+  const messageFlagIndex = args.indexOf("--message");
+  if (messageFlagIndex !== -1) {
+    const message = args[messageFlagIndex + 1];
+    if (message === undefined || message === "") {
+      failUsage("--message requires a value");
+    }
+
+    return { message };
+  }
+
+  failUsage("expected --file <path>, --message <text>, or stdin");
+}
+
+async function readFromStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    failUsage("no commit message provided");
+  }
+
+  let message = "";
+  for await (const chunk of process.stdin) {
+    message += String(chunk);
+  }
+
+  return message;
+}
+
+function validateCommitMessage(message: string): ValidationResult {
+  const subject = firstSubjectLine(message);
+  const errors: string[] = [];
+
+  if (subject === "") {
+    errors.push("subject is empty");
+    return { valid: false, errors };
+  }
+
+  if (subject.length > maxSubjectLength) {
+    errors.push(`subject must be ${maxSubjectLength} characters or fewer`);
+  }
+
+  const match = subject.match(subjectPattern);
+  if (match === null || match.groups === undefined) {
+    errors.push("subject must match Conventional Commits format");
+    return { valid: false, errors };
+  }
+
+  const type = match.groups.type ?? "";
+  const summary = match.groups.summary ?? "";
+  if (!allowedTypes.has(type)) {
+    errors.push(`type '${type}' is not accepted`);
+  }
+
+  if (summary.trim() !== summary) {
+    errors.push("summary must not start or end with whitespace");
+  }
+
+  if (summary.endsWith(".")) {
+    errors.push("summary must not end with a period");
+  }
+
+  if (vagueSummaries.has(normalizeSummary(summary))) {
+    errors.push("summary is too vague to support useful git blame");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+function firstSubjectLine(message: string): string {
+  return (
+    message
+      .replace(/\r\n/gu, "\n")
+      .split("\n")
+      .find((line) => line.trim() !== "" && !line.startsWith("#"))
+      ?.trimEnd() ?? ""
+  );
+}
+
+function normalizeSummary(summary: string): string {
+  return summary
+    .trim()
+    .toLowerCase()
+    .replace(/[.!?]+$/u, "");
+}
+
+function failUsage(message: string): never {
+  console.error(`Usage error: ${message}`);
+  process.exit(2);
+}

--- a/scripts/check-type-escapes.ts
+++ b/scripts/check-type-escapes.ts
@@ -1,11 +1,29 @@
 #!/usr/bin/env node
 
 import { readdir, readFile, stat } from "node:fs/promises";
+import type { Dirent } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
-const sourceExtensions = new Set([".cts", ".mts", ".ts", ".tsx"]);
-const ignoredDirectoryNames = new Set([
+type ForbiddenPattern = {
+  readonly name: string;
+  readonly regex: RegExp;
+};
+
+type SourceLocation = {
+  readonly line: number;
+  readonly column: number;
+};
+
+type TypeEscapeViolation = SourceLocation & {
+  readonly filePath: string;
+  readonly pattern: string;
+};
+
+type ScannerState = "code" | "lineComment" | "blockComment" | "string";
+
+const sourceExtensions = new Set<string>([".cts", ".mts", ".ts", ".tsx"]);
+const ignoredDirectoryNames = new Set<string>([
   ".git",
   ".next",
   "build",
@@ -14,20 +32,20 @@ const ignoredDirectoryNames = new Set([
   "node_modules",
   "test-results",
 ]);
-const ignoredFileNames = new Set([
+const ignoredFileNames = new Set<string>([
   "package-lock.json",
   "pnpm-lock.yaml",
   "yarn.lock",
 ]);
-const defaultIgnoredRelativePaths = new Set([
+const defaultIgnoredRelativePaths = new Set<string>([
   "test/fixtures/type-escapes/rejected",
 ]);
 const marker = "type-escape:";
 const markerLookbackLineCount = 3;
 const anyKeyword = "any";
-const patternLabel = (parts) => parts.join(" ");
+const patternLabel = (parts: readonly string[]): string => parts.join(" ");
 
-const forbiddenPatterns = [
+const forbiddenPatterns: readonly ForbiddenPattern[] = [
   {
     name: patternLabel(["as", anyKeyword]),
     regex: /\bas\s+any\b/g,
@@ -50,13 +68,13 @@ const args = process.argv.slice(2);
 const root = process.cwd();
 const explicitTargets = args.length > 0;
 const targets = explicitTargets ? args : ["."];
-const files = [];
+const files: string[] = [];
 
 for (const target of targets) {
   await collectFiles(path.resolve(root, target), explicitTargets);
 }
 
-const violations = [];
+const violations: TypeEscapeViolation[] = [];
 
 for (const filePath of files) {
   const text = await readFile(filePath, "utf8");
@@ -77,7 +95,10 @@ if (violations.length > 0) {
   process.exitCode = 1;
 }
 
-async function collectFiles(targetPath, includeDefaultFixtureExamples) {
+async function collectFiles(
+  targetPath: string,
+  includeDefaultFixtureExamples: boolean,
+): Promise<void> {
   const targetStat = await stat(targetPath);
 
   if (targetStat.isDirectory()) {
@@ -97,7 +118,11 @@ async function collectFiles(targetPath, includeDefaultFixtureExamples) {
   }
 }
 
-function shouldIgnorePath(entryPath, entry, includeDefaultFixtureExamples) {
+function shouldIgnorePath(
+  entryPath: string,
+  entry: Dirent,
+  includeDefaultFixtureExamples: boolean,
+): boolean {
   if (entry.isDirectory() && ignoredDirectoryNames.has(entry.name)) {
     return true;
   }
@@ -113,14 +138,14 @@ function shouldIgnorePath(entryPath, entry, includeDefaultFixtureExamples) {
   return defaultIgnoredRelativePaths.has(toRelativePath(entryPath));
 }
 
-function shouldScanFile(filePath) {
+function shouldScanFile(filePath: string): boolean {
   return sourceExtensions.has(path.extname(filePath));
 }
 
-function findViolations(filePath, text) {
+function findViolations(filePath: string, text: string): TypeEscapeViolation[] {
   const maskedText = maskCommentsAndStrings(text);
   const rawLines = text.split(/\r?\n/);
-  const found = [];
+  const found: TypeEscapeViolation[] = [];
 
   for (const pattern of forbiddenPatterns) {
     for (const match of maskedText.matchAll(pattern.regex)) {
@@ -150,10 +175,10 @@ function findViolations(filePath, text) {
   });
 }
 
-function maskCommentsAndStrings(text) {
+function maskCommentsAndStrings(text: string): string {
   let masked = "";
   let index = 0;
-  let state = "code";
+  let state: ScannerState = "code";
   let quote = "";
 
   while (index < text.length) {
@@ -185,7 +210,7 @@ function maskCommentsAndStrings(text) {
 
     if (state === "string") {
       if (current === "\\") {
-        masked += current === "\n" ? "\n" : " ";
+        masked += " ";
         if (next !== "") {
           masked += next === "\n" ? "\n" : " ";
         }
@@ -235,7 +260,7 @@ function maskCommentsAndStrings(text) {
   return masked;
 }
 
-function locationForIndex(text, matchIndex) {
+function locationForIndex(text: string, matchIndex: number): SourceLocation {
   let line = 1;
   let lastLineStart = 0;
 
@@ -252,14 +277,17 @@ function locationForIndex(text, matchIndex) {
   };
 }
 
-function hasNearbyMarker(lines, oneBasedLineNumber) {
+function hasNearbyMarker(
+  lines: readonly string[],
+  oneBasedLineNumber: number,
+): boolean {
   const lineIndex = oneBasedLineNumber - 1;
   const firstLineIndex = Math.max(0, lineIndex - markerLookbackLineCount);
   const candidateLines = lines.slice(firstLineIndex, lineIndex + 1);
   return candidateLines.some((line) => isMarkerComment(line));
 }
 
-function isMarkerComment(line) {
+function isMarkerComment(line: string): boolean {
   const markerIndex = line.indexOf(marker);
   if (markerIndex === -1) {
     return false;
@@ -273,6 +301,6 @@ function isMarkerComment(line) {
   );
 }
 
-function toRelativePath(filePath) {
+function toRelativePath(filePath: string): string {
   return path.relative(root, filePath).split(path.sep).join("/");
 }

--- a/test/commit-messages/check-commit-message.test.ts
+++ b/test/commit-messages/check-commit-message.test.ts
@@ -1,0 +1,88 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const scriptPath = path.join(repoRoot, "scripts/check-commit-message.ts");
+
+function runValidator(args: ReadonlyArray<string>, input?: string) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input,
+  });
+}
+
+describe("commit message validator", () => {
+  it("accepts conventional commit subjects with useful scopes", () => {
+    const subjects = [
+      "feat(chat): model targeted follow-up conversations",
+      "fix: preserve evidence citations",
+      "docs(architecture): define commit standards",
+      "refactor(domain/scoring): isolate confidence policy",
+      "feat!: require report schema migration",
+    ];
+
+    for (const subject of subjects) {
+      const result = runValidator(["--message", subject]);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+    }
+  });
+
+  it("rejects non-conventional or low-signal subjects", () => {
+    const subjects = [
+      "update stuff",
+      "feat(ui): ",
+      "style(ui): adjust page",
+      "fix: update",
+      "docs: define commit standards.",
+      "feat(BadScope): add thing",
+    ];
+
+    for (const subject of subjects) {
+      const result = runValidator(["--message", subject]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Invalid commit message subject");
+    }
+  });
+
+  it("reads the subject from a commit message file", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "green-commit-message-"));
+    const messagePath = path.join(directory, "COMMIT_EDITMSG");
+
+    try {
+      writeFileSync(
+        messagePath,
+        [
+          "test(type-safety): guard unsafe type escapes",
+          "",
+          "Explain the domain reason for this guard.",
+        ].join("\n"),
+      );
+
+      const result = runValidator(["--file", messagePath]);
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("reads the subject from stdin when no source flag is provided", () => {
+    const result = runValidator(
+      [],
+      "ci(github): validate pull request titles\n",
+    );
+
+    expect(result.status).toBe(0);
+  });
+});

--- a/test/type-escapes/check-type-escapes.test.ts
+++ b/test/type-escapes/check-type-escapes.test.ts
@@ -7,7 +7,7 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
-const scriptPath = path.join(repoRoot, "scripts/check-type-escapes.mjs");
+const scriptPath = path.join(repoRoot, "scripts/check-type-escapes.ts");
 
 function runGuard(targets: ReadonlyArray<string> = []) {
   return spawnSync(process.execPath, [scriptPath, ...targets], {


### PR DESCRIPTION
Closes #7

## Scope
- Add a typed commit-message validator for Conventional Commit subjects.
- Wire the validator into Lefthook `commit-msg` and GitHub Actions PR title checks.
- Document commit/PR title rules, examples, and local validation commands.
- Convert the unsafe type-escape guard from `.mjs` to `.ts` so repository tooling is checked by `tsc`.

## Non-goals
- Branch protection settings still need to be applied in GitHub settings.
- Project board automation remains documented in #47 and is not configured here.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
