### PR TITLE
build(postcss): use typescript config

### DIFF
--- a/postcss.config.ts
+++ b/postcss.config.ts
@@ -2,6 +2,8 @@ const config = {
   plugins: {
     "@tailwindcss/postcss": {},
   },
+} satisfies {
+  readonly plugins: Record<string, object>;
 };
 
 export default config;


### PR DESCRIPTION
Closes #59

## Scope
- Rename `postcss.config.mjs` to `postcss.config.ts`.
- Keep the Tailwind/PostCSS config behavior unchanged.
- Add a small TypeScript `satisfies` constraint for the config shape.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
