### PR TITLE
feat(reviewer): add fake reviewer adapter

### DIFF
--- a/src/domain/reviewer/reviewer.ts
+++ b/src/domain/reviewer/reviewer.ts
@@ -1,0 +1,38 @@
+import type {
+  RepositoryIdentity,
+  ReviewerMetadata,
+} from "../report/report-card";
+import type { EvidenceReference } from "../shared/evidence-reference";
+
+import type { ReviewerAssessment } from "./reviewer-assessment";
+
+export type ReviewerRequest = {
+  readonly repository: RepositoryIdentity;
+  readonly evidenceReferences: readonly EvidenceReference[];
+  readonly evidenceSummary?: string;
+};
+
+export type ReviewerResponseValidationIssue = {
+  readonly path: readonly (string | number)[];
+  readonly message: string;
+};
+
+export type ReviewerAssessmentResult = {
+  readonly kind: "assessment";
+  readonly assessment: ReviewerAssessment;
+};
+
+export type MalformedReviewerResponse = {
+  readonly kind: "malformed-response";
+  readonly reviewer: ReviewerMetadata;
+  readonly rawResponse: string;
+  readonly validationIssues: readonly ReviewerResponseValidationIssue[];
+};
+
+export type ReviewerResult =
+  | ReviewerAssessmentResult
+  | MalformedReviewerResponse;
+
+export interface Reviewer {
+  assess(request: ReviewerRequest): Promise<ReviewerResult>;
+}

--- a/src/infrastructure/reviewer/fake-reviewer.ts
+++ b/src/infrastructure/reviewer/fake-reviewer.ts
@@ -1,0 +1,47 @@
+import {
+  ReviewerAssessmentSchema,
+  type ReviewerAssessment,
+} from "../../domain/reviewer/reviewer-assessment";
+import type {
+  Reviewer,
+  ReviewerRequest,
+  ReviewerResult,
+} from "../../domain/reviewer/reviewer";
+
+export type FakeReviewerOptions = {
+  readonly result: ReviewerResult;
+};
+
+export class FakeReviewer implements Reviewer {
+  private readonly result: ReviewerResult;
+  private readonly requests: ReviewerRequest[] = [];
+
+  constructor(options: FakeReviewerOptions) {
+    this.result = normalizeResult(options.result);
+  }
+
+  get receivedRequests(): readonly ReviewerRequest[] {
+    return [...this.requests];
+  }
+
+  async assess(request: ReviewerRequest): Promise<ReviewerResult> {
+    this.requests.push(request);
+    return this.result;
+  }
+}
+
+function normalizeResult(result: ReviewerResult): ReviewerResult {
+  switch (result.kind) {
+    case "assessment":
+      return {
+        kind: "assessment",
+        assessment: parseAssessment(result.assessment),
+      };
+    case "malformed-response":
+      return result;
+  }
+}
+
+function parseAssessment(assessment: ReviewerAssessment): ReviewerAssessment {
+  return ReviewerAssessmentSchema.parse(assessment);
+}

