### PR TITLE
feat(scoring): add reviewer evidence policy

### DIFF
--- a/src/domain/scoring/scoring-policy.test.ts
+++ b/src/domain/scoring/scoring-policy.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ReviewerAssessmentSchemaVersion,
+  type ReviewerAssessment,
+} from "../reviewer/reviewer-assessment";
+import { scoreRepositoryQuality } from "./scoring-policy";
+
+const packageManifestReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+} as const;
+
+const testFileReference = {
+  id: "evidence:test-file",
+  kind: "file",
+  label: "Unit test file",
+  path: "test/add.spec.ts",
+} as const;
+
+const highConfidence = {
+  level: "high",
+  score: 0.9,
+  rationale: "Multiple files support the assessment.",
+} as const;
+
+const lowConfidence = {
+  level: "low",
+  score: 0.25,
+  rationale: "The repository snapshot omits important evidence.",
+} as const;
+
+const baseReviewerAssessment: ReviewerAssessment = {
+  schemaVersion: ReviewerAssessmentSchemaVersion,
+  reviewer: {
+    kind: "fake",
+    name: "Fake reviewer",
+    reviewedAt: "2026-04-25T20:00:00-07:00",
+  },
+  assessedArchetype: {
+    value: "library",
+    confidence: highConfidence,
+    evidenceReferences: [packageManifestReference],
+    rationale: "The package manifest exposes a reusable library entrypoint.",
+  },
+  dimensions: [
+    {
+      dimension: "maintainability",
+      summary: "The modules are small, but naming around boundaries is uneven.",
+      confidence: highConfidence,
+      evidenceReferences: [packageManifestReference],
+      strengths: ["Small modules are easy to scan."],
+      risks: ["Boundary naming is inconsistent."],
+      missingEvidence: [],
+    },
+    {
+      dimension: "verifiability",
+      summary: "Focused tests cover exported behavior.",
+      confidence: highConfidence,
+      evidenceReferences: [testFileReference],
+      strengths: ["Unit tests exercise the public add function."],
+      risks: [],
+      missingEvidence: [],
+    },
+  ],
+  caveats: [],
+  followUpQuestions: [
+    {
+      id: "question:test-depth",
+      question: "What behavior remains untested?",
+      targetDimension: "verifiability",
+      rationale: "The initial fixture has a narrow test suite.",
+    },
+  ],
+};
+
+describe("scoreRepositoryQuality", () => {
+  it("combines fake evidence and fake reviewer assessment into report-card input", () => {
+    const reportInput = scoreRepositoryQuality({
+      repository: {
+        provider: "local-fixture",
+        name: "minimal-node-library",
+        revision: "fixture",
+      },
+      evidenceReferences: [packageManifestReference, testFileReference],
+      reviewerAssessment: baseReviewerAssessment,
+    });
+
+    expect(reportInput.assessedArchetype).toBe("library");
+    expect(reportInput.reviewerMetadata.kind).toBe("fake");
+    expect(reportInput.evidenceReferences).toEqual([
+      packageManifestReference,
+      testFileReference,
+    ]);
+    expect(reportInput.dimensionAssessments).toHaveLength(2);
+    expect(reportInput.recommendedNextQuestions).toEqual([
+      baseReviewerAssessment.followUpQuestions[0],
+    ]);
+  });
+
+  it("documents maintainability risk without treating the finding as evidence-free", () => {
+    const reportInput = scoreRepositoryQuality({
+      repository: {
+        provider: "local-fixture",
+        name: "minimal-node-library",
+      },
+      evidenceReferences: [packageManifestReference],
+      reviewerAssessment: baseReviewerAssessment,
+    });
+
+    const maintainability = reportInput.dimensionAssessments.find(
+      (assessment) => assessment.dimension === "maintainability",
+    );
+
+    expect(maintainability?.rating).toBe("fair");
+    expect(maintainability?.score).toBe(65);
+    expect(maintainability?.findings).toContainEqual({
+      id: "finding:maintainability:risk:0",
+      dimension: "maintainability",
+      severity: "medium",
+      title: "Maintainability risk",
+      summary: "Boundary naming is inconsistent.",
+      confidence: highConfidence,
+      evidenceReferences: [packageManifestReference],
+    });
+  });
+
+  it("represents missing verifiability evidence as uncertainty rather than a score penalty", () => {
+    const reviewerAssessment: ReviewerAssessment = {
+      ...baseReviewerAssessment,
+      dimensions: [
+        {
+          dimension: "verifiability",
+          summary: "Tests exist, but integration behavior is not visible.",
+          confidence: highConfidence,
+          evidenceReferences: [testFileReference],
+          strengths: ["Unit tests exercise exported behavior."],
+          risks: [],
+          missingEvidence: ["Integration test results", "Coverage trend"],
+        },
+      ],
+    };
+
+    const reportInput = scoreRepositoryQuality({
+      repository: {
+        provider: "local-fixture",
+        name: "minimal-node-library",
+      },
+      evidenceReferences: [testFileReference],
+      reviewerAssessment,
+    });
+
+    expect(reportInput.dimensionAssessments[0]?.rating).toBe("excellent");
+    expect(reportInput.dimensionAssessments[0]?.score).toBe(90);
+    expect(reportInput.dimensionAssessments[0]?.confidence.level).toBe(
+      "medium",
+    );
+    expect(reportInput.caveats[0]).toMatchObject({
+      id: "caveat:verifiability:missing-evidence",
+      title: "Missing verifiability evidence",
+      affectedDimensions: ["verifiability"],
+      missingEvidence: ["Integration test results", "Coverage trend"],
+    });
+  });
+
+  it("turns low-confidence reviewer claims into caveats and lower report confidence", () => {
+    const reviewerAssessment: ReviewerAssessment = {
+      ...baseReviewerAssessment,
+      dimensions: [
+        {
+          dimension: "security",
+          summary: "Security posture cannot be established from the snapshot.",
+          confidence: lowConfidence,
+          evidenceReferences: [],
+          strengths: [],
+          risks: ["Dependency audit output is unavailable."],
+          missingEvidence: ["Dependency audit output", "Secret scan results"],
+        },
+      ],
+    };
+
+    const reportInput = scoreRepositoryQuality({
+      repository: {
+        provider: "local-fixture",
+        name: "minimal-node-library",
+      },
+      evidenceReferences: [],
+      reviewerAssessment,
+    });
+
+    expect(reportInput.dimensionAssessments[0]).toMatchObject({
+      dimension: "security",
+      rating: "not-assessed",
+      confidence: lowConfidence,
+      caveatIds: [
+        "caveat:security:low-confidence",
+        "caveat:security:missing-evidence",
+      ],
+    });
+    expect(reportInput.dimensionAssessments[0]?.score).toBeUndefined();
+    expect(reportInput.caveats.map((caveat) => caveat.id)).toEqual([
+      "caveat:security:low-confidence",
+      "caveat:security:missing-evidence",
+    ]);
+  });
+});

