### PR TITLE
test(fixtures): establish repository harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ The scaffold intentionally contains only the application shell, architecture fol
 
 See [docs/development-plan.md](docs/development-plan.md) for the milestone and issue plan.
 See [docs/commit-messages.md](docs/commit-messages.md) for commit and PR title standards.
+See [docs/fixtures.md](docs/fixtures.md) for repository fixture rules.

--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -1,0 +1,31 @@
+# Test Fixtures
+
+Fixtures let the project test repository analysis without network calls, model calls, external services, or private data.
+
+## Repository Fixture Rules
+
+- Keep fixtures small enough to inspect in review.
+- Name fixtures by archetype and purpose, for example `minimal-node-library`.
+- Store repository fixtures under `test/fixtures/repositories/<fixture-id>`.
+- Register fixtures in `test/support/fixtures.ts` before using them in tests.
+- Include a short fixture `README.md` that states what the fixture represents.
+- Prefer source files that pass the repo's own type and type-escape checks.
+- Prefer fixture test files named `.spec.ts` so parent Vitest runs do not execute fixture suites by accident.
+- Do not include secrets, tokens, real customer code, or generated dependency folders.
+- Do not let fixtures require network, database, model-provider, GitHub, or deployment access.
+
+## Current Fixtures
+
+### `minimal-node-library`
+
+A tiny TypeScript library with a package manifest, one source module, one unit test, and local scripts. Use it for early repository-source, inventory, manifest, test-signal, and report-card tests.
+
+## Maintenance
+
+When a fixture changes, update:
+
+- `test/support/fixtures.ts`
+- The fixture README
+- Any tests that assert expected files or signals
+
+If a test needs a larger or language-specific repository, add a new fixture instead of expanding an existing one beyond its stated purpose.

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+
+test("renders the initial analysis shell", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", {
+      name: "Evidence-backed repository quality analysis.",
+    }),
+  ).toBeVisible();
+  await expect(page.getByText("Repo Analyzer Green")).toBeVisible();
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["127.0.0.1"],
   turbopack: {
     root: process.cwd(),
   },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "typecheck": "rm -rf .next/types .next/dev/types && NODE_ENV=development next typegen && tsc --noEmit",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test --pass-with-no-tests",
+    "test:e2e": "playwright test",
     "check": "pnpm run type-escape:check && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test",
     "ci": "pnpm check && pnpm build && pnpm test:e2e"
   },

--- a/test/fixtures/repositories/minimal-node-library/README.md
+++ b/test/fixtures/repositories/minimal-node-library/README.md
@@ -1,0 +1,10 @@
+# Minimal Node Library
+
+Small deterministic fixture used by Repo Analyzer Green tests.
+
+The fixture represents a TypeScript package with:
+
+- A package manifest
+- One source module
+- One unit test
+- No network, model, database, or deployment dependency

--- a/test/fixtures/repositories/minimal-node-library/package.json
+++ b/test/fixtures/repositories/minimal-node-library/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "minimal-node-library",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/test/fixtures/repositories/minimal-node-library/src/add.ts
+++ b/test/fixtures/repositories/minimal-node-library/src/add.ts
@@ -1,0 +1,3 @@
+export function add(left: number, right: number): number {
+  return left + right;
+}

--- a/test/fixtures/repositories/minimal-node-library/test/add.spec.ts
+++ b/test/fixtures/repositories/minimal-node-library/test/add.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { add } from "../src/add";
+
+describe("add", () => {
+  it("adds two numbers", () => {
+    expect(add(2, 3)).toBe(5);
+  });
+});

--- a/test/fixtures/repository-fixtures.test.ts
+++ b/test/fixtures/repository-fixtures.test.ts
@@ -1,0 +1,29 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { getRepositoryFixture, repositoryFixtures } from "../support/fixtures";
+
+describe("repository fixtures", () => {
+  it("registers the minimal Node library fixture", () => {
+    const fixture = getRepositoryFixture("minimal-node-library");
+
+    expect(fixture.archetype).toBe("node-library");
+    expect(fixture.expectedFiles).toEqual([
+      "README.md",
+      "package.json",
+      "src/add.ts",
+      "test/add.spec.ts",
+    ]);
+  });
+
+  it("keeps registered fixture files present on disk", async () => {
+    for (const fixture of Object.values(repositoryFixtures)) {
+      for (const expectedFile of fixture.expectedFiles) {
+        await expect(
+          access(path.join(fixture.rootPath, expectedFile)),
+        ).resolves.toBeUndefined();
+      }
+    }
+  });
+});

--- a/test/support/fixtures.ts
+++ b/test/support/fixtures.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+
+export type RepositoryFixtureId = "minimal-node-library";
+
+export type RepositoryFixture = {
+  readonly id: RepositoryFixtureId;
+  readonly archetype: "node-library";
+  readonly rootPath: string;
+  readonly expectedFiles: readonly string[];
+};
+
+const fixtureRoot = path.resolve(process.cwd(), "test/fixtures/repositories");
+
+export const repositoryFixtures: Record<
+  RepositoryFixtureId,
+  RepositoryFixture
+> = {
+  "minimal-node-library": {
+    id: "minimal-node-library",
+    archetype: "node-library",
+    rootPath: path.join(fixtureRoot, "minimal-node-library"),
+    expectedFiles: [
+      "README.md",
+      "package.json",
+      "src/add.ts",
+      "test/add.spec.ts",
+    ],
+  },
+};
+
+export function getRepositoryFixture(
+  id: RepositoryFixtureId,
+): RepositoryFixture {
+  return repositoryFixtures[id];
+}


### PR DESCRIPTION
Closes #3

## Scope
- Add the first deterministic repository fixture: `minimal-node-library`.
- Add a typed fixture registry and tests that assert registered fixture files exist.
- Document fixture naming, maintenance, and no-network/no-model rules.
- Add a real Playwright app-shell smoke test and remove no-test pass flags from Vitest/Playwright scripts.
- Allow the Playwright localhost origin in Next dev config to keep E2E output clean.

## Non-goals
- This does not implement repository acquisition or evidence collection yet.
- The Playwright test is a shell smoke test, not the final analysis workflow E2E. That should evolve once the first vertical domain slice exists.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
