### PR TITLE
ci(vercel): add preview e2e workflow

### DIFF
--- a/.github/workflows/preview-e2e.yml
+++ b/.github/workflows/preview-e2e.yml
@@ -1,0 +1,53 @@
+name: Preview E2E
+
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+  deployments: read
+
+jobs:
+  preview-e2e:
+    name: Preview E2E
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment_status.environment_url != '' &&
+      github.event.deployment.production_environment == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        if: env.VERCEL_AUTOMATION_BYPASS_SECRET != ''
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Explain skipped protected preview E2E
+        if: env.VERCEL_AUTOMATION_BYPASS_SECRET == ''
+        run: |
+          echo "::notice title=Preview E2E skipped::Set the VERCEL_AUTOMATION_BYPASS_SECRET GitHub secret after enabling Vercel Protection Bypass for Automation to run Playwright against protected preview URLs."
+
+      - name: Run Playwright against preview
+        if: env.VERCEL_AUTOMATION_BYPASS_SECRET != ''
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+        run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tsconfig.tsbuildinfo
 .env
 .env.*
 !.env.example
+.vercel/
 .DS_Store
 npm-debug.log*
 yarn-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ If a task conflicts with those documents, call out the conflict before editing. 
 - Do not merge work that bypasses failing checks unless there is an explicit documented exception.
 - Use Conventional Commits for all commit subjects.
 - Include a high-signal commit body with a second `-m` for non-trivial changes so future `git blame` readers can understand intent and tradeoffs.
