### PR TITLE
feat(evidence): collect file inventory omissions

### DIFF
--- a/src/domain/evidence/file-inventory.test.ts
+++ b/src/domain/evidence/file-inventory.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  RepositoryFileContent,
+  RepositoryFileEntry,
+  RepositoryPath,
+  RepositoryReference,
+  RepositorySource,
+} from "../repository/repository-source";
+
+import { collectFileInventory } from "./file-inventory";
+
+const repository: RepositoryReference = {
+  provider: "local-fixture",
+  name: "inventory-fixture",
+  revision: "test",
+};
+
+describe("collectFileInventory", () => {
+  it("records file inventory with path, size, extension, and classification signals", async () => {
+    const inventory = await collectFileInventory(
+      repository,
+      new FakeRepositorySource([
+        textFile("README.md", "# Package\n"),
+        textFile("src/add.ts", "export function add() {}\n"),
+        textFile("test/add.spec.ts", "import { describe } from 'vitest';\n"),
+        textFile("package.json", '{"scripts":{"test":"vitest"}}\n'),
+      ]),
+    );
+
+    expect(inventory.files).toEqual([
+      expect.objectContaining({
+        path: "README.md",
+        sizeBytes: 10,
+        extension: ".md",
+        signals: expect.arrayContaining(["documentation"]),
+      }),
+      expect.objectContaining({
+        path: "package.json",
+        sizeBytes: 30,
+        extension: ".json",
+        signals: expect.arrayContaining(["manifest", "configuration"]),
+      }),
+      expect.objectContaining({
+        path: "src/add.ts",
+        sizeBytes: 25,
+        extension: ".ts",
+        signals: expect.arrayContaining(["source"]),
+      }),
+      expect.objectContaining({
+        path: "test/add.spec.ts",
+        sizeBytes: 35,
+        extension: ".ts",
+        signals: expect.arrayContaining(["test", "source"]),
+      }),
+    ]);
+    expect(inventory.omissions).toEqual([]);
+  });
+
+  it("records ignored, oversized, binary, generated, and vendor omissions with reasons", async () => {
+    const inventory = await collectFileInventory(
+      repository,
+      new FakeRepositorySource([
+        textFile(".git/config", "[core]\n"),
+        textFile("src/add.ts", "export function add() {}\n"),
+        textFile("dist/add.js", "export function add() {}\n"),
+        textFile("node_modules/lib/index.js", "module.exports = {}\n"),
+        textFile("src/api.generated.ts", "export const generated = true;\n"),
+        textFile("assets/logo.png", "png\0bytes"),
+        textFile("docs/reference.md", "x".repeat(51)),
+      ]),
+      { maxFileSizeBytes: 50 },
+    );
+
+    expect(inventory.files.map((file) => file.path)).toEqual(["src/add.ts"]);
+    expect(inventory.omissions).toEqual([
+      expect.objectContaining({
+        path: ".git/config",
+        reason: "ignored",
+        detail: "version-control metadata is ignored",
+      }),
+      expect.objectContaining({
+        path: "assets/logo.png",
+        reason: "binary",
+        detail: "file content appears to be binary",
+      }),
+      expect.objectContaining({
+        path: "dist/add.js",
+        reason: "generated",
+        detail: "generated output directory is omitted",
+      }),
+      expect.objectContaining({
+        path: "docs/reference.md",
+        reason: "oversized",
+        detail: "file exceeds the 50 byte inventory limit",
+      }),
+      expect.objectContaining({
+        path: "node_modules/lib/index.js",
+        reason: "vendor",
+        detail: "vendor dependency directory is omitted",
+      }),
+      expect.objectContaining({
+        path: "src/api.generated.ts",
+        reason: "generated",
+        detail: "generated filename pattern is omitted",
+      }),
+    ]);
+  });
+});
+
+function textFile(path: RepositoryPath, text: string): FakeRepositoryFile {
+  return {
+    path,
+    text,
+    sizeBytes: Buffer.byteLength(text),
+  };
+}
+
+type FakeRepositoryFile = {
+  readonly path: RepositoryPath;
+  readonly text: string;
+  readonly sizeBytes: number;
+};
+
+class FakeRepositorySource implements RepositorySource {
+  private readonly files: readonly FakeRepositoryFile[];
+
+  constructor(files: readonly FakeRepositoryFile[]) {
+    this.files = files;
+  }
+
+  async listFiles(): Promise<readonly RepositoryFileEntry[]> {
+    return this.files.map((file) => ({
+      path: file.path,
+      sizeBytes: file.sizeBytes,
+      provenance: {
+        repository,
+        sourceKind: "local-fixture",
+        sourceId: "inventory-fixture",
+        path: file.path,
+      },
+    }));
+  }
+
+  async readFile(
+    _repository: RepositoryReference,
+    filePath: RepositoryPath,
+  ): Promise<RepositoryFileContent> {
+    const file = this.files.find((candidate) => candidate.path === filePath);
+
+    if (file === undefined) {
+      throw new Error(`Missing fake file: ${filePath}`);
+    }
+
+    return {
+      path: file.path,
+      text: file.text,
+      sizeBytes: file.sizeBytes,
+      provenance: {
+        repository,
+        sourceKind: "local-fixture",
+        sourceId: "inventory-fixture",
+        path: file.path,
+      },
+    };
+  }
+}