--- a/src/domain/scoring/scoring-policy.ts
+++ b/src/domain/scoring/scoring-policy.ts
@@ -1,0 +1,277 @@
+import type {
+  DimensionAssessment,
+  FindingSeverity,
+  RecommendedQuestion,
+  ReportCardInput,
+  ReportCaveat,
+  ReportDimensionKey,
+  ReportRating,
+  RepositoryIdentity,
+} from "../report/report-card";
+import type {
+  ReviewerAssessment,
+  ReviewerDimensionAssessment,
+} from "../reviewer/reviewer-assessment";
+import type { Confidence } from "../shared/confidence";
+import type { EvidenceReference } from "../shared/evidence-reference";
+
+export type ScoreRepositoryQualityInput = {
+  readonly repository: RepositoryIdentity;
+  readonly evidenceReferences: readonly EvidenceReference[];
+  readonly reviewerAssessment: ReviewerAssessment;
+};
+
+export function scoreRepositoryQuality(
+  input: ScoreRepositoryQualityInput,
+): ReportCardInput {
+  const dimensionAssessments = input.reviewerAssessment.dimensions.map(
+    scoreDimensionAssessment,
+  );
+
+  return {
+    repository: input.repository,
+    assessedArchetype: input.reviewerAssessment.assessedArchetype.value,
+    reviewerMetadata: input.reviewerAssessment.reviewer,
+    evidenceReferences: [...input.evidenceReferences],
+    dimensionAssessments,
+    caveats: [
+      ...input.reviewerAssessment.caveats.map(toReportCaveat),
+      ...dimensionAssessments.flatMap((assessment) =>
+        caveatsForDimension(
+          assessment.dimension,
+          input.reviewerAssessment.dimensions.find(
+            (dimension) => dimension.dimension === assessment.dimension,
+          ),
+        ),
+      ),
+    ],
+    recommendedNextQuestions: input.reviewerAssessment.followUpQuestions.map(
+      toRecommendedQuestion,
+    ),
+  };
+}
+
+function scoreDimensionAssessment(
+  reviewerDimension: ReviewerDimensionAssessment,
+): DimensionAssessment {
+  const caveatIds = caveatIdsForDimension(reviewerDimension);
+  const confidence = confidenceForDimension(reviewerDimension);
+  const evidenceReferences = [
+    ...evidenceReferencesForDimension(reviewerDimension),
+  ];
+  const score = scoreForDimension(reviewerDimension);
+  const baseAssessment = {
+    dimension: reviewerDimension.dimension,
+    title: titleForDimension(reviewerDimension.dimension),
+    summary: reviewerDimension.summary,
+    rating: ratingForScore(score, reviewerDimension.confidence),
+    confidence,
+    evidenceReferences,
+    findings: findingsForDimension(reviewerDimension, evidenceReferences),
+    caveatIds,
+  };
+
+  if (score === undefined) {
+    return baseAssessment;
+  }
+
+  return {
+    ...baseAssessment,
+    score,
+  };
+}
+
+function scoreForDimension(
+  reviewerDimension: ReviewerDimensionAssessment,
+): number | undefined {
+  if (reviewerDimension.confidence.level === "low") {
+    return undefined;
+  }
+
+  return clampScore(
+    reviewerDimension.confidence.score * 100 -
+      reviewerDimension.risks.length * 25,
+  );
+}
+
+function ratingForScore(
+  score: number | undefined,
+  confidence: Confidence,
+): ReportRating {
+  if (score === undefined || confidence.level === "low") {
+    return "not-assessed";
+  }
+
+  if (score >= 90) {
+    return "excellent";
+  }
+
+  if (score >= 80) {
+    return "good";
+  }
+
+  if (score >= 60) {
+    return "fair";
+  }
+
+  if (score >= 40) {
+    return "weak";
+  }
+
+  return "poor";
+}
+
+function confidenceForDimension(
+  reviewerDimension: ReviewerDimensionAssessment,
+): Confidence {
+  if (
+    reviewerDimension.confidence.level === "high" &&
+    reviewerDimension.missingEvidence.length > 0
+  ) {
+    return {
+      level: "medium",
+      score: Math.max(0, reviewerDimension.confidence.score - 0.2),
+      rationale: `${reviewerDimension.confidence.rationale} Missing evidence limits confidence.`,
+    };
+  }
+
+  return reviewerDimension.confidence;
+}
+
+function findingsForDimension(
+  reviewerDimension: ReviewerDimensionAssessment,
+  evidenceReferences: readonly EvidenceReference[],
+) {
+  return [
+    ...reviewerDimension.strengths.map((strength, index) => ({
+      id: `finding:${reviewerDimension.dimension}:strength:${index}`,
+      dimension: reviewerDimension.dimension,
+      severity: "info" as const,
+      title: `${titleForDimension(reviewerDimension.dimension)} strength`,
+      summary: strength,
+      confidence: reviewerDimension.confidence,
+      evidenceReferences: [...evidenceReferences],
+    })),
+    ...reviewerDimension.risks.map((risk, index) => ({
+      id: `finding:${reviewerDimension.dimension}:risk:${index}`,
+      dimension: reviewerDimension.dimension,
+      severity: severityForRisk(reviewerDimension.confidence),
+      title: `${titleForDimension(reviewerDimension.dimension)} risk`,
+      summary: risk,
+      confidence: reviewerDimension.confidence,
+      evidenceReferences: [...evidenceReferences],
+    })),
+  ];
+}
+
+function caveatIdsForDimension(
+  reviewerDimension: ReviewerDimensionAssessment,
+): string[] {
+  return [
+    reviewerDimension.confidence.level === "low"
+      ? `caveat:${reviewerDimension.dimension}:low-confidence`
+      : undefined,
+    reviewerDimension.missingEvidence.length > 0
+      ? `caveat:${reviewerDimension.dimension}:missing-evidence`
+      : undefined,
+  ].filter(isDefined);
+}
+
+function caveatsForDimension(
+  dimension: ReportDimensionKey,
+  reviewerDimension: ReviewerDimensionAssessment | undefined,
+): ReportCaveat[] {
+  if (reviewerDimension === undefined) {
+    return [];
+  }
+
+  return [
+    reviewerDimension.confidence.level === "low"
+      ? {
+          id: `caveat:${dimension}:low-confidence`,
+          title: `Low-confidence ${dimension} assessment`,
+          summary:
+            "Reviewer confidence is low, so this dimension should be treated as a prompt for investigation rather than a quality judgment.",
+          affectedDimensions: [dimension],
+          missingEvidence: [],
+        }
+      : undefined,
+    reviewerDimension.missingEvidence.length > 0
+      ? {
+          id: `caveat:${dimension}:missing-evidence`,
+          title: `Missing ${dimension} evidence`,
+          summary:
+            "Missing evidence is represented as uncertainty, not as an automatic penalty.",
+          affectedDimensions: [dimension],
+          missingEvidence: [...reviewerDimension.missingEvidence],
+        }
+      : undefined,
+  ].filter(isDefined);
+}
+
+function toReportCaveat(
+  reviewerCaveat: ReviewerAssessment["caveats"][number],
+): ReportCaveat {
+  return {
+    id: reviewerCaveat.id,
+    title: reviewerCaveat.summary,
+    summary: reviewerCaveat.summary,
+    affectedDimensions: [...reviewerCaveat.affectedDimensions],
+    missingEvidence: [...reviewerCaveat.missingEvidence],
+  };
+}
+
+function toRecommendedQuestion(
+  question: ReviewerAssessment["followUpQuestions"][number],
+): RecommendedQuestion {
+  return {
+    id: question.id,
+    question: question.question,
+    targetDimension: question.targetDimension,
+    rationale: question.rationale,
+  };
+}
+
+function evidenceReferencesForDimension(
+  reviewerDimension: ReviewerDimensionAssessment,
+): readonly EvidenceReference[] {
+  if (reviewerDimension.evidenceReferences.length > 0) {
+    return reviewerDimension.evidenceReferences;
+  }
+
+  return [
+    {
+      id: `reviewer:${reviewerDimension.dimension}`,
+      kind: "reviewer",
+      label: `${titleForDimension(reviewerDimension.dimension)} reviewer assessment`,
+      notes: "Reviewer did not cite deterministic evidence for this dimension.",
+    },
+  ];
+}
+
+function severityForRisk(confidence: Confidence): FindingSeverity {
+  if (confidence.level === "high") {
+    return "medium";
+  }
+
+  if (confidence.level === "medium") {
+    return "low";
+  }
+
+  return "info";
+}
+
+function titleForDimension(dimension: ReportDimensionKey): string {
+  return dimension
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}


### PR DESCRIPTION
Closes #19

## Scope
- Add the first domain scoring policy for turning structured reviewer assessment plus evidence references into report-card input.
- Cover maintainability and verifiability examples with colocated red/green tests.
- Represent missing evidence as uncertainty/caveats instead of a direct score penalty.
- Keep low-confidence reviewer claims as not-assessed rather than hard quality judgments.

## Non-goals
- No UI, API, persistence, GitHub, or LLM provider wiring.
- No final calibration of all scoring dimensions.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