--- a/test/infrastructure/reviewer/fake-reviewer.test.ts
+++ b/test/infrastructure/reviewer/fake-reviewer.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ReviewerAssessmentSchemaVersion,
+  type ReviewerAssessment,
+} from "../../../src/domain/reviewer/reviewer-assessment";
+import type {
+  MalformedReviewerResponse,
+  ReviewerRequest,
+} from "../../../src/domain/reviewer/reviewer";
+import { FakeReviewer } from "../../../src/infrastructure/reviewer/fake-reviewer";
+
+const packageManifestReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+  lineStart: 1,
+  lineEnd: 24,
+} as const;
+
+const testFileReference = {
+  id: "evidence:test-file",
+  kind: "file",
+  label: "Unit test file",
+  path: "test/add.spec.ts",
+} as const;
+
+const highConfidence = {
+  level: "high",
+  score: 0.91,
+  rationale: "Package and test files support this conclusion.",
+} as const;
+
+const lowConfidence = {
+  level: "low",
+  score: 0.19,
+  rationale: "The fixture intentionally omits operational context.",
+} as const;
+
+const reviewerMetadata = {
+  kind: "fake",
+  name: "Fake reviewer",
+  reviewerVersion: "issue-26",
+  reviewedAt: "2026-04-25T20:00:00-07:00",
+} as const;
+
+const request: ReviewerRequest = {
+  repository: {
+    provider: "local-fixture",
+    name: "minimal-node-library",
+    revision: "fixture",
+  },
+  evidenceReferences: [packageManifestReference, testFileReference],
+  evidenceSummary: "A minimal TypeScript library with one unit test.",
+};
+
+const deterministicAssessment = {
+  schemaVersion: ReviewerAssessmentSchemaVersion,
+  reviewer: reviewerMetadata,
+  assessedArchetype: {
+    value: "library",
+    confidence: highConfidence,
+    evidenceReferences: [packageManifestReference],
+    rationale: "The package manifest exposes reusable library code.",
+  },
+  dimensions: [
+    {
+      dimension: "verifiability",
+      summary: "The fixture includes a focused public API test.",
+      confidence: highConfidence,
+      evidenceReferences: [testFileReference],
+      strengths: ["The exported add function is covered by a unit test."],
+      risks: ["The test suite remains narrow."],
+      missingEvidence: [],
+    },
+  ],
+  caveats: [],
+  followUpQuestions: [],
+} satisfies ReviewerAssessment;
+
+const lowConfidenceAssessment = {
+  ...deterministicAssessment,
+  assessedArchetype: {
+    value: "unknown",
+    confidence: lowConfidence,
+    evidenceReferences: [],
+    rationale: "The fake response simulates ambiguous archetype evidence.",
+  },
+  dimensions: [
+    {
+      dimension: "operability",
+      summary: "Release readiness is uncertain from the fixture alone.",
+      confidence: lowConfidence,
+      evidenceReferences: [packageManifestReference],
+      strengths: [],
+      risks: ["Release and incident history are unavailable."],
+      missingEvidence: ["Release workflow history", "Incident history"],
+    },
+  ],
+  caveats: [
+    {
+      id: "caveat:missing-operability-context",
+      summary: "Operational evidence is absent from the fixture snapshot.",
+      affectedDimensions: ["operability"],
+      missingEvidence: ["Deployment history"],
+      confidence: lowConfidence,
+      evidenceReferences: [],
+    },
+  ],
+} satisfies ReviewerAssessment;
+
+describe("FakeReviewer", () => {
+  it("returns an injected deterministic reviewer assessment and records the request", async () => {
+    const reviewer = new FakeReviewer({
+      result: {
+        kind: "assessment",
+        assessment: deterministicAssessment,
+      },
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result).toEqual({
+      kind: "assessment",
+      assessment: deterministicAssessment,
+    });
+    expect(reviewer.receivedRequests).toEqual([request]);
+  });
+
+  it("returns malformed reviewer output as a typed recoverable result", async () => {
+    const malformedResponse: MalformedReviewerResponse = {
+      kind: "malformed-response",
+      reviewer: reviewerMetadata,
+      rawResponse: "{ malformed reviewer response",
+      validationIssues: [
+        {
+          path: ["dimensions", 0, "confidence"],
+          message: "Required",
+        },
+      ],
+    };
+    const reviewer = new FakeReviewer({ result: malformedResponse });
+
+    const result = await reviewer.assess(request);
+
+    expect(result).toEqual(malformedResponse);
+  });
+
+  it("can simulate low-confidence reviewer claims without model or network calls", async () => {
+    const reviewer = new FakeReviewer({
+      result: {
+        kind: "assessment",
+        assessment: lowConfidenceAssessment,
+      },
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result.kind).toBe("assessment");
+    if (result.kind !== "assessment") {
+      throw new Error("fake reviewer must return the injected assessment");
+    }
+    expect(result.assessment.assessedArchetype.confidence.level).toBe("low");
+    expect(result.assessment.dimensions[0]?.confidence).toEqual(lowConfidence);
+    expect(result.assessment.reviewer.kind).toBe("fake");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reviewer domain port with typed success and malformed-response results.
- Add a provider-free FakeReviewer that returns injected deterministic assessments and records requests.
- Cover deterministic assessments, malformed output simulation, and low-confidence fake claims.

## Tests
- pnpm exec vitest run test/infrastructure/reviewer/fake-reviewer.test.ts
- pnpm run check
- pnpm run ci

Issue: #26
PR: #68