--- a/src/domain/evidence/file-inventory.ts
+++ b/src/domain/evidence/file-inventory.ts
@@ -1,0 +1,310 @@
+import path from "node:path";
+
+import type {
+  RepositoryFileEntry,
+  RepositoryReference,
+  RepositorySource,
+} from "../repository/repository-source";
+
+export type FileClassificationSignal =
+  | "configuration"
+  | "documentation"
+  | "lockfile"
+  | "manifest"
+  | "source"
+  | "test";
+
+export type FileOmissionReason =
+  | "binary"
+  | "generated"
+  | "ignored"
+  | "oversized"
+  | "vendor";
+
+export type InventoryFile = {
+  readonly path: string;
+  readonly sizeBytes: number;
+  readonly extension: string;
+  readonly signals: readonly FileClassificationSignal[];
+};
+
+export type InventoryOmission = {
+  readonly path: string;
+  readonly sizeBytes: number;
+  readonly reason: FileOmissionReason;
+  readonly detail: string;
+};
+
+export type FileInventory = {
+  readonly files: readonly InventoryFile[];
+  readonly omissions: readonly InventoryOmission[];
+};
+
+export type FileInventoryOptions = {
+  readonly maxFileSizeBytes?: number;
+};
+
+const defaultMaxFileSizeBytes = 256 * 1024;
+
+const ignoredDirectoryDetails = new Map<string, string>([
+  [".git", "version-control metadata is ignored"],
+  [".hg", "version-control metadata is ignored"],
+  [".svn", "version-control metadata is ignored"],
+]);
+
+const generatedDirectoryDetails = new Map<string, string>([
+  [".next", "generated output directory is omitted"],
+  ["build", "generated output directory is omitted"],
+  ["coverage", "generated output directory is omitted"],
+  ["dist", "generated output directory is omitted"],
+  ["out", "generated output directory is omitted"],
+]);
+
+const vendorDirectoryDetails = new Map<string, string>([
+  ["node_modules", "vendor dependency directory is omitted"],
+  ["vendor", "vendor dependency directory is omitted"],
+]);
+
+const manifestFilenames = new Set([
+  "Cargo.toml",
+  "Gemfile",
+  "go.mod",
+  "package.json",
+  "pom.xml",
+  "pyproject.toml",
+  "requirements.txt",
+]);
+
+const lockfileFilenames = new Set([
+  "Cargo.lock",
+  "Gemfile.lock",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "poetry.lock",
+  "yarn.lock",
+]);
+
+const documentationFilenames = new Set([
+  "CHANGELOG.md",
+  "CONTRIBUTING.md",
+  "LICENSE",
+  "README.md",
+]);
+
+const configurationFilenames = new Set([
+  ".eslintrc",
+  ".prettierrc",
+  "next.config.js",
+  "next.config.mjs",
+  "next.config.ts",
+  "tsconfig.json",
+  "vitest.config.ts",
+]);
+
+const sourceExtensions = new Set([
+  ".c",
+  ".cpp",
+  ".cs",
+  ".go",
+  ".java",
+  ".js",
+  ".jsx",
+  ".kt",
+  ".php",
+  ".py",
+  ".rb",
+  ".rs",
+  ".swift",
+  ".ts",
+  ".tsx",
+]);
+
+const documentationExtensions = new Set([
+  ".adoc",
+  ".md",
+  ".mdx",
+  ".rst",
+  ".txt",
+]);
+const configurationExtensions = new Set([".json", ".toml", ".yaml", ".yml"]);
+
+export async function collectFileInventory(
+  repository: RepositoryReference,
+  source: RepositorySource,
+  options: FileInventoryOptions = {},
+): Promise<FileInventory> {
+  const maxFileSizeBytes = options.maxFileSizeBytes ?? defaultMaxFileSizeBytes;
+  const entries = [...(await source.listFiles(repository))].sort(comparePaths);
+  const files: InventoryFile[] = [];
+  const omissions: InventoryOmission[] = [];
+
+  for (const entry of entries) {
+    const pathOmission = omissionFromPath(entry);
+
+    if (pathOmission !== undefined) {
+      omissions.push(pathOmission);
+      continue;
+    }
+
+    if (entry.sizeBytes > maxFileSizeBytes) {
+      omissions.push({
+        path: entry.path,
+        sizeBytes: entry.sizeBytes,
+        reason: "oversized",
+        detail: `file exceeds the ${maxFileSizeBytes} byte inventory limit`,
+      });
+      continue;
+    }
+
+    const file = await source.readFile(repository, entry.path);
+
+    if (appearsBinary(file.text)) {
+      omissions.push({
+        path: entry.path,
+        sizeBytes: entry.sizeBytes,
+        reason: "binary",
+        detail: "file content appears to be binary",
+      });
+      continue;
+    }
+
+    files.push({
+      path: entry.path,
+      sizeBytes: entry.sizeBytes,
+      extension: path.posix.extname(entry.path),
+      signals: classifyFile(entry.path),
+    });
+  }
+
+  return { files, omissions };
+}
+
+function omissionFromPath(
+  entry: RepositoryFileEntry,
+): InventoryOmission | undefined {
+  const segments = entry.path.split("/");
+
+  for (const segment of segments) {
+    const ignoredDetail = ignoredDirectoryDetails.get(segment);
+    if (ignoredDetail !== undefined) {
+      return omission(entry, "ignored", ignoredDetail);
+    }
+
+    const vendorDetail = vendorDirectoryDetails.get(segment);
+    if (vendorDetail !== undefined) {
+      return omission(entry, "vendor", vendorDetail);
+    }
+
+    const generatedDetail = generatedDirectoryDetails.get(segment);
+    if (generatedDetail !== undefined) {
+      return omission(entry, "generated", generatedDetail);
+    }
+  }
+
+  const basename = path.posix.basename(entry.path);
+  if (
+    basename.includes(".generated.") ||
+    basename.endsWith(".generated") ||
+    basename.endsWith(".min.js") ||
+    basename.endsWith(".min.css")
+  ) {
+    return omission(
+      entry,
+      "generated",
+      "generated filename pattern is omitted",
+    );
+  }
+
+  return undefined;
+}
+
+function omission(
+  entry: RepositoryFileEntry,
+  reason: FileOmissionReason,
+  detail: string,
+): InventoryOmission {
+  return {
+    path: entry.path,
+    sizeBytes: entry.sizeBytes,
+    reason,
+    detail,
+  };
+}
+
+function appearsBinary(text: string): boolean {
+  return text.includes("\0");
+}
+
+function classifyFile(filePath: string): readonly FileClassificationSignal[] {
+  const basename = path.posix.basename(filePath);
+  const extension = path.posix.extname(filePath);
+  const signals: FileClassificationSignal[] = [];
+
+  if (isDocumentationFile(basename, extension)) {
+    signals.push("documentation");
+  }
+
+  if (manifestFilenames.has(basename)) {
+    signals.push("manifest");
+  }
+
+  if (lockfileFilenames.has(basename)) {
+    signals.push("lockfile");
+  }
+
+  if (isConfigurationFile(basename, extension)) {
+    signals.push("configuration");
+  }
+
+  if (isTestFile(filePath)) {
+    signals.push("test");
+  }
+
+  if (sourceExtensions.has(extension)) {
+    signals.push("source");
+  }
+
+  return signals;
+}
+
+function isDocumentationFile(basename: string, extension: string): boolean {
+  return (
+    documentationFilenames.has(basename) ||
+    documentationExtensions.has(extension)
+  );
+}
+
+function isConfigurationFile(basename: string, extension: string): boolean {
+  return (
+    configurationFilenames.has(basename) ||
+    configurationExtensions.has(extension)
+  );
+}
+
+function isTestFile(filePath: string): boolean {
+  const basename = path.posix.basename(filePath);
+
+  return (
+    filePath.startsWith("test/") ||
+    filePath.includes("/test/") ||
+    filePath.startsWith("tests/") ||
+    filePath.includes("/tests/") ||
+    basename.includes(".test.") ||
+    basename.includes(".spec.")
+  );
+}
+
+function comparePaths(
+  left: RepositoryFileEntry,
+  right: RepositoryFileEntry,
+): number {
+  if (left.path < right.path) {
+    return -1;
+  }
+
+  if (left.path > right.path) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/src/domain/repository/repository-source.ts
+++ b/src/domain/repository/repository-source.ts
@@ -21,6 +21,7 @@ export type RepositoryFileProvenance = {
 
 export type RepositoryFileEntry = {
   readonly path: RepositoryPath;
+  readonly sizeBytes: number;
   readonly provenance: RepositoryFileProvenance;
 };
 

--- a/src/infrastructure/filesystem/local-fixture-repository-source.ts
+++ b/src/infrastructure/filesystem/local-fixture-repository-source.ts
@@ -32,13 +32,14 @@ export class LocalFixtureRepositorySource implements RepositorySource {
     const fixture = this.requireFixture(repository);
     const files = await listFixtureFiles(fixture.rootPath);
 
-    return files.map((filePath) => ({
-      path: filePath,
+    return files.map((file) => ({
+      path: file.path,
+      sizeBytes: file.sizeBytes,
       provenance: {
         repository,
         sourceKind: "local-fixture",
         sourceId: fixture.id,
-        path: filePath,
+        path: file.path,
       },
     }));
   }
@@ -64,6 +65,7 @@ export class LocalFixtureRepositorySource implements RepositorySource {
       return {
         path: filePath,
         text,
+        sizeBytes: fileStat.size,
         provenance: {
           repository,
           sourceKind: "local-fixture",
@@ -96,16 +98,23 @@ export class LocalFixtureRepositorySource implements RepositorySource {
   }
 }
 
-async function listFixtureFiles(rootPath: string): Promise<readonly string[]> {
-  const files: string[] = [];
+type DiscoveredFixtureFile = {
+  readonly path: RepositoryPath;
+  readonly sizeBytes: number;
+};
+
+async function listFixtureFiles(
+  rootPath: string,
+): Promise<readonly DiscoveredFixtureFile[]> {
+  const files: DiscoveredFixtureFile[] = [];
   await collectFiles(rootPath, rootPath, files);
-  return files.sort();
+  return files.sort(compareDiscoveredFixtureFiles);
 }
 
 async function collectFiles(
   rootPath: string,
   currentPath: string,
-  files: string[],
+  files: DiscoveredFixtureFile[],
 ): Promise<void> {
   const entries = await readdir(currentPath, { withFileTypes: true });
 
@@ -117,7 +126,12 @@ async function collectFiles(
     }
 
     if (entry.isFile()) {
-      files.push(toRepositoryPath(rootPath, entryPath));
+      const fileStat = await stat(entryPath);
+      const repositoryPath = toRepositoryPath(rootPath, entryPath);
+      files.push({
+        path: repositoryPath,
+        sizeBytes: fileStat.size,
+      });
     }
   }
 }
@@ -169,4 +183,19 @@ function notFound(
     "file-not-found",
     repository,
   );
+}
+
+function compareDiscoveredFixtureFiles(
+  left: DiscoveredFixtureFile,
+  right: DiscoveredFixtureFile,
+): number {
+  if (left.path < right.path) {
+    return -1;
+  }
+
+  if (left.path > right.path) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/infrastructure/filesystem/local-fixture-repository-source.test.ts
+++ b/test/infrastructure/filesystem/local-fixture-repository-source.test.ts
@@ -28,11 +28,45 @@ describe("LocalFixtureRepositorySource", () => {
       "src/add.ts",
       "test/add.spec.ts",
     ]);
-    expect(files[0]?.provenance).toEqual({
-      repository: minimalNodeLibrary,
-      sourceKind: "local-fixture",
-      sourceId: "minimal-node-library",
+    expect(files[0]).toEqual({
       path: "README.md",
+      sizeBytes: 252,
+      provenance: {
+        repository: minimalNodeLibrary,
+        sourceKind: "local-fixture",
+        sourceId: "minimal-node-library",
+        path: "README.md",
+      },
+    });
+    expect(files[2]).toEqual({
+      path: "src/add.ts",
+      sizeBytes: 84,
+      provenance: {
+        repository: minimalNodeLibrary,
+        sourceKind: "local-fixture",
+        sourceId: "minimal-node-library",
+        path: "src/add.ts",
+      },
+    });
+  });
+
+  it("reads file contents with byte size metadata", async () => {
+    const source = new LocalFixtureRepositorySource({
+      fixtures: repositoryFixtures,
+    });
+
+    const file = await source.readFile(minimalNodeLibrary, "src/add.ts");
+
+    expect(file).toEqual({
+      path: "src/add.ts",
+      text: "export function add(left: number, right: number): number {\n  return left + right;\n}\n",
+      sizeBytes: 84,
+      provenance: {
+        repository: minimalNodeLibrary,
+        sourceKind: "local-fixture",
+        sourceId: "minimal-node-library",
+        path: "src/add.ts",
+      },
     });
   });
 
@@ -50,6 +84,19 @@ describe("LocalFixtureRepositorySource", () => {
       sourceKind: "local-fixture",
       sourceId: "minimal-node-library",
       path: "src/add.ts",
+    });
+  });
+
+  it("carries repository source failure context with the expanded file shape", async () => {
+    const source = new LocalFixtureRepositorySource({
+      fixtures: repositoryFixtures,
+    });
+
+    await expect(
+      source.readFile(minimalNodeLibrary, "src/missing.ts"),
+    ).rejects.toMatchObject({
+      code: "file-not-found",
+      repository: minimalNodeLibrary,
     });
   });
 


### PR DESCRIPTION
## Summary
- add a domain file inventory collector with relative path, byte size, extension, and classification signals
- record explicit omissions for ignored metadata, generated output, vendor dependencies, oversized files, and binary-looking files
- surface file byte sizes through RepositorySource and the local fixture adapter

## Tests
- pnpm run ci

Issue: #21
PR: #62