### PR TITLE
docs(ui): define thin screen architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ If a task conflicts with those documents, call out the conflict before editing. 
 ## Project-Specific Direction
 
 - This project is domain-first. Keep domain logic independent of framework, filesystem, network, GitHub, and model-provider details.
+- Keep frontend route/page files as thin screens. Put reusable UI and non-trivial presentation behavior in modular components, and test those components when behavior, state, or conditional rendering matters.
 - Use fake adapters for tests before wiring real infrastructure.
 - Preserve provenance, confidence, caveats, and missing evidence in report behavior.
 - Do not treat raw test LOC, raw coverage, or single static scores as direct proof of repository quality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ If a task conflicts with those documents, call out the conflict before editing. 
 - Use Conventional Commits for all commit subjects.
 - Include a high-signal commit body with a second `-m` for non-trivial changes so future `git blame` readers can understand intent and tradeoffs.
 - Include GitHub references in non-trivial commit bodies once known: `Issue: #<number>` and `PR: #<number>`.
+- Do not amend commits during normal PR work. Add follow-up commits for PR metadata, review fixes, and corrections so the development history stays inspectable.
 
 ## 5. Respect Software Fundamentals
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ See [docs/commit-messages.md](docs/commit-messages.md) for commit and PR title s
 See [docs/fixtures.md](docs/fixtures.md) for repository fixture rules.
 See [docs/architecture.md](docs/architecture.md#test-placement) for test placement rules.
 See [docs/deployment.md](docs/deployment.md) for Vercel deployment and preview E2E setup.
+See [docs/architecture.md](docs/architecture.md#frontend-architecture) for frontend thin-screen and component rules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,45 @@ The application should preserve provenance, caveats, missing evidence, and confi
 
 Next.js is a good fit because the app needs a browser UI, API boundaries, server-side repository analysis, and future auth/database integration. The domain must remain independent of Next.js.
 
+### Frontend Architecture
+
+Keep route and page files thin. Next.js route files should compose data loading, application-service calls, and reusable components; they should not own business policy or accumulate detailed UI behavior.
+
+Recommended structure:
+
+```text
+src/
+  app/
+    page.tsx
+    reports/
+      [reportId]/
+        page.tsx
+  components/
+    report/
+      report-summary.tsx
+      report-finding-list.tsx
+    chat/
+      follow-up-thread.tsx
+      follow-up-composer.tsx
+    shared/
+      confidence-badge.tsx
+      evidence-link.tsx
+```
+
+Rules:
+- Screens/routes are composition boundaries, not business-policy modules.
+- Reusable UI belongs in named components under `src/components/` once it is shared, stateful, conditional, or large enough to hide route intent.
+- Component names should describe product concepts, not visual implementation details.
+- Components may format and present domain/application data, but scoring policy, evidence interpretation, reviewer rules, and authorization decisions stay outside the component tree.
+- Keep component props explicit and typed. Parse external/runtime data before it reaches UI components.
+- Do not create `index.ts` component barrels. Import concrete component modules directly.
+
+Testing:
+- Component tests are required for non-trivial state, conditional rendering, accessibility-critical controls, error/empty/loading states, and user interactions.
+- Pure static presentational components can be covered through parent workflow tests until they gain behavior.
+- Keep narrow component tests colocated with the component using `*.test.tsx`.
+- Keep browser workflow tests in `e2e/`.
+
 ## Scaffolding Strategy
 
 Scaffold in two passes: first the framework/tooling skeleton, then the first vertical domain slice. Do not start by cloning the red UI or wiring real GitHub/model infrastructure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -443,6 +443,7 @@ Commit body expectations:
 - Include `Issue: #<number>`
 - Include `PR: #<number>` once the PR exists
 - Avoid repeating the subject
+- Do not amend commits during normal PR work; add follow-up commits for metadata, review fixes, and corrections.
 
 Examples:
 

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -47,7 +47,7 @@ The body should explain:
 - The GitHub issue number as `Issue: #<number>`
 - The GitHub pull request number as `PR: #<number>` once the PR exists
 
-Do not repeat the subject in the body. If the PR number is not known before the first push, amend the commit body after opening the PR and force-push with lease.
+Do not repeat the subject in the body. Do not amend commits during normal PR work. If the PR number is not known before the first push, add a follow-up commit that records the PR reference or include the PR reference in the squash-merge body.
 
 ## Examples
 


### PR DESCRIPTION
Closes #61

## Scope
- Document thin-screen route/page expectations.
- Define reusable component placement under `src/components/`.
- Require component tests for non-trivial UI behavior, state, conditional rendering, accessibility-critical controls, and interactions.
- Reinforce that UI components do not own business policy.

## Non-goals
- No UI feature implementation.
- No component library introduction.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
