### PR TITLE
test(architecture): define hybrid placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,13 @@ If a task conflicts with those documents, call out the conflict before editing. 
 - Keep the foundational E2E test stable, deterministic, and independent of paid/network model calls.
 - Use fake or fixture-backed adapters where needed.
 
+## Test Placement
+
+- Colocate narrow unit and domain tests with the source module using `*.test.ts`.
+- Keep integration, fixture, contract, tooling, and browser E2E tests in `test/` or `e2e/`.
+- When adding domain behavior, start red/green/refactor next to the model, value object, policy, or domain service being changed.
+- Do not move shared fixtures into `src`; fixtures remain test harness assets.
+
 ## 4. Use PR Discipline
 
 - Always open PRs against an upstream branch.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ The scaffold intentionally contains only the application shell, architecture fol
 See [docs/development-plan.md](docs/development-plan.md) for the milestone and issue plan.
 See [docs/commit-messages.md](docs/commit-messages.md) for commit and PR title standards.
 See [docs/fixtures.md](docs/fixtures.md) for repository fixture rules.
+See [docs/architecture.md](docs/architecture.md#test-placement) for test placement rules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,6 +236,42 @@ Test layers:
 - Fixture tests across repo archetypes
 - One foundational Playwright E2E test for the core analysis/report/chat path
 
+### Test Placement
+
+Use a hybrid placement strategy.
+
+Colocate narrow unit and domain tests with the source module they specify:
+
+```text
+src/domain/report/report-card.ts
+src/domain/report/report-card.test.ts
+src/domain/scoring/scoring-policy.ts
+src/domain/scoring/scoring-policy.test.ts
+```
+
+Keep broader harness-oriented tests outside `src`:
+
+```text
+test/fixtures/
+test/infrastructure/
+test/tooling/
+test/contracts/
+e2e/
+```
+
+Rationale:
+- Co-located domain tests keep red/green/refactor tight and make behavior examples visible next to the model or policy.
+- External integration and fixture tests keep cross-module scenarios, filesystem fixtures, tooling checks, and browser workflows out of production source directories.
+- Shared fixtures are test harness assets, not domain code.
+
+Default placement:
+- Domain value objects, schemas, policies, and domain services: colocated `*.test.ts`
+- Application use cases with fake ports: colocated when the test is narrow, `test/application/` when it spans multiple adapters or fixtures
+- Infrastructure adapters: `test/infrastructure/`
+- Fixture registry and fixture maintenance checks: `test/fixtures/`
+- Tooling scripts: `test/tooling/`
+- Browser workflows: `e2e/`
+
 Recommended scripts:
 
 ```json

--- a/src/domain/report/report-card.test.ts
+++ b/src/domain/report/report-card.test.ts
@@ -5,8 +5,8 @@ import {
   ReportCardSchema,
   ReportCardSchemaVersion,
   ReviewerMetadataSchema,
-} from "../../../src/domain/report/report-card";
-import { EvidenceReferenceSchema } from "../../../src/domain/shared/evidence-reference";
+} from "./report-card";
+import { EvidenceReferenceSchema } from "../shared/evidence-reference";
 
 const highConfidence = {
   level: "high",

--- a/src/domain/repository/repository-source.test.ts
+++ b/src/domain/repository/repository-source.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   RepositorySourceError,
   type RepositoryReference,
-} from "../../../src/domain/repository/repository-source";
+} from "./repository-source";
 
 describe("RepositorySource domain types", () => {
   it("carries repository source failure context", () => {


### PR DESCRIPTION
Closes #57

## Scope
- Document the hybrid test-placement strategy in `AGENTS.md`, `README.md`, and `docs/architecture.md`.
- Move narrow report-card and repository-source domain unit tests next to their source modules.
- Keep fixture, infrastructure, tooling, and E2E tests in the external harness.

## Placement Rule
- Domain value objects, schemas, policies, and domain services: colocated `*.test.ts`.
- Integration, fixture, contract, tooling, infrastructure adapter, and browser workflow tests: `test/` or `e2e/`.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
