### PR TITLE
feat(domain): model report card contracts

### DIFF
--- a/src/domain/report/report-card.ts
+++ b/src/domain/report/report-card.ts
@@ -1,0 +1,185 @@
+import { z } from "zod";
+
+import { ConfidenceSchema } from "../shared/confidence";
+import { EvidenceReferenceSchema } from "../shared/evidence-reference";
+
+export const ReportCardSchemaVersion = "report-card.v1";
+
+export const RepositoryProviderSchema = z.enum([
+  "github",
+  "gitlab",
+  "bitbucket",
+  "local-fixture",
+  "local-path",
+  "unknown",
+]);
+
+export type RepositoryProvider = z.infer<typeof RepositoryProviderSchema>;
+
+export const RepositoryIdentitySchema = z
+  .object({
+    provider: RepositoryProviderSchema,
+    name: z.string().min(1),
+    owner: z.string().min(1).optional(),
+    url: z.url().optional(),
+    revision: z.string().min(1).optional(),
+    defaultBranch: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type RepositoryIdentity = z.infer<typeof RepositoryIdentitySchema>;
+
+export const ProjectArchetypeSchema = z.enum([
+  "web-app",
+  "cli",
+  "library",
+  "service",
+  "infrastructure",
+  "research-notebook",
+  "generated-sdk",
+  "embedded",
+  "unknown",
+]);
+
+export type ProjectArchetype = z.infer<typeof ProjectArchetypeSchema>;
+
+export const ReportDimensionKeySchema = z.enum([
+  "architecture-boundaries",
+  "maintainability",
+  "verifiability",
+  "security",
+  "operability",
+  "documentation",
+]);
+
+export type ReportDimensionKey = z.infer<typeof ReportDimensionKeySchema>;
+
+export const ReportRatingSchema = z.enum([
+  "excellent",
+  "good",
+  "fair",
+  "weak",
+  "poor",
+  "not-assessed",
+]);
+
+export type ReportRating = z.infer<typeof ReportRatingSchema>;
+
+export const FindingSeveritySchema = z.enum([
+  "info",
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+export type FindingSeverity = z.infer<typeof FindingSeveritySchema>;
+
+export const ReviewerKindSchema = z.enum(["fake", "human", "llm", "automated"]);
+
+export type ReviewerKind = z.infer<typeof ReviewerKindSchema>;
+
+export const ReviewerMetadataSchema = z
+  .object({
+    kind: ReviewerKindSchema,
+    name: z.string().min(1),
+    reviewerVersion: z.string().min(1).optional(),
+    modelProvider: z.string().min(1).optional(),
+    modelName: z.string().min(1).optional(),
+    modelVersion: z.string().min(1).optional(),
+    reviewedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict()
+  .refine(
+    (metadata) =>
+      metadata.kind !== "llm" ||
+      (metadata.modelProvider !== undefined &&
+        metadata.modelName !== undefined),
+    {
+      message: "LLM reviewer metadata must include modelProvider and modelName",
+      path: ["modelName"],
+    },
+  );
+
+export type ReviewerMetadata = z.infer<typeof ReviewerMetadataSchema>;
+
+export const ReportFindingSchema = z
+  .object({
+    id: z.string().min(1),
+    dimension: ReportDimensionKeySchema,
+    severity: FindingSeveritySchema,
+    title: z.string().min(1),
+    summary: z.string().min(1),
+    confidence: ConfidenceSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema).min(1),
+  })
+  .strict();
+
+export type ReportFinding = z.infer<typeof ReportFindingSchema>;
+
+export const ReportCaveatSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    summary: z.string().min(1),
+    affectedDimensions: z.array(ReportDimensionKeySchema).min(1),
+    missingEvidence: z.array(z.string().min(1)).default([]),
+  })
+  .strict();
+
+export type ReportCaveat = z.infer<typeof ReportCaveatSchema>;
+
+export const DimensionAssessmentSchema = z
+  .object({
+    dimension: ReportDimensionKeySchema,
+    title: z.string().min(1),
+    summary: z.string().min(1),
+    rating: ReportRatingSchema,
+    score: z.number().min(0).max(100).optional(),
+    confidence: ConfidenceSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema).min(1),
+    findings: z.array(ReportFindingSchema).default([]),
+    caveatIds: z.array(z.string().min(1)).default([]),
+  })
+  .strict();
+
+export type DimensionAssessment = z.infer<typeof DimensionAssessmentSchema>;
+
+export const RecommendedQuestionSchema = z
+  .object({
+    id: z.string().min(1),
+    question: z.string().min(1),
+    targetDimension: ReportDimensionKeySchema.optional(),
+    rationale: z.string().min(1),
+  })
+  .strict();
+
+export type RecommendedQuestion = z.infer<typeof RecommendedQuestionSchema>;
+
+export const ReportCardInputSchema = z
+  .object({
+    repository: RepositoryIdentitySchema,
+    assessedArchetype: ProjectArchetypeSchema,
+    reviewerMetadata: ReviewerMetadataSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema).default([]),
+    dimensionAssessments: z.array(DimensionAssessmentSchema).min(1),
+    caveats: z.array(ReportCaveatSchema).default([]),
+    recommendedNextQuestions: z.array(RecommendedQuestionSchema).default([]),
+  })
+  .strict();
+
+export type ReportCardInput = z.infer<typeof ReportCardInputSchema>;
+
+export const ReportCardSchema = ReportCardInputSchema.extend({
+  id: z.string().min(1),
+  schemaVersion: z.literal(ReportCardSchemaVersion),
+  generatedAt: z.iso.datetime({ offset: true }),
+  scoringPolicy: z
+    .object({
+      name: z.string().min(1),
+      version: z.string().min(1),
+    })
+    .strict(),
+}).strict();
+
+export type ReportCard = z.infer<typeof ReportCardSchema>;

--- a/src/domain/shared/confidence.ts
+++ b/src/domain/shared/confidence.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const ConfidenceLevelSchema = z.enum(["low", "medium", "high"]);
+
+export type ConfidenceLevel = z.infer<typeof ConfidenceLevelSchema>;
+
+export const ConfidenceSchema = z
+  .object({
+    level: ConfidenceLevelSchema,
+    score: z.number().min(0).max(1),
+    rationale: z.string().min(1),
+  })
+  .strict();
+
+export type Confidence = z.infer<typeof ConfidenceSchema>;

--- a/src/domain/shared/evidence-reference.ts
+++ b/src/domain/shared/evidence-reference.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const EvidenceReferenceKindSchema = z.enum([
+  "file",
+  "collector",
+  "reviewer",
+  "derived",
+]);
+
+export type EvidenceReferenceKind = z.infer<typeof EvidenceReferenceKindSchema>;
+
+export const EvidenceReferenceSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: EvidenceReferenceKindSchema,
+    label: z.string().min(1),
+    path: z.string().min(1).optional(),
+    lineStart: z.number().int().positive().optional(),
+    lineEnd: z.number().int().positive().optional(),
+    notes: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine(
+    (reference) =>
+      reference.lineStart === undefined ||
+      reference.lineEnd === undefined ||
+      reference.lineEnd >= reference.lineStart,
+    {
+      message: "lineEnd must be greater than or equal to lineStart",
+      path: ["lineEnd"],
+    },
+  );
+
+export type EvidenceReference = z.infer<typeof EvidenceReferenceSchema>;

--- a/test/domain/report/report-card.test.ts
+++ b/test/domain/report/report-card.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ReportCardInputSchema,
+  ReportCardSchema,
+  ReportCardSchemaVersion,
+  ReviewerMetadataSchema,
+} from "../../../src/domain/report/report-card";
+import { EvidenceReferenceSchema } from "../../../src/domain/shared/evidence-reference";
+
+const highConfidence = {
+  level: "high",
+  score: 0.92,
+  rationale: "Multiple repository files support this conclusion.",
+};
+
+const packageManifestReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+  lineStart: 1,
+  lineEnd: 24,
+};
+
+const testFileReference = {
+  id: "evidence:test-file",
+  kind: "file",
+  label: "Unit test file",
+  path: "test/add.spec.ts",
+};
+
+const reviewerMetadata = {
+  kind: "llm",
+  name: "Fixture reviewer",
+  reviewerVersion: "2026-04-issue-17",
+  modelProvider: "fixture-provider",
+  modelName: "fixture-model",
+  modelVersion: "fixture-model-1",
+  reviewedAt: "2026-04-25T20:00:00-07:00",
+};
+
+const dimensionAssessment = {
+  dimension: "verifiability",
+  title: "Verifiability",
+  summary: "The repository has an executable unit test around the public API.",
+  rating: "good",
+  score: 82,
+  confidence: highConfidence,
+  evidenceReferences: [testFileReference],
+  findings: [
+    {
+      id: "finding:test-coverage-shape",
+      dimension: "verifiability",
+      severity: "low",
+      title: "Tests exercise the exported behavior",
+      summary:
+        "The fixture includes a unit test for the exported add function.",
+      confidence: highConfidence,
+      evidenceReferences: [testFileReference],
+    },
+  ],
+};
+
+const reportCardInput = {
+  repository: {
+    provider: "local-fixture",
+    name: "minimal-node-library",
+    revision: "fixture",
+  },
+  assessedArchetype: "library",
+  reviewerMetadata,
+  evidenceReferences: [packageManifestReference, testFileReference],
+  dimensionAssessments: [dimensionAssessment],
+  caveats: [
+    {
+      id: "caveat:limited-fixture",
+      title: "Limited fixture scope",
+      summary: "The fixture does not include release or incident history.",
+      affectedDimensions: ["operability"],
+      missingEvidence: ["Release workflow history", "Production incident data"],
+    },
+  ],
+  recommendedNextQuestions: [
+    {
+      id: "question:release-process",
+      question: "How is this package released and verified before publishing?",
+      targetDimension: "operability",
+      rationale:
+        "Release readiness cannot be inferred from source files alone.",
+    },
+  ],
+};
+
+describe("report card domain models", () => {
+  it("parses a report-card input that preserves evidence, caveats, questions, and reviewer metadata", () => {
+    const parsed = ReportCardInputSchema.parse(reportCardInput);
+
+    expect(parsed.repository.provider).toBe("local-fixture");
+    expect(parsed.assessedArchetype).toBe("library");
+    expect(parsed.reviewerMetadata.modelName).toBe("fixture-model");
+    expect(parsed.dimensionAssessments[0]?.confidence.level).toBe("high");
+    expect(
+      parsed.dimensionAssessments[0]?.findings[0]?.evidenceReferences,
+    ).toEqual([testFileReference]);
+    expect(parsed.caveats[0]?.missingEvidence).toEqual([
+      "Release workflow history",
+      "Production incident data",
+    ]);
+    expect(parsed.recommendedNextQuestions[0]?.targetDimension).toBe(
+      "operability",
+    );
+  });
+
+  it("parses a generated report card with schema and scoring policy metadata", () => {
+    const parsed = ReportCardSchema.parse({
+      ...reportCardInput,
+      id: "report:minimal-node-library",
+      schemaVersion: ReportCardSchemaVersion,
+      generatedAt: "2026-04-25T20:05:00-07:00",
+      scoringPolicy: {
+        name: "fixture policy",
+        version: "0.1.0",
+      },
+    });
+
+    expect(parsed.schemaVersion).toBe("report-card.v1");
+    expect(parsed.scoringPolicy).toEqual({
+      name: "fixture policy",
+      version: "0.1.0",
+    });
+  });
+
+  it("rejects dimension confidence outside the normalized range", () => {
+    const result = ReportCardInputSchema.safeParse({
+      ...reportCardInput,
+      dimensionAssessments: [
+        {
+          ...dimensionAssessment,
+          confidence: {
+            ...highConfidence,
+            score: 1.2,
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("requires evidence-backed findings", () => {
+    const result = ReportCardInputSchema.safeParse({
+      ...reportCardInput,
+      dimensionAssessments: [
+        {
+          ...dimensionAssessment,
+          findings: [
+            {
+              ...dimensionAssessment.findings[0],
+              evidenceReferences: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("requires LLM reviewer metadata to identify the model", () => {
+    const result = ReviewerMetadataSchema.safeParse({
+      kind: "llm",
+      name: "Reviewer without model identity",
+      reviewedAt: "2026-04-25T20:00:00-07:00",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects evidence line ranges that run backward", () => {
+    const result = EvidenceReferenceSchema.safeParse({
+      ...packageManifestReference,
+      lineStart: 10,
+      lineEnd: 2,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #17

## Scope
- Add Zod-backed report-card input and output domain models.
- Add shared confidence and evidence-reference primitives for report behavior.
- Cover validation for confidence, evidence-backed findings, reviewer metadata, generated report metadata, and evidence line ranges.

## Non-goals
- No repository source, evidence collection, reviewer adapter, application service, UI, persistence, or API route implementation.

## Test evidence
- `pnpm run ci` passed locally.
- Note: local Node is v25.9.0, while package engines request Node 24.x; pnpm emitted an engine warning but all checks passed.

## Type-safety notes
- No `as any` or `as unknown` escapes added.
- Runtime boundary shapes are parsed with Zod schemas.