### PR TITLE
feat(repository): add GitHub archive source

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.0.0",
+    "tar": "^7.5.13",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-hook-form:
         specifier: ^7.0.0
         version: 7.74.0(react@19.2.5)
+      tar:
+        specifier: ^7.5.13
+        version: 7.5.13
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -233,6 +236,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -708,6 +715,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -892,6 +903,14 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1029,6 +1048,10 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1143,6 +1166,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -1268,6 +1295,10 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1587,6 +1618,8 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chownr@3.0.0: {}
+
   client-only@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -1717,6 +1750,12 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   nanoid@3.3.11: {}
 
@@ -1883,6 +1922,14 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -1943,5 +1990,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yallist@5.0.0: {}
 
   zod@4.3.6: {}

--- a/src/domain/repository/repository-source.ts
+++ b/src/domain/repository/repository-source.ts
@@ -1,4 +1,4 @@
-export type RepositoryProvider = "local-fixture";
+export type RepositoryProvider = "github" | "local-fixture";
 
 export type RepositoryReference = {
   readonly provider: RepositoryProvider;
@@ -10,7 +10,7 @@ export type RepositoryReference = {
 
 export type RepositoryPath = string;
 
-export type RepositorySourceKind = "local-fixture";
+export type RepositorySourceKind = "github-archive" | "local-fixture";
 
 export type RepositoryFileProvenance = {
   readonly repository: RepositoryReference;
@@ -42,7 +42,12 @@ export interface RepositorySource {
 export class RepositorySourceError extends Error {
   constructor(
     message: string,
-    readonly code: "repository-not-found" | "file-not-found",
+    readonly code:
+      | "download-failed"
+      | "extraction-failed"
+      | "file-not-found"
+      | "invalid-repository-reference"
+      | "repository-not-found",
     readonly repository: RepositoryReference,
   ) {
     super(message);

--- a/src/infrastructure/github/github-archive-repository-source.ts
+++ b/src/infrastructure/github/github-archive-repository-source.ts
@@ -1,0 +1,338 @@
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { extract } from "tar";
+
+import type {
+  RepositoryFileContent,
+  RepositoryFileEntry,
+  RepositoryPath,
+  RepositoryReference,
+  RepositorySource,
+} from "../../domain/repository/repository-source";
+import { RepositorySourceError } from "../../domain/repository/repository-source";
+
+export type GitHubArchiveFetcher = (
+  url: string,
+  init: RequestInit,
+) => Promise<Response>;
+
+export type GitHubArchiveExtractor = (input: {
+  readonly archivePath: string;
+  readonly destinationPath: string;
+}) => Promise<void>;
+
+export type GitHubArchiveRepositorySourceOptions = {
+  readonly fetcher?: GitHubArchiveFetcher;
+  readonly extractor?: GitHubArchiveExtractor;
+  readonly temporaryRoot?: string;
+};
+
+type CachedRepository = {
+  readonly repository: RepositoryReference;
+  readonly rootPath: string;
+};
+
+type DiscoveredArchiveFile = {
+  readonly path: RepositoryPath;
+  readonly sizeBytes: number;
+};
+
+export class GitHubArchiveRepositorySource implements RepositorySource {
+  private readonly fetcher: GitHubArchiveFetcher;
+  private readonly extractor: GitHubArchiveExtractor;
+  private readonly temporaryRoot: string | undefined;
+  private readonly cachedRepositories = new Map<string, CachedRepository>();
+  private ownedTemporaryRoot: string | undefined;
+
+  constructor(options: GitHubArchiveRepositorySourceOptions = {}) {
+    this.fetcher = options.fetcher ?? fetch;
+    this.extractor = options.extractor ?? extractArchive;
+    this.temporaryRoot = options.temporaryRoot;
+  }
+
+  async listFiles(
+    repository: RepositoryReference,
+  ): Promise<readonly RepositoryFileEntry[]> {
+    const cachedRepository = await this.ensureRepository(repository);
+    const files = await listArchiveFiles(cachedRepository.rootPath);
+
+    return files.map((file) => ({
+      path: file.path,
+      sizeBytes: file.sizeBytes,
+      provenance: {
+        repository,
+        sourceKind: "github-archive",
+        sourceId: sourceIdForRepository(repository),
+        path: file.path,
+      },
+    }));
+  }
+
+  async readFile(
+    repository: RepositoryReference,
+    filePath: RepositoryPath,
+  ): Promise<RepositoryFileContent> {
+    const cachedRepository = await this.ensureRepository(repository);
+    const absolutePath = resolveArchiveFilePath(
+      cachedRepository.rootPath,
+      filePath,
+      repository,
+    );
+
+    try {
+      const fileStat = await stat(absolutePath);
+      if (!fileStat.isFile()) {
+        throw notFound(repository, filePath);
+      }
+      const text = await readFile(absolutePath, "utf8");
+
+      return {
+        path: filePath,
+        text,
+        sizeBytes: fileStat.size,
+        provenance: {
+          repository,
+          sourceKind: "github-archive",
+          sourceId: sourceIdForRepository(repository),
+          path: filePath,
+        },
+      };
+    } catch (error) {
+      if (error instanceof RepositorySourceError) {
+        throw error;
+      }
+      throw notFound(repository, filePath);
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.cachedRepositories.clear();
+
+    if (this.ownedTemporaryRoot !== undefined) {
+      await rm(this.ownedTemporaryRoot, { recursive: true, force: true });
+      this.ownedTemporaryRoot = undefined;
+    }
+  }
+
+  private async ensureRepository(
+    repository: RepositoryReference,
+  ): Promise<CachedRepository> {
+    validateGitHubRepository(repository);
+
+    const cacheKey = sourceIdForRepository(repository);
+    const cachedRepository = this.cachedRepositories.get(cacheKey);
+    if (cachedRepository !== undefined) {
+      return cachedRepository;
+    }
+
+    const rootPath = await this.prepareRepository(repository);
+    const nextCachedRepository = { repository, rootPath };
+    this.cachedRepositories.set(cacheKey, nextCachedRepository);
+    return nextCachedRepository;
+  }
+
+  private async prepareRepository(
+    repository: RepositoryReference,
+  ): Promise<string> {
+    const temporaryRoot = await this.requireTemporaryRoot();
+    const repositoryRoot = await mkdtemp(
+      path.join(temporaryRoot, `${sourceIdForRepository(repository)}-`),
+    );
+    const archivePath = path.join(repositoryRoot, "archive.tgz");
+    const extractRoot = path.join(repositoryRoot, "repo");
+    const archiveUrl = archiveUrlForRepository(repository);
+    const response = await this.fetcher(archiveUrl, {
+      headers: {
+        Accept: "application/x-gzip",
+        "User-Agent": "repo-analyzer-green",
+      },
+    });
+
+    if (!response.ok) {
+      throw new RepositorySourceError(
+        `Unable to download GitHub repository archive (${response.status}).`,
+        "download-failed",
+        repository,
+      );
+    }
+
+    await writeFile(archivePath, Buffer.from(await response.arrayBuffer()));
+    await mkdir(extractRoot, { recursive: true });
+
+    try {
+      await this.extractor({
+        archivePath,
+        destinationPath: extractRoot,
+      });
+    } catch {
+      throw new RepositorySourceError(
+        "Unable to extract GitHub repository archive.",
+        "extraction-failed",
+        repository,
+      );
+    } finally {
+      await rm(archivePath, { force: true });
+    }
+
+    return extractRoot;
+  }
+
+  private async requireTemporaryRoot(): Promise<string> {
+    if (this.temporaryRoot !== undefined) {
+      return this.temporaryRoot;
+    }
+
+    if (this.ownedTemporaryRoot === undefined) {
+      this.ownedTemporaryRoot = await mkdtemp(
+        path.join(tmpdir(), "repo-analyzer-green-github-"),
+      );
+    }
+
+    return this.ownedTemporaryRoot;
+  }
+}
+
+export function archiveUrlForRepository(
+  repository: RepositoryReference,
+): string {
+  validateGitHubRepository(repository);
+
+  return `https://codeload.github.com/${repository.owner}/${repository.name}/tar.gz/${repository.revision ?? "HEAD"}`;
+}
+
+function validateGitHubRepository(repository: RepositoryReference): void {
+  if (
+    repository.provider !== "github" ||
+    repository.owner === undefined ||
+    repository.name.trim() === ""
+  ) {
+    throw new RepositorySourceError(
+      "Repository reference must identify a GitHub owner and repository name.",
+      "invalid-repository-reference",
+      repository,
+    );
+  }
+}
+
+async function extractArchive(input: {
+  readonly archivePath: string;
+  readonly destinationPath: string;
+}): Promise<void> {
+  await extract({
+    file: input.archivePath,
+    cwd: input.destinationPath,
+    strip: 1,
+  });
+}
+
+async function listArchiveFiles(
+  rootPath: string,
+): Promise<readonly DiscoveredArchiveFile[]> {
+  const files: DiscoveredArchiveFile[] = [];
+  await collectFiles(rootPath, rootPath, files);
+  return files.sort(compareDiscoveredArchiveFiles);
+}
+
+async function collectFiles(
+  rootPath: string,
+  currentPath: string,
+  files: DiscoveredArchiveFile[],
+): Promise<void> {
+  const entries = await readdir(currentPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(currentPath, entry.name);
+    if (entry.isDirectory()) {
+      await collectFiles(rootPath, entryPath, files);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      const fileStat = await stat(entryPath);
+      files.push({
+        path: toRepositoryPath(rootPath, entryPath),
+        sizeBytes: fileStat.size,
+      });
+    }
+  }
+}
+
+function resolveArchiveFilePath(
+  rootPath: string,
+  filePath: RepositoryPath,
+  repository: RepositoryReference,
+): string {
+  if (!isNormalizedRepositoryPath(filePath)) {
+    throw notFound(repository, filePath);
+  }
+
+  const absolutePath = path.resolve(rootPath, filePath);
+  const relativePath = path.relative(rootPath, absolutePath);
+
+  if (
+    relativePath === "" ||
+    relativePath.startsWith("..") ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw notFound(repository, filePath);
+  }
+
+  return absolutePath;
+}
+
+function isNormalizedRepositoryPath(filePath: RepositoryPath): boolean {
+  return (
+    filePath !== "" &&
+    !filePath.includes("\\") &&
+    !path.posix.isAbsolute(filePath) &&
+    path.posix.normalize(filePath) === filePath &&
+    filePath !== "." &&
+    !filePath.startsWith("../")
+  );
+}
+
+function toRepositoryPath(rootPath: string, filePath: string): RepositoryPath {
+  return path.relative(rootPath, filePath).split(path.sep).join(path.posix.sep);
+}
+
+function sourceIdForRepository(repository: RepositoryReference): string {
+  return `${repository.owner ?? "unknown"}-${repository.name}-${repository.revision ?? "HEAD"}`
+    .replace(/[^a-z0-9._-]/giu, "-")
+    .slice(0, 160);
+}
+
+function notFound(
+  repository: RepositoryReference,
+  filePath: RepositoryPath,
+): RepositorySourceError {
+  return new RepositorySourceError(
+    `Repository file '${filePath}' was not found in GitHub archive '${repository.owner}/${repository.name}'.`,
+    "file-not-found",
+    repository,
+  );
+}
+
+function compareDiscoveredArchiveFiles(
+  left: DiscoveredArchiveFile,
+  right: DiscoveredArchiveFile,
+): number {
+  if (left.path < right.path) {
+    return -1;
+  }
+
+  if (left.path > right.path) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/src/infrastructure/github/github-repository-url.ts
+++ b/src/infrastructure/github/github-repository-url.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import type { RepositoryReference } from "../../domain/repository/repository-source";
+
+export const GitHubRepositoryUrlSchema = z.url().transform((value, context) => {
+  const parsedUrl = new URL(value);
+
+  if (
+    parsedUrl.hostname !== "github.com" &&
+    parsedUrl.hostname !== "www.github.com"
+  ) {
+    context.addIssue({
+      code: "custom",
+      message: "Repository URL must use github.com.",
+    });
+    return z.NEVER;
+  }
+
+  const [owner, rawName] = parsedUrl.pathname.split("/").filter(Boolean);
+  if (owner === undefined || rawName === undefined) {
+    context.addIssue({
+      code: "custom",
+      message: "GitHub repository URL must include owner and repository name.",
+    });
+    return z.NEVER;
+  }
+
+  return {
+    provider: "github",
+    owner,
+    name: rawName.replace(/\.git$/u, ""),
+    url: `https://github.com/${owner}/${rawName.replace(/\.git$/u, "")}`,
+  } satisfies RepositoryReference;
+});
+
+export function parseGitHubRepositoryUrl(input: string): RepositoryReference {
+  return GitHubRepositoryUrlSchema.parse(input.trim());
+}

--- a/test/infrastructure/github/github-archive-repository-source.test.ts
+++ b/test/infrastructure/github/github-archive-repository-source.test.ts
@@ -1,0 +1,160 @@
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  RepositorySourceError,
+  type RepositoryReference,
+} from "../../../src/domain/repository/repository-source";
+import {
+  archiveUrlForRepository,
+  GitHubArchiveRepositorySource,
+  type GitHubArchiveExtractor,
+  type GitHubArchiveFetcher,
+} from "../../../src/infrastructure/github/github-archive-repository-source";
+import { parseGitHubRepositoryUrl } from "../../../src/infrastructure/github/github-repository-url";
+
+const repository: RepositoryReference = {
+  provider: "github",
+  owner: "lightstrikelabs",
+  name: "repo-analyzer-green",
+  url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+  revision: "main",
+};
+
+describe("parseGitHubRepositoryUrl", () => {
+  it("parses GitHub repository URLs into repository references", () => {
+    expect(
+      parseGitHubRepositoryUrl(
+        "https://github.com/lightstrikelabs/repo-analyzer-green.git",
+      ),
+    ).toEqual({
+      provider: "github",
+      owner: "lightstrikelabs",
+      name: "repo-analyzer-green",
+      url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+    });
+  });
+
+  it("rejects non-GitHub repository URLs", () => {
+    expect(() =>
+      parseGitHubRepositoryUrl("https://example.com/lightstrikelabs/repo"),
+    ).toThrow();
+  });
+});
+
+describe("GitHubArchiveRepositorySource", () => {
+  it("downloads and exposes archive files through the repository source port", async () => {
+    const temporaryRoot = await mkdtemp(
+      path.join(tmpdir(), "repo-analyzer-green-github-test-"),
+    );
+    const requestedUrls: string[] = [];
+    const fetcher: GitHubArchiveFetcher = async (url) => {
+      requestedUrls.push(url);
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    };
+    const extractor: GitHubArchiveExtractor = async ({ destinationPath }) => {
+      await mkdir(path.join(destinationPath, "src"), { recursive: true });
+      await writeFile(path.join(destinationPath, "README.md"), "# Green\n");
+      await writeFile(
+        path.join(destinationPath, "src", "add.ts"),
+        "export const add = (left: number, right: number) => left + right;\n",
+      );
+    };
+    const source = new GitHubArchiveRepositorySource({
+      fetcher,
+      extractor,
+      temporaryRoot,
+    });
+
+    const files = await source.listFiles(repository);
+    const file = await source.readFile(repository, "src/add.ts");
+
+    expect(requestedUrls).toEqual([archiveUrlForRepository(repository)]);
+    expect(files.map((entry) => entry.path)).toEqual([
+      "README.md",
+      "src/add.ts",
+    ]);
+    expect(file.text).toContain("export const add");
+    expect(file.provenance).toMatchObject({
+      repository,
+      sourceKind: "github-archive",
+      path: "src/add.ts",
+    });
+  });
+
+  it("fails with typed context when GitHub archive download fails", async () => {
+    const source = new GitHubArchiveRepositorySource({
+      fetcher: async () => new Response("not found", { status: 404 }),
+      extractor: async () => undefined,
+      temporaryRoot: await mkdtemp(
+        path.join(tmpdir(), "repo-analyzer-green-github-test-"),
+      ),
+    });
+
+    await expect(source.listFiles(repository)).rejects.toMatchObject({
+      code: "download-failed",
+      repository,
+    });
+  });
+
+  it("fails with typed context when archive extraction fails", async () => {
+    const source = new GitHubArchiveRepositorySource({
+      fetcher: async () => new Response(new Uint8Array([1]), { status: 200 }),
+      extractor: async () => {
+        throw new Error("bad archive");
+      },
+      temporaryRoot: await mkdtemp(
+        path.join(tmpdir(), "repo-analyzer-green-github-test-"),
+      ),
+    });
+
+    await expect(source.listFiles(repository)).rejects.toMatchObject({
+      code: "extraction-failed",
+      repository,
+    });
+  });
+
+  it("does not allow reads outside the extracted repository root", async () => {
+    const source = new GitHubArchiveRepositorySource({
+      fetcher: async () => new Response(new Uint8Array([1]), { status: 200 }),
+      extractor: async ({ destinationPath }) => {
+        await writeFile(path.join(destinationPath, "README.md"), "# Green\n");
+      },
+      temporaryRoot: await mkdtemp(
+        path.join(tmpdir(), "repo-analyzer-green-github-test-"),
+      ),
+    });
+
+    await expect(
+      source.readFile(repository, "../README.md"),
+    ).rejects.toBeInstanceOf(RepositorySourceError);
+    await expect(
+      source.readFile(repository, "../README.md"),
+    ).rejects.toMatchObject({
+      code: "file-not-found",
+      repository,
+    });
+  });
+
+  it("cleans up owned temporary repository archives on dispose", async () => {
+    let extractedRoot = "";
+    const source = new GitHubArchiveRepositorySource({
+      fetcher: async () => new Response(new Uint8Array([1]), { status: 200 }),
+      extractor: async ({ destinationPath }) => {
+        extractedRoot = destinationPath;
+        await writeFile(path.join(destinationPath, "README.md"), "# Green\n");
+      },
+    });
+    const files = await source.listFiles(repository);
+
+    expect(files[0]?.path).toBe("README.md");
+    await expect(stat(extractedRoot)).resolves.toMatchObject({
+      isDirectory: expect.any(Function),
+    });
+    await source.dispose();
+    await expect(stat(extractedRoot)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add a GitHub archive repository source adapter outside the domain
- parse GitHub repository URLs into repository references
- download tar archives, extract them into temporary storage, and expose files through the repository source port
- add typed infrastructure tests for success, download failure, extraction failure, path traversal protection, and cleanup

## Validation
- `pnpm run ci`

Closes #70