### PR TITLE
feat(repository): add fixture source port adapter

### DIFF
--- a/src/domain/repository/index.ts
+++ b/src/domain/repository/index.ts
@@ -1,0 +1,11 @@
+export type {
+  RepositoryFileContent,
+  RepositoryFileEntry,
+  RepositoryFileProvenance,
+  RepositoryPath,
+  RepositoryProvider,
+  RepositoryReference,
+  RepositorySource,
+  RepositorySourceKind,
+} from "./repository-source";
+export { RepositorySourceError } from "./repository-source";

--- a/src/domain/repository/repository-source.ts
+++ b/src/domain/repository/repository-source.ts
@@ -1,0 +1,50 @@
+export type RepositoryProvider = "local-fixture";
+
+export type RepositoryReference = {
+  readonly provider: RepositoryProvider;
+  readonly name: string;
+  readonly owner?: string;
+  readonly url?: string;
+  readonly revision?: string;
+};
+
+export type RepositoryPath = string;
+
+export type RepositorySourceKind = "local-fixture";
+
+export type RepositoryFileProvenance = {
+  readonly repository: RepositoryReference;
+  readonly sourceKind: RepositorySourceKind;
+  readonly sourceId: string;
+  readonly path: RepositoryPath;
+};
+
+export type RepositoryFileEntry = {
+  readonly path: RepositoryPath;
+  readonly provenance: RepositoryFileProvenance;
+};
+
+export type RepositoryFileContent = RepositoryFileEntry & {
+  readonly text: string;
+};
+
+export interface RepositorySource {
+  listFiles(
+    repository: RepositoryReference,
+  ): Promise<readonly RepositoryFileEntry[]>;
+  readFile(
+    repository: RepositoryReference,
+    filePath: RepositoryPath,
+  ): Promise<RepositoryFileContent>;
+}
+
+export class RepositorySourceError extends Error {
+  constructor(
+    message: string,
+    readonly code: "repository-not-found" | "file-not-found",
+    readonly repository: RepositoryReference,
+  ) {
+    super(message);
+    this.name = "RepositorySourceError";
+  }
+}

--- a/src/infrastructure/filesystem/index.ts
+++ b/src/infrastructure/filesystem/index.ts
@@ -1,0 +1,5 @@
+export { LocalFixtureRepositorySource } from "./local-fixture-repository-source";
+export type {
+  LocalFixtureRepositorySourceOptions,
+  LocalRepositoryFixture,
+} from "./local-fixture-repository-source";

