### PR TITLE
feat(evidence): parse manifest and workflow signals

### DIFF
--- a/src/domain/evidence/manifest-workflow-signals.test.ts
+++ b/src/domain/evidence/manifest-workflow-signals.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import { parseManifestWorkflowSignals } from "./manifest-workflow-signals";
+
+describe("parseManifestWorkflowSignals", () => {
+  it("reads package, dependency, build, and test signals from package.json", () => {
+    const result = parseManifestWorkflowSignals({
+      files: [
+        {
+          path: "package.json",
+          text: JSON.stringify({
+            name: "@fixture/web-app",
+            private: true,
+            packageManager: "pnpm@10.29.3",
+            scripts: {
+              build: "next build",
+              test: "vitest run",
+              lint: "oxlint .",
+              dev: "next dev",
+            },
+            dependencies: {
+              next: "^16.0.0",
+              react: "^19.0.0",
+            },
+            devDependencies: {
+              typescript: "^5.0.0",
+              vitest: "^4.0.0",
+            },
+          }),
+        },
+      ],
+    });
+
+    expect(result.packageManifests).toEqual([
+      {
+        kind: "package-json",
+        path: "package.json",
+        name: "@fixture/web-app",
+        private: true,
+        packageManager: "pnpm@10.29.3",
+        evidenceReferences: [
+          {
+            id: "manifest-workflow:package-json:package.json",
+            kind: "file",
+            label: "Package manifest",
+            path: "package.json",
+          },
+        ],
+      },
+    ]);
+    expect(result.dependencySignals).toEqual([
+      expect.objectContaining({
+        path: "package.json",
+        name: "next",
+        relationship: "production",
+      }),
+      expect.objectContaining({
+        path: "package.json",
+        name: "react",
+        relationship: "production",
+      }),
+      expect.objectContaining({
+        path: "package.json",
+        name: "typescript",
+        relationship: "development",
+      }),
+      expect.objectContaining({
+        path: "package.json",
+        name: "vitest",
+        relationship: "development",
+      }),
+    ]);
+    expect(result.scriptSignals).toEqual([
+      expect.objectContaining({
+        path: "package.json",
+        name: "build",
+        command: "next build",
+        purpose: "build",
+      }),
+      expect.objectContaining({
+        path: "package.json",
+        name: "dev",
+        command: "next dev",
+        purpose: "development",
+      }),
+      expect.objectContaining({
+        path: "package.json",
+        name: "lint",
+        command: "oxlint .",
+        purpose: "lint",
+      }),
+      expect.objectContaining({
+        path: "package.json",
+        name: "test",
+        command: "vitest run",
+        purpose: "test",
+      }),
+    ]);
+    expect(result.omissions).toEqual([]);
+    expect(result.unsupportedManifests).toEqual([]);
+  });
+
+  it("records GitHub CI and release workflow files as evidence", () => {
+    const result = parseManifestWorkflowSignals({
+      files: [
+        {
+          path: ".github/workflows/ci.yml",
+          text: "name: CI\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n",
+        },
+        {
+          path: ".github/workflows/publish.yaml",
+          text: "name: Release\non:\n  release:\n    types: [published]\n",
+        },
+        {
+          path: ".github/workflows/notes.txt",
+          text: "not a workflow",
+        },
+      ],
+    });
+
+    expect(result.workflowSignals).toEqual([
+      {
+        kind: "github-workflow",
+        path: ".github/workflows/ci.yml",
+        name: "ci",
+        purpose: "ci",
+        evidenceReferences: [
+          {
+            id: "manifest-workflow:github-workflow:.github/workflows/ci.yml",
+            kind: "file",
+            label: "GitHub workflow",
+            path: ".github/workflows/ci.yml",
+          },
+        ],
+      },
+      {
+        kind: "github-workflow",
+        path: ".github/workflows/publish.yaml",
+        name: "publish",
+        purpose: "release",
+        evidenceReferences: [
+          {
+            id: "manifest-workflow:github-workflow:.github/workflows/publish.yaml",
+            kind: "file",
+            label: "GitHub workflow",
+            path: ".github/workflows/publish.yaml",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("records unsupported manifest notes without failing", () => {
+    const result = parseManifestWorkflowSignals({
+      files: [
+        {
+          path: "go.mod",
+          text: "module example.com/fixture\n",
+        },
+        {
+          path: "pyproject.toml",
+          text: '[project]\nname = "fixture"\n',
+        },
+      ],
+    });
+
+    expect(result.packageManifests).toEqual([]);
+    expect(result.dependencySignals).toEqual([]);
+    expect(result.scriptSignals).toEqual([]);
+    expect(result.unsupportedManifests).toEqual([
+      expect.objectContaining({
+        path: "go.mod",
+        ecosystem: "go",
+        detail: "Go module manifests are detected but not parsed yet.",
+      }),
+      expect.objectContaining({
+        path: "pyproject.toml",
+        ecosystem: "python",
+        detail: "Python project manifests are detected but not parsed yet.",
+      }),
+    ]);
+    expect(result.omissions).toEqual([]);
+  });
+
+  it("omits invalid supported manifests with provenance instead of throwing", () => {
+    const result = parseManifestWorkflowSignals({
+      files: [
+        {
+          path: "package.json",
+          text: "{ invalid json",
+        },
+      ],
+    });
+
+    expect(result.packageManifests).toEqual([]);
+    expect(result.omissions).toEqual([
+      {
+        path: "package.json",
+        reason: "parse-error",
+        detail: "Package manifest is not valid JSON.",
+        evidenceReferences: [
+          {
+            id: "manifest-workflow:package-json:package.json",
+            kind: "file",
+            label: "Package manifest",
+            path: "package.json",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/domain/evidence/manifest-workflow-signals.ts
+++ b/src/domain/evidence/manifest-workflow-signals.ts
@@ -1,0 +1,571 @@
+import path from "node:path";
+
+import { z } from "zod";
+
+import type { EvidenceReference } from "../shared/evidence-reference";
+
+export type ManifestWorkflowFileSnapshot = {
+  readonly path: string;
+  readonly text: string;
+};
+
+export type ManifestWorkflowSignalInput = {
+  readonly files: readonly ManifestWorkflowFileSnapshot[];
+};
+
+export type PackageManifestSignal = {
+  readonly kind: "package-json";
+  readonly path: string;
+  readonly name?: string;
+  readonly private?: boolean;
+  readonly packageManager?: string;
+  readonly main?: string;
+  readonly module?: string;
+  readonly types?: string;
+  readonly exports?: boolean;
+  readonly bin?: boolean;
+  readonly evidenceReferences: readonly EvidenceReference[];
+};
+
+export type DependencyRelationship =
+  | "production"
+  | "development"
+  | "peer"
+  | "optional";
+
+export type DependencySignal = {
+  readonly path: string;
+  readonly name: string;
+  readonly relationship: DependencyRelationship;
+  readonly versionRange: string;
+  readonly evidenceReferences: readonly EvidenceReference[];
+};
+
+export type ScriptPurpose =
+  | "build"
+  | "development"
+  | "lint"
+  | "release"
+  | "test"
+  | "other";
+
+export type PackageScriptSignal = {
+  readonly path: string;
+  readonly name: string;
+  readonly command: string;
+  readonly purpose: ScriptPurpose;
+  readonly evidenceReferences: readonly EvidenceReference[];
+};
+
+export type WorkflowPurpose = "ci" | "release" | "other";
+
+export type WorkflowSignal = {
+  readonly kind: "github-workflow";
+  readonly path: string;
+  readonly name: string;
+  readonly purpose: WorkflowPurpose;
+  readonly evidenceReferences: readonly EvidenceReference[];
+};
+
+export type UnsupportedManifestEcosystem =
+  | "dotnet"
+  | "go"
+  | "java"
+  | "php"
+  | "python"
+  | "ruby"
+  | "rust";
+
+export type UnsupportedManifestNote = {
+  readonly path: string;
+  readonly ecosystem: UnsupportedManifestEcosystem;
+  readonly detail: string;
+  readonly evidenceReferences: readonly EvidenceReference[];
+};
+
+export type ManifestWorkflowOmissionReason = "invalid-shape" | "parse-error";
+
+export type ManifestWorkflowOmission = {
+  readonly path: string;
+  readonly reason: ManifestWorkflowOmissionReason;
+  readonly detail: string;
+  readonly evidenceReferences: readonly EvidenceReference[];
+};
+
+export type ManifestWorkflowSignalResult = {
+  readonly packageManifests: readonly PackageManifestSignal[];
+  readonly dependencySignals: readonly DependencySignal[];
+  readonly scriptSignals: readonly PackageScriptSignal[];
+  readonly workflowSignals: readonly WorkflowSignal[];
+  readonly unsupportedManifests: readonly UnsupportedManifestNote[];
+  readonly omissions: readonly ManifestWorkflowOmission[];
+};
+
+type DependencyField = {
+  readonly key:
+    | "dependencies"
+    | "devDependencies"
+    | "optionalDependencies"
+    | "peerDependencies";
+  readonly relationship: DependencyRelationship;
+};
+
+type UnsupportedManifestDefinition = {
+  readonly ecosystem: UnsupportedManifestEcosystem;
+  readonly detail: string;
+};
+
+const packageJsonSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    private: z.boolean().optional(),
+    packageManager: z.string().min(1).optional(),
+    main: z.string().min(1).optional(),
+    module: z.string().min(1).optional(),
+    types: z.string().min(1).optional(),
+    exports: z
+      .union([z.string(), z.record(z.string(), z.unknown())])
+      .optional(),
+    bin: z.union([z.string(), z.record(z.string(), z.string())]).optional(),
+    scripts: z.record(z.string(), z.string()).optional(),
+    dependencies: z.record(z.string(), z.string()).optional(),
+    devDependencies: z.record(z.string(), z.string()).optional(),
+    optionalDependencies: z.record(z.string(), z.string()).optional(),
+    peerDependencies: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+
+type PackageJsonData = z.infer<typeof packageJsonSchema>;
+
+const dependencyFields: readonly DependencyField[] = [
+  { key: "dependencies", relationship: "production" },
+  { key: "devDependencies", relationship: "development" },
+  { key: "peerDependencies", relationship: "peer" },
+  { key: "optionalDependencies", relationship: "optional" },
+];
+
+const relationshipRank = new Map<DependencyRelationship, number>([
+  ["production", 0],
+  ["development", 1],
+  ["peer", 2],
+  ["optional", 3],
+]);
+
+const unsupportedManifestDefinitions = new Map<
+  string,
+  UnsupportedManifestDefinition
+>([
+  [
+    "Cargo.toml",
+    {
+      ecosystem: "rust",
+      detail: "Rust package manifests are detected but not parsed yet.",
+    },
+  ],
+  [
+    "Gemfile",
+    {
+      ecosystem: "ruby",
+      detail: "Ruby dependency manifests are detected but not parsed yet.",
+    },
+  ],
+  [
+    "go.mod",
+    {
+      ecosystem: "go",
+      detail: "Go module manifests are detected but not parsed yet.",
+    },
+  ],
+  [
+    "pom.xml",
+    {
+      ecosystem: "java",
+      detail: "Java Maven manifests are detected but not parsed yet.",
+    },
+  ],
+  [
+    "pyproject.toml",
+    {
+      ecosystem: "python",
+      detail: "Python project manifests are detected but not parsed yet.",
+    },
+  ],
+  [
+    "requirements.txt",
+    {
+      ecosystem: "python",
+      detail: "Python dependency manifests are detected but not parsed yet.",
+    },
+  ],
+  [
+    "composer.json",
+    {
+      ecosystem: "php",
+      detail: "PHP Composer manifests are detected but not parsed yet.",
+    },
+  ],
+]);
+
+export function parseManifestWorkflowSignals(
+  input: ManifestWorkflowSignalInput,
+): ManifestWorkflowSignalResult {
+  const files = [...input.files].sort(compareFilesByPath);
+  const packageManifests: PackageManifestSignal[] = [];
+  const dependencySignals: DependencySignal[] = [];
+  const scriptSignals: PackageScriptSignal[] = [];
+  const workflowSignals: WorkflowSignal[] = [];
+  const unsupportedManifests: UnsupportedManifestNote[] = [];
+  const omissions: ManifestWorkflowOmission[] = [];
+
+  for (const file of files) {
+    if (isPackageJsonPath(file.path)) {
+      const parseResult = parsePackageJson(file);
+
+      if (parseResult.kind === "parsed") {
+        packageManifests.push(
+          packageManifestSignal(file.path, parseResult.data),
+        );
+        dependencySignals.push(
+          ...dependencySignalsForPackageJson(file.path, parseResult.data),
+        );
+        scriptSignals.push(
+          ...scriptSignalsForPackageJson(file.path, parseResult.data),
+        );
+      } else {
+        omissions.push(parseResult.omission);
+      }
+
+      continue;
+    }
+
+    if (isGithubWorkflowPath(file.path)) {
+      workflowSignals.push(workflowSignal(file));
+      continue;
+    }
+
+    const unsupportedManifest = unsupportedManifestForFile(file);
+    if (unsupportedManifest !== undefined) {
+      unsupportedManifests.push(unsupportedManifest);
+    }
+  }
+
+  return {
+    packageManifests,
+    dependencySignals: dependencySignals.sort(compareDependencySignals),
+    scriptSignals: scriptSignals.sort(compareScriptSignals),
+    workflowSignals,
+    unsupportedManifests,
+    omissions,
+  };
+}
+
+type PackageJsonParseResult =
+  | {
+      readonly kind: "parsed";
+      readonly data: PackageJsonData;
+    }
+  | {
+      readonly kind: "omitted";
+      readonly omission: ManifestWorkflowOmission;
+    };
+
+function parsePackageJson(
+  file: ManifestWorkflowFileSnapshot,
+): PackageJsonParseResult {
+  let parsedJson: unknown;
+
+  try {
+    parsedJson = JSON.parse(file.text);
+  } catch {
+    return {
+      kind: "omitted",
+      omission: {
+        path: file.path,
+        reason: "parse-error",
+        detail: "Package manifest is not valid JSON.",
+        evidenceReferences: [packageJsonReference(file.path)],
+      },
+    };
+  }
+
+  const parsedPackageJson = packageJsonSchema.safeParse(parsedJson);
+  if (!parsedPackageJson.success) {
+    return {
+      kind: "omitted",
+      omission: {
+        path: file.path,
+        reason: "invalid-shape",
+        detail: "Package manifest fields have unsupported value shapes.",
+        evidenceReferences: [packageJsonReference(file.path)],
+      },
+    };
+  }
+
+  return {
+    kind: "parsed",
+    data: parsedPackageJson.data,
+  };
+}
+
+function packageManifestSignal(
+  filePath: string,
+  data: PackageJsonData,
+): PackageManifestSignal {
+  return {
+    kind: "package-json",
+    path: filePath,
+    ...(data.name !== undefined ? { name: data.name } : {}),
+    ...(data.private !== undefined ? { private: data.private } : {}),
+    ...(data.packageManager !== undefined
+      ? { packageManager: data.packageManager }
+      : {}),
+    ...(data.main !== undefined ? { main: data.main } : {}),
+    ...(data.module !== undefined ? { module: data.module } : {}),
+    ...(data.types !== undefined ? { types: data.types } : {}),
+    ...(data.exports !== undefined ? { exports: true } : {}),
+    ...(data.bin !== undefined ? { bin: true } : {}),
+    evidenceReferences: [packageJsonReference(filePath)],
+  };
+}
+
+function dependencySignalsForPackageJson(
+  filePath: string,
+  data: PackageJsonData,
+): readonly DependencySignal[] {
+  const signals: DependencySignal[] = [];
+
+  for (const field of dependencyFields) {
+    const dependencies = data[field.key];
+
+    if (dependencies === undefined) {
+      continue;
+    }
+
+    for (const [name, versionRange] of Object.entries(dependencies)) {
+      signals.push({
+        path: filePath,
+        name,
+        relationship: field.relationship,
+        versionRange,
+        evidenceReferences: [packageJsonReference(filePath)],
+      });
+    }
+  }
+
+  return signals;
+}
+
+function scriptSignalsForPackageJson(
+  filePath: string,
+  data: PackageJsonData,
+): readonly PackageScriptSignal[] {
+  return Object.entries(data.scripts ?? {}).map(([name, command]) => ({
+    path: filePath,
+    name,
+    command,
+    purpose: scriptPurpose(name, command),
+    evidenceReferences: [packageJsonReference(filePath)],
+  }));
+}
+
+function workflowSignal(file: ManifestWorkflowFileSnapshot): WorkflowSignal {
+  return {
+    kind: "github-workflow",
+    path: file.path,
+    name: workflowName(file.path),
+    purpose: workflowPurpose(file),
+    evidenceReferences: [githubWorkflowReference(file.path)],
+  };
+}
+
+function workflowPurpose(file: ManifestWorkflowFileSnapshot): WorkflowPurpose {
+  const pathText = file.path.toLowerCase();
+  const contentText = file.text.toLowerCase();
+  const searchableText = `${pathText}\n${contentText}`;
+
+  if (
+    searchableText.includes("release") ||
+    searchableText.includes("publish") ||
+    searchableText.includes("deploy")
+  ) {
+    return "release";
+  }
+
+  if (
+    searchableText.includes("ci") ||
+    searchableText.includes("test") ||
+    searchableText.includes("check") ||
+    searchableText.includes("pull_request") ||
+    searchableText.includes("push")
+  ) {
+    return "ci";
+  }
+
+  return "other";
+}
+
+function unsupportedManifestForFile(
+  file: ManifestWorkflowFileSnapshot,
+): UnsupportedManifestNote | undefined {
+  const basename = path.posix.basename(file.path);
+  const definition =
+    unsupportedManifestDefinitions.get(basename) ??
+    unsupportedManifestDefinitionFromExtension(file.path);
+
+  if (definition === undefined) {
+    return undefined;
+  }
+
+  return {
+    path: file.path,
+    ecosystem: definition.ecosystem,
+    detail: definition.detail,
+    evidenceReferences: [unsupportedManifestReference(file.path)],
+  };
+}
+
+function unsupportedManifestDefinitionFromExtension(
+  filePath: string,
+): UnsupportedManifestDefinition | undefined {
+  if (filePath.endsWith(".csproj")) {
+    return {
+      ecosystem: "dotnet",
+      detail: ".NET project manifests are detected but not parsed yet.",
+    };
+  }
+
+  if (filePath.endsWith(".gradle") || filePath.endsWith(".gradle.kts")) {
+    return {
+      ecosystem: "java",
+      detail: "Java Gradle manifests are detected but not parsed yet.",
+    };
+  }
+
+  return undefined;
+}
+
+function scriptPurpose(name: string, command: string): ScriptPurpose {
+  const lowercaseName = name.toLowerCase();
+  const lowercaseCommand = command.toLowerCase();
+
+  if (lowercaseName.includes("build") || lowercaseCommand.includes(" build")) {
+    return "build";
+  }
+
+  if (
+    lowercaseName.includes("test") ||
+    lowercaseCommand.includes("vitest") ||
+    lowercaseCommand.includes("jest") ||
+    lowercaseCommand.includes(" test")
+  ) {
+    return "test";
+  }
+
+  if (
+    lowercaseName.includes("lint") ||
+    lowercaseCommand.includes("eslint") ||
+    lowercaseCommand.includes("oxlint") ||
+    lowercaseCommand.includes(" lint")
+  ) {
+    return "lint";
+  }
+
+  if (
+    lowercaseName === "dev" ||
+    lowercaseName.startsWith("dev:") ||
+    lowercaseCommand.includes(" dev")
+  ) {
+    return "development";
+  }
+
+  if (
+    lowercaseName.includes("release") ||
+    lowercaseName.includes("publish") ||
+    lowercaseName.includes("deploy") ||
+    lowercaseCommand.includes("npm publish")
+  ) {
+    return "release";
+  }
+
+  return "other";
+}
+
+function packageJsonReference(filePath: string): EvidenceReference {
+  return {
+    id: `manifest-workflow:package-json:${filePath}`,
+    kind: "file",
+    label: "Package manifest",
+    path: filePath,
+  };
+}
+
+function githubWorkflowReference(filePath: string): EvidenceReference {
+  return {
+    id: `manifest-workflow:github-workflow:${filePath}`,
+    kind: "file",
+    label: "GitHub workflow",
+    path: filePath,
+  };
+}
+
+function unsupportedManifestReference(filePath: string): EvidenceReference {
+  return {
+    id: `manifest-workflow:unsupported-manifest:${filePath}`,
+    kind: "file",
+    label: "Unsupported manifest",
+    path: filePath,
+  };
+}
+
+function isPackageJsonPath(filePath: string): boolean {
+  return path.posix.basename(filePath) === "package.json";
+}
+
+function isGithubWorkflowPath(filePath: string): boolean {
+  return /^\.github\/workflows\/[^/]+\.ya?ml$/iu.test(normalizePath(filePath));
+}
+
+function workflowName(filePath: string): string {
+  const basename = path.posix.basename(filePath);
+  const extension = path.posix.extname(basename);
+
+  return basename.slice(0, basename.length - extension.length);
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replaceAll("\\", "/").replace(/^\.\//u, "");
+}
+
+function compareFilesByPath(
+  left: ManifestWorkflowFileSnapshot,
+  right: ManifestWorkflowFileSnapshot,
+): number {
+  return left.path.localeCompare(right.path);
+}
+
+function compareDependencySignals(
+  left: DependencySignal,
+  right: DependencySignal,
+): number {
+  return (
+    left.path.localeCompare(right.path) ||
+    dependencyRelationshipRank(left.relationship) -
+      dependencyRelationshipRank(right.relationship) ||
+    left.name.localeCompare(right.name)
+  );
+}
+
+function compareScriptSignals(
+  left: PackageScriptSignal,
+  right: PackageScriptSignal,
+): number {
+  return (
+    left.path.localeCompare(right.path) || left.name.localeCompare(right.name)
+  );
+}
+
+function dependencyRelationshipRank(
+  relationship: DependencyRelationship,
+): number {
+  return relationshipRank.get(relationship) ?? relationshipRank.size;
+}

--- a/src/domain/evidence/manifest-workflow-signals.ts
+++ b/src/domain/evidence/manifest-workflow-signals.ts
@@ -1,5 +1,3 @@
-import path from "node:path";
-
 import { z } from "zod";
 
 import type { EvidenceReference } from "../shared/evidence-reference";
@@ -407,7 +405,7 @@ function workflowPurpose(file: ManifestWorkflowFileSnapshot): WorkflowPurpose {
 function unsupportedManifestForFile(
   file: ManifestWorkflowFileSnapshot,
 ): UnsupportedManifestNote | undefined {
-  const basename = path.posix.basename(file.path);
+  const basename = basenameForPath(file.path);
   const definition =
     unsupportedManifestDefinitions.get(basename) ??
     unsupportedManifestDefinitionFromExtension(file.path);
@@ -518,7 +516,7 @@ function unsupportedManifestReference(filePath: string): EvidenceReference {
 }
 
 function isPackageJsonPath(filePath: string): boolean {
-  return path.posix.basename(filePath) === "package.json";
+  return basenameForPath(filePath) === "package.json";
 }
 
 function isGithubWorkflowPath(filePath: string): boolean {
@@ -526,14 +524,28 @@ function isGithubWorkflowPath(filePath: string): boolean {
 }
 
 function workflowName(filePath: string): string {
-  const basename = path.posix.basename(filePath);
-  const extension = path.posix.extname(basename);
+  const basename = basenameForPath(filePath);
+  const extension = extensionForPath(basename);
 
   return basename.slice(0, basename.length - extension.length);
 }
 
 function normalizePath(filePath: string): string {
   return filePath.replaceAll("\\", "/").replace(/^\.\//u, "");
+}
+
+function basenameForPath(filePath: string): string {
+  return normalizePath(filePath).split("/").at(-1) ?? filePath;
+}
+
+function extensionForPath(filePath: string): string {
+  const extensionStart = filePath.lastIndexOf(".");
+
+  if (extensionStart <= 0) {
+    return "";
+  }
+
+  return filePath.slice(extensionStart);
 }
 
 function compareFilesByPath(


### PR DESCRIPTION
## Summary
- Add a pure domain parser for package.json manifest metadata, dependency groups, and package scripts.
- Record GitHub workflow YAML files as CI/release/other workflow evidence.
- Return unsupported manifest notes and parse omissions with shared evidence references instead of throwing.

## Tests
- pnpm run ci

Issue: #23