### PR TITLE
docs(e2e): document OpenRouter test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ See [docs/fixtures.md](docs/fixtures.md) for repository fixture rules.
 See [docs/architecture.md](docs/architecture.md#test-placement) for test placement rules.
 See [docs/deployment.md](docs/deployment.md) for Vercel deployment and preview E2E setup.
 See [docs/how-tos/vercel-preview-e2e.md](docs/how-tos/vercel-preview-e2e.md) for protected Vercel preview E2E setup.
+See [docs/how-tos/openrouter-e2e.md](docs/how-tos/openrouter-e2e.md) for OpenRouter-backed E2E secret setup.
 See [docs/architecture.md](docs/architecture.md#frontend-architecture) for frontend thin-screen and component rules.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,8 @@ x-vercel-set-bypass-cookie: true
 
 For protected preview deployments, this secret is required for Preview E2E to exercise the application instead of Vercel's deployment protection page.
 
+Future live-provider E2E that uses OpenRouter should read `OPENROUTER_API_KEY` from GitHub Actions secrets and `E2E_TEST_REPOSITORY_URL` from GitHub Actions variables. See [How To Configure OpenRouter For E2E Tests](how-tos/openrouter-e2e.md).
+
 References:
 - [Vercel: Methods to bypass Deployment Protection](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection)
 - [Vercel: Protection Bypass for Automation](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation)

--- a/docs/how-tos/openrouter-e2e.md
+++ b/docs/how-tos/openrouter-e2e.md
@@ -1,0 +1,73 @@
+# How To Configure OpenRouter For E2E Tests
+
+This guide documents the GitHub Actions configuration for future E2E tests that exercise OpenRouter-backed reviewer or follow-up behavior.
+
+The foundational E2E test should stay deterministic and fake-backed. Live-provider E2E should be added as a separate, explicitly scoped workflow or job so ordinary product checks do not depend on paid/network model calls unless that dependency is intentional.
+
+## GitHub Actions Secret
+
+Store the OpenRouter key as a GitHub Actions repository secret named `OPENROUTER_API_KEY`.
+
+Do not put the key in:
+
+- committed files
+- issue comments
+- PR descriptions
+- commit messages
+- screenshots
+- copied workflow logs
+
+Verify only that the secret exists:
+
+```bash
+gh secret list --repo lightstrikelabs/repo-analyzer-green --app actions
+```
+
+Do not verify by printing the secret value.
+
+## Test Repository
+
+Use a GitHub Actions repository variable named `E2E_TEST_REPOSITORY_URL` for the public repository used by live-provider E2E.
+
+Current value:
+
+```text
+https://github.com/lightstrikelabs/repo-analyzer-green
+```
+
+Verify the variable with:
+
+```bash
+gh variable list --repo lightstrikelabs/repo-analyzer-green
+```
+
+This repository is public and safe to document. It should still be treated as a network dependency for any live GitHub acquisition or live-provider E2E job.
+
+## Expected Workflow Use
+
+A live-provider E2E job should read:
+
+```yaml
+OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+E2E_TEST_REPOSITORY_URL: ${{ vars.E2E_TEST_REPOSITORY_URL }}
+```
+
+The test should pass the key only through environment variables or request-scoped server-side configuration. It should not expose the key to browser localStorage, rendered HTML, screenshots, traces, or client-side logs.
+
+## Safety Rules
+
+- Keep the deterministic foundational E2E fake-backed.
+- Put live OpenRouter E2E in its own clearly named job.
+- Avoid running live-provider E2E on untrusted fork pull requests unless secrets are unavailable or the job is explicitly guarded.
+- Use a low-cost/free model default where possible.
+- Fail with a clear missing-secret message if a live-provider job is manually requested without `OPENROUTER_API_KEY`.
+- Redact provider errors before showing them in user-facing UI or persisted artifacts.
+
+## Rotation
+
+If the key is rotated:
+
+1. Update the GitHub Actions repository secret.
+2. Re-run the live-provider E2E job.
+3. Confirm logs do not contain the key.
+4. Revoke the previous key in OpenRouter.


### PR DESCRIPTION
Closes #78

## Scope
- Add `docs/how-tos/openrouter-e2e.md` for future OpenRouter-backed E2E configuration.
- Link the guide from README and deployment docs.
- Document `OPENROUTER_API_KEY` as a GitHub Actions secret and `E2E_TEST_REPOSITORY_URL` as a GitHub Actions variable.
- Record that the current test repository URL is `https://github.com/lightstrikelabs/repo-analyzer-green`.

## Non-goals
- No live OpenRouter E2E implementation in this PR.
- No secret values in docs, issues, PR text, or committed files.
- No change to the deterministic foundational E2E path.

## Verification
- `pnpm run ci` passes locally. Local machine reports a Node engine warning because it is running v25.9.0 while the repo pins Node 24.x.
- Verified `OPENROUTER_API_KEY` exists by secret metadata only.
- Verified `E2E_TEST_REPOSITORY_URL` is configured as a non-secret Actions variable.