--- a/src/infrastructure/filesystem/local-fixture-repository-source.ts
+++ b/src/infrastructure/filesystem/local-fixture-repository-source.ts
@@ -1,0 +1,172 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  RepositoryFileContent,
+  RepositoryFileEntry,
+  RepositoryPath,
+  RepositoryReference,
+  RepositorySource,
+} from "../../domain/repository";
+import { RepositorySourceError } from "../../domain/repository";
+
+export type LocalRepositoryFixture = {
+  readonly id: string;
+  readonly rootPath: string;
+};
+
+export type LocalFixtureRepositorySourceOptions = {
+  readonly fixtures: Readonly<Record<string, LocalRepositoryFixture>>;
+};
+
+export class LocalFixtureRepositorySource implements RepositorySource {
+  private readonly fixtures: Readonly<Record<string, LocalRepositoryFixture>>;
+
+  constructor(options: LocalFixtureRepositorySourceOptions) {
+    this.fixtures = options.fixtures;
+  }
+
+  async listFiles(
+    repository: RepositoryReference,
+  ): Promise<readonly RepositoryFileEntry[]> {
+    const fixture = this.requireFixture(repository);
+    const files = await listFixtureFiles(fixture.rootPath);
+
+    return files.map((filePath) => ({
+      path: filePath,
+      provenance: {
+        repository,
+        sourceKind: "local-fixture",
+        sourceId: fixture.id,
+        path: filePath,
+      },
+    }));
+  }
+
+  async readFile(
+    repository: RepositoryReference,
+    filePath: RepositoryPath,
+  ): Promise<RepositoryFileContent> {
+    const fixture = this.requireFixture(repository);
+    const absolutePath = resolveFixtureFilePath(
+      fixture.rootPath,
+      filePath,
+      repository,
+    );
+
+    try {
+      const fileStat = await stat(absolutePath);
+      if (!fileStat.isFile()) {
+        throw notFound(repository, filePath);
+      }
+      const text = await readFile(absolutePath, "utf8");
+
+      return {
+        path: filePath,
+        text,
+        provenance: {
+          repository,
+          sourceKind: "local-fixture",
+          sourceId: fixture.id,
+          path: filePath,
+        },
+      };
+    } catch (error) {
+      if (error instanceof RepositorySourceError) {
+        throw error;
+      }
+      throw notFound(repository, filePath);
+    }
+  }
+
+  private requireFixture(
+    repository: RepositoryReference,
+  ): LocalRepositoryFixture {
+    const fixture = this.fixtures[repository.name];
+
+    if (fixture === undefined) {
+      throw new RepositorySourceError(
+        `Repository fixture '${repository.name}' is not registered.`,
+        "repository-not-found",
+        repository,
+      );
+    }
+
+    return fixture;
+  }
+}
+
+async function listFixtureFiles(rootPath: string): Promise<readonly string[]> {
+  const files: string[] = [];
+  await collectFiles(rootPath, rootPath, files);
+  return files.sort();
+}
+
+async function collectFiles(
+  rootPath: string,
+  currentPath: string,
+  files: string[],
+): Promise<void> {
+  const entries = await readdir(currentPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(currentPath, entry.name);
+    if (entry.isDirectory()) {
+      await collectFiles(rootPath, entryPath, files);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(toRepositoryPath(rootPath, entryPath));
+    }
+  }
+}
+
+function resolveFixtureFilePath(
+  rootPath: string,
+  filePath: RepositoryPath,
+  repository: RepositoryReference,
+): string {
+  if (!isNormalizedRepositoryPath(filePath)) {
+    throw notFound(repository, filePath);
+  }
+
+  const absolutePath = path.resolve(rootPath, filePath);
+  const relativePath = path.relative(rootPath, absolutePath);
+
+  if (
+    relativePath === "" ||
+    relativePath.startsWith("..") ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw notFound(repository, filePath);
+  }
+
+  return absolutePath;
+}
+
+function isNormalizedRepositoryPath(filePath: RepositoryPath): boolean {
+  return (
+    filePath !== "" &&
+    !filePath.includes("\\") &&
+    !path.posix.isAbsolute(filePath) &&
+    path.posix.normalize(filePath) === filePath &&
+    filePath !== "." &&
+    !filePath.startsWith("../")
+  );
+}
+
+function toRepositoryPath(rootPath: string, filePath: string): RepositoryPath {
+  return path.relative(rootPath, filePath).split(path.sep).join(path.posix.sep);
+}
+
+function notFound(
+  repository: RepositoryReference,
+  filePath: RepositoryPath,
+): RepositorySourceError {
+  return new RepositorySourceError(
+    `Repository file '${filePath}' was not found in fixture '${repository.name}'.`,
+    "file-not-found",
+    repository,
+  );
+}