+- Include GitHub references in non-trivial commit bodies once known: `Issue: #<number>` and `PR: #<number>`.
 
 ## 5. Respect Software Fundamentals
 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ See [docs/development-plan.md](docs/development-plan.md) for the milestone and i
 See [docs/commit-messages.md](docs/commit-messages.md) for commit and PR title standards.
 See [docs/fixtures.md](docs/fixtures.md) for repository fixture rules.
 See [docs/architecture.md](docs/architecture.md#test-placement) for test placement rules.
+See [docs/deployment.md](docs/deployment.md) for Vercel deployment and preview E2E setup.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -391,13 +391,18 @@ Non-trivial commits should include a body. Use a second `-m` when committing fro
 
 ```bash
 git commit -m "feat(chat): model targeted follow-up conversations" \
-  -m "Add conversation targets for report dimensions, findings, caveats, and evidence items. This keeps chat context explicit before persistence and auth are introduced."
+  -m "Add conversation targets for report dimensions, findings, caveats, and evidence items. This keeps chat context explicit before persistence and auth are introduced.
+
+Issue: #32
+PR: #58"
 ```
 
 Commit body expectations:
 - Explain why the change exists
 - Mention important tradeoffs or constraints
 - Mention test or migration implications when relevant
+- Include `Issue: #<number>`
+- Include `PR: #<number>` once the PR exists
 - Avoid repeating the subject
 
 Examples:
@@ -406,12 +411,18 @@ Examples:
 docs(architecture): define enforcement model
 
 Add CI, hook, branch-protection, and unsafe-type-escape standards so local agent work and GitHub enforcement share the same quality gate.
+
+Issue: #7
+PR: #50
 ```
 
 ```text
 test(domain): cover low-confidence reviewer caveats
 
 Prove that low-confidence reviewer claims reduce report confidence instead of becoming hard quality judgments. This protects the evidence-first report model.
+
+Issue: #19
+PR: #61
 ```
 
 Mechanical enforcement:

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -34,15 +34,20 @@ Non-trivial commits should include a body. When committing from the command line
 
 ```bash
 git commit -m "feat(chat): model targeted follow-up conversations" \
-  -m "Add conversation targets for report dimensions, findings, caveats, and evidence items. This keeps chat context explicit before persistence and auth are introduced."
+  -m "Add conversation targets for report dimensions, findings, caveats, and evidence items. This keeps chat context explicit before persistence and auth are introduced.
+
+Issue: #32
+PR: #58"
 ```
 
 The body should explain:
 - Why the change exists
 - Important tradeoffs or constraints
 - Test, migration, or rollout implications when relevant
+- The GitHub issue number as `Issue: #<number>`
+- The GitHub pull request number as `PR: #<number>` once the PR exists
 
-Do not repeat the subject in the body.
+Do not repeat the subject in the body. If the PR number is not known before the first push, amend the commit body after opening the PR and force-push with lease.
 
 ## Examples
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,84 @@
+# Deployment
+
+The production target is Vercel. Pull requests should receive Vercel preview deployments, and preview URLs should run the Playwright E2E smoke suite.
+
+## Vercel Project
+
+Expected project connection:
+
+- GitHub repository: `lightstrikelabs/repo-analyzer-green`
+- Framework preset: Next.js
+- Install command: `pnpm install --frozen-lockfile`
+- Build command: `pnpm build`
+- Development command: `pnpm dev`
+
+The committed Vercel configuration lives in `vercel.json`.
+
+Do not commit `.vercel/`. Vercel stores local project linkage there, including project and org identifiers. Those identifiers are not application secrets, but they are environment-specific operational metadata and should stay local.
+
+## CLI Setup
+
+Use the Vercel CLI from the repository root:
+
+```bash
+vercel --version
+vercel whoami --no-color
+vercel link --yes --project repo-analyzer-green
+```
+
+If multiple Vercel scopes are available, add `--scope <scope-name>` to `vercel link`.
+
+Connect the Vercel project to GitHub:
+
+```bash
+vercel git connect https://github.com/lightstrikelabs/repo-analyzer-green
+```
+
+For a private repository, this may require granting the Vercel GitHub integration access to the repository in the Vercel dashboard or GitHub app settings first.
+
+Do not paste Vercel tokens, project IDs, org IDs, deployment IDs, or pulled environment values into issues, PRs, commit messages, or docs.
+
+## Preview E2E
+
+`.github/workflows/preview-e2e.yml` listens for successful GitHub deployment statuses with an environment URL where `production_environment` is `false`. When Vercel reports a preview URL, the workflow runs:
+
+```bash
+PLAYWRIGHT_BASE_URL=<preview-url> pnpm test:e2e
+```
+
+`playwright.config.ts` uses `PLAYWRIGHT_BASE_URL` when present. Without it, Playwright starts the local Next.js dev server and targets `http://127.0.0.1:3000`.
+
+Vercel preview deployments may be protected by Vercel Authentication. For automated preview E2E, enable Vercel Protection Bypass for Automation and store the generated value as the GitHub Actions secret `VERCEL_AUTOMATION_BYPASS_SECRET`.
+
+When the secret is present, Playwright sends:
+
+```text
+x-vercel-protection-bypass: <secret>
+x-vercel-set-bypass-cookie: true
+```
+
+When the secret is missing, the preview workflow emits a GitHub notice and skips the browser run instead of logging protected page contents or failing with an authentication page assertion.
+
+References:
+- [Vercel: Methods to bypass Deployment Protection](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection)
+- [Vercel: Protection Bypass for Automation](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation)
+
+## Production
+
+Production deployments should come from merges to `main` through protected PRs with green `Quality Gate` checks.
+
+Before production has real users or private repository access, define:
+
+- Required environment variables in Vercel
+- Secret ownership and rotation policy
+- Model-provider credentials and usage limits
+- GitHub provider token policy for private repositories
+- Database connection and migration process
+
+No secret values should be stored in GitHub issues, pull requests, docs, or committed files.
+
+## Branch Protection
+
+`Quality Gate` is the required merge check for `main`.
+
+Preview E2E is event-driven by Vercel deployment statuses. Treat preview E2E failures as release blockers once Vercel preview deployments are consistently available for pull requests.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,30 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000";
+const vercelAutomationBypassSecret =
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const webServer = process.env.PLAYWRIGHT_BASE_URL
+  ? undefined
+  : {
+      command: "pnpm dev",
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+    };
+
 export default defineConfig({
   testDir: "./e2e",
-  webServer: {
-    command: "pnpm dev",
-    url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI,
-  },
+  ...(webServer === undefined ? {} : { webServer }),
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL,
+    ...(vercelAutomationBypassSecret === undefined ||
+    vercelAutomationBypassSecret === ""
+      ? {}
+      : {
+          extraHTTPHeaders: {
+            "x-vercel-protection-bypass": vercelAutomationBypassSecret,
+            "x-vercel-set-bypass-cookie": "true",
+          },
+        }),
     trace: "on-first-retry",
   },
   projects: [

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm build",
+  "devCommand": "pnpm dev"
+}


### PR DESCRIPTION
Closes #45

## Scope
- Add committed Vercel project settings in `vercel.json`.
- Add a deployment-status workflow that runs Playwright against successful Vercel Preview URLs.
- Let Playwright target `PLAYWRIGHT_BASE_URL` when a preview URL is provided, while keeping local dev-server behavior by default.
- Document Vercel CLI setup, GitHub connection, preview E2E, production path, and secret-handling rules.
- Ignore local `.vercel/` linkage metadata.

## Vercel CLI Evidence
- `vercel --version` confirmed the CLI is installed.
- `vercel whoami --no-color` confirmed local authentication; account details are not included here.
- `vercel link --yes --project repo-analyzer-green --scope <team-scope>` linked the project locally.
- `vercel git connect https://github.com/lightstrikelabs/repo-analyzer-green --scope <team-scope>` succeeded after the GitHub app was granted access to the private repo.
- `vercel project inspect repo-analyzer-green --scope <team-scope>` confirmed Next.js, Node 24.x, `pnpm install --frozen-lockfile`, and `pnpm build`.

No Vercel tokens, project IDs, org IDs, deployment IDs, pulled env files, or secret values are committed or copied into this PR.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