--- a/test/domain/repository/repository-source.test.ts
+++ b/test/domain/repository/repository-source.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { RepositorySourceError } from "../../../src/domain/repository";
+import type { RepositoryReference } from "../../../src/domain/repository";
+
+describe("RepositorySource domain types", () => {
+  it("carries repository source failure context", () => {
+    const repository: RepositoryReference = {
+      provider: "local-fixture",
+      name: "missing-fixture",
+    };
+
+    const error = new RepositorySourceError(
+      "Fixture is unavailable.",
+      "repository-not-found",
+      repository,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe("repository-not-found");
+    expect(error.repository).toBe(repository);
+  });
+});

--- a/test/infrastructure/filesystem/local-fixture-repository-source.test.ts
+++ b/test/infrastructure/filesystem/local-fixture-repository-source.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import type { RepositoryReference } from "../../../src/domain/repository";
+import { RepositorySourceError } from "../../../src/domain/repository";
+import { LocalFixtureRepositorySource } from "../../../src/infrastructure/filesystem";
+
+import { repositoryFixtures } from "../../support/fixtures";
+
+const minimalNodeLibrary: RepositoryReference = {
+  provider: "local-fixture",
+  name: "minimal-node-library",
+  revision: "fixture",
+};
+
+describe("LocalFixtureRepositorySource", () => {
+  it("lists files from a registered repository fixture with provenance", async () => {
+    const source = new LocalFixtureRepositorySource({
+      fixtures: repositoryFixtures,
+    });
+
+    const files = await source.listFiles(minimalNodeLibrary);
+
+    expect(files.map((file) => file.path)).toEqual([
+      "README.md",
+      "package.json",
+      "src/add.ts",
+      "test/add.spec.ts",
+    ]);
+    expect(files[0]?.provenance).toEqual({
+      repository: minimalNodeLibrary,
+      sourceKind: "local-fixture",
+      sourceId: "minimal-node-library",
+      path: "README.md",
+    });
+  });
+
+  it("reads file contents from a registered repository fixture with provenance", async () => {
+    const source = new LocalFixtureRepositorySource({
+      fixtures: repositoryFixtures,
+    });
+
+    const file = await source.readFile(minimalNodeLibrary, "src/add.ts");
+
+    expect(file.path).toBe("src/add.ts");
+    expect(file.text).toContain("export function add");
+    expect(file.provenance).toEqual({
+      repository: minimalNodeLibrary,
+      sourceKind: "local-fixture",
+      sourceId: "minimal-node-library",
+      path: "src/add.ts",
+    });
+  });
+
+  it("fails explicitly when a repository fixture is not registered", async () => {
+    const source = new LocalFixtureRepositorySource({
+      fixtures: repositoryFixtures,
+    });
+    const missingRepository: RepositoryReference = {
+      provider: "local-fixture",
+      name: "missing-fixture",
+    };
+
+    await expect(source.listFiles(missingRepository)).rejects.toMatchObject({
+      code: "repository-not-found",
+      repository: missingRepository,
+    });
+  });
+
+  it("fails explicitly when a requested fixture file is missing", async () => {
+    const source = new LocalFixtureRepositorySource({
+      fixtures: repositoryFixtures,
+    });
+
+    await expect(
+      source.readFile(minimalNodeLibrary, "src/missing.ts"),
+    ).rejects.toBeInstanceOf(RepositorySourceError);
+    await expect(
+      source.readFile(minimalNodeLibrary, "src/missing.ts"),
+    ).rejects.toMatchObject({
+      code: "file-not-found",
+      repository: minimalNodeLibrary,
+    });
+  });
+
+  it("does not allow fixture reads outside the fixture root", async () => {
+    const source = new LocalFixtureRepositorySource({
+      fixtures: repositoryFixtures,
+    });
+
+    await expect(
+      source.readFile(
+        minimalNodeLibrary,
+        "../minimal-node-library/package.json",
+      ),
+    ).rejects.toMatchObject({
+      code: "file-not-found",
+      repository: minimalNodeLibrary,
+    });
+  });
+});


### PR DESCRIPTION
Closes #20

## Summary
- Define the repository acquisition source port and provenance-carrying repository file types.
- Add a local fixture repository source that lists and reads registered fixtures without network or model calls.
- Return typed source errors for missing fixtures and missing or invalid repository paths.

## Test Evidence
- pnpm run ci

## Changed Files
- src/domain/repository/index.ts
- src/domain/repository/repository-source.ts
- src/infrastructure/filesystem/index.ts
- src/infrastructure/filesystem/local-fixture-repository-source.ts
- test/domain/repository/repository-source.test.ts
- test/infrastructure/filesystem/local-fixture-repository-source.test.ts