### PR TITLE
feat(llm): add OpenRouter provider contract

### DIFF
--- a/docs/how-tos/openrouter-e2e.md
+++ b/docs/how-tos/openrouter-e2e.md
@@ -54,6 +54,17 @@ E2E_TEST_REPOSITORY_URL: ${{ vars.E2E_TEST_REPOSITORY_URL }}
 
 The test should pass the key only through environment variables or request-scoped server-side configuration. It should not expose the key to browser localStorage, rendered HTML, screenshots, traces, or client-side logs.
 
+## Runtime Contract
+
+OpenRouter configuration is parsed at the provider boundary in `src/infrastructure/llm/openrouter-config.ts`.
+
+- `OPENROUTER_API_KEY` is request-scoped configuration. This slice does not store it.
+- Empty or missing model input defaults to `openrouter/free`.
+- Empty API key input is normalized to an unavailable provider configuration.
+- Provider request metadata stays in infrastructure and currently supports `reviewer-assessment` and `follow-up-answer` usage contexts.
+
+The OpenRouter chat provider returns typed provider failures instead of throwing provider details into the domain. Missing keys, network failures, non-2xx responses, invalid response shapes, and empty or reasoning-only responses should become user-facing caveats that say OpenRouter output is unavailable. Do not include raw provider error bodies or secret values in user-facing UI, persisted reports, traces, or PR/issue text.
+
 ## Safety Rules
 
 - Keep the deterministic foundational E2E fake-backed.

--- a/src/infrastructure/llm/openrouter-chat-provider.ts
+++ b/src/infrastructure/llm/openrouter-chat-provider.ts
@@ -125,9 +125,20 @@ export class OpenRouterChatCompletionProvider {
       });
     }
 
-    const parsedResponse = OpenRouterChatProviderResponseSchema.safeParse(
-      await response.json(),
-    );
+    let responseBody: unknown;
+    try {
+      responseBody = await response.json();
+    } catch {
+      return providerFailure({
+        model: request.config.model,
+        code: "invalid-response",
+        userFacingCaveat:
+          "OpenRouter reviewer output is unavailable because the provider returned an unexpected response shape.",
+      });
+    }
+
+    const parsedResponse =
+      OpenRouterChatProviderResponseSchema.safeParse(responseBody);
 
     if (!parsedResponse.success) {
       return providerFailure({

--- a/src/infrastructure/llm/openrouter-chat-provider.ts
+++ b/src/infrastructure/llm/openrouter-chat-provider.ts
@@ -1,0 +1,192 @@
+import { z } from "zod";
+
+import {
+  OpenRouterRequestMetadataSchema,
+  type OpenRouterModelId,
+  type OpenRouterProviderConfig,
+  type OpenRouterRequestMetadata,
+} from "./openrouter-config";
+
+export type OpenRouterChatFetcher = (request: Request) => Promise<Response>;
+
+export type OpenRouterChatMessage = {
+  readonly role: "system" | "user" | "assistant";
+  readonly content: string;
+};
+
+export type OpenRouterChatCompletionRequest = {
+  readonly config: OpenRouterProviderConfig;
+  readonly metadata: OpenRouterRequestMetadata;
+  readonly messages: readonly OpenRouterChatMessage[];
+};
+
+export type OpenRouterChatCompletion = {
+  readonly kind: "completed";
+  readonly provider: "openrouter";
+  readonly model: OpenRouterModelId;
+  readonly content: string;
+  readonly rawResponseId?: string;
+};
+
+export type OpenRouterProviderFailureCode =
+  | "missing-api-key"
+  | "provider-error"
+  | "invalid-response"
+  | "empty-response"
+  | "network-error";
+
+export type OpenRouterProviderFailure = {
+  readonly kind: "provider-failure";
+  readonly provider: "openrouter";
+  readonly model: OpenRouterModelId;
+  readonly code: OpenRouterProviderFailureCode;
+  readonly status?: number;
+  readonly userFacingCaveat: string;
+};
+
+export type OpenRouterChatCompletionResult =
+  | OpenRouterChatCompletion
+  | OpenRouterProviderFailure;
+
+const OpenRouterChatProviderResponseSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+    choices: z
+      .array(
+        z
+          .object({
+            message: z
+              .object({
+                content: z.string().optional().nullable(),
+              })
+              .passthrough()
+              .optional(),
+          })
+          .passthrough(),
+      )
+      .default([]),
+  })
+  .passthrough();
+
+export class OpenRouterChatCompletionProvider {
+  private readonly fetcher: OpenRouterChatFetcher;
+
+  constructor(options: { readonly fetcher?: OpenRouterChatFetcher } = {}) {
+    this.fetcher = options.fetcher ?? fetch;
+  }
+
+  async complete(
+    request: OpenRouterChatCompletionRequest,
+  ): Promise<OpenRouterChatCompletionResult> {
+    const metadata = OpenRouterRequestMetadataSchema.parse(request.metadata);
+
+    if (request.config.apiKey === undefined) {
+      return providerFailure({
+        model: request.config.model,
+        code: "missing-api-key",
+        userFacingCaveat:
+          "OpenRouter reviewer output is unavailable because OPENROUTER_API_KEY is not configured for this request.",
+      });
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetcher(
+        new Request(`${request.config.baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${request.config.apiKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: request.config.model,
+            messages: request.messages,
+            metadata,
+          }),
+        }),
+      );
+    } catch {
+      return providerFailure({
+        model: request.config.model,
+        code: "network-error",
+        userFacingCaveat:
+          "OpenRouter reviewer output is unavailable because the provider request could not be completed.",
+      });
+    }
+
+    if (!response.ok) {
+      return providerFailure({
+        model: request.config.model,
+        code: "provider-error",
+        status: response.status,
+        userFacingCaveat:
+          "OpenRouter reviewer output is unavailable because the provider request failed.",
+      });
+    }
+
+    const parsedResponse = OpenRouterChatProviderResponseSchema.safeParse(
+      await response.json(),
+    );
+
+    if (!parsedResponse.success) {
+      return providerFailure({
+        model: request.config.model,
+        code: "invalid-response",
+        userFacingCaveat:
+          "OpenRouter reviewer output is unavailable because the provider returned an unexpected response shape.",
+      });
+    }
+
+    const content = parsedResponse.data.choices[0]?.message?.content?.trim();
+
+    if (content === undefined || content === "") {
+      return providerFailure({
+        model: request.config.model,
+        code: "empty-response",
+        userFacingCaveat:
+          "OpenRouter reviewer output is unavailable because the provider returned no usable message content.",
+      });
+    }
+
+    const completion: Omit<OpenRouterChatCompletion, "rawResponseId"> = {
+      kind: "completed",
+      provider: "openrouter",
+      model: request.config.model,
+      content,
+    };
+
+    if (parsedResponse.data.id === undefined) {
+      return completion;
+    }
+
+    return {
+      ...completion,
+      rawResponseId: parsedResponse.data.id,
+    };
+  }
+}
+
+function providerFailure(options: {
+  readonly model: OpenRouterModelId;
+  readonly code: OpenRouterProviderFailureCode;
+  readonly status?: number;
+  readonly userFacingCaveat: string;
+}): OpenRouterProviderFailure {
+  const baseFailure = {
+    kind: "provider-failure" as const,
+    provider: "openrouter" as const,
+    model: options.model,
+    code: options.code,
+    userFacingCaveat: options.userFacingCaveat,
+  };
+
+  if (options.status === undefined) {
+    return baseFailure;
+  }
+
+  return {
+    ...baseFailure,
+    status: options.status,
+  };
+}

--- a/src/infrastructure/llm/openrouter-config.ts
+++ b/src/infrastructure/llm/openrouter-config.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+export const OpenRouterDefaultModelId = "openrouter/free";
+export const OpenRouterDefaultBaseUrl = "https://openrouter.ai/api/v1";
+
+export const OpenRouterModelIdSchema = z.preprocess(
+  (value) => normalizeTextInput(value) ?? OpenRouterDefaultModelId,
+  z.string().min(1).regex(/^\S+$/, "Model id must not contain whitespace"),
+);
+
+export type OpenRouterModelId = z.infer<typeof OpenRouterModelIdSchema>;
+
+const OpenRouterProviderConfigInputSchema = z
+  .object({
+    provider: z.literal("openrouter").default("openrouter"),
+    apiKey: z.preprocess(normalizeTextInput, z.string().min(1).optional()),
+    model: OpenRouterModelIdSchema,
+    baseUrl: z.preprocess(
+      (value) => normalizeTextInput(value) ?? OpenRouterDefaultBaseUrl,
+      z.url(),
+    ),
+  })
+  .strict();
+
+export type OpenRouterProviderConfig = {
+  readonly provider: "openrouter";
+  readonly apiKey?: string;
+  readonly model: OpenRouterModelId;
+  readonly baseUrl: string;
+};
+
+export const OpenRouterProviderConfigSchema: z.ZodType<OpenRouterProviderConfig> =
+  OpenRouterProviderConfigInputSchema.transform((config) => {
+    const baseConfig = {
+      provider: config.provider,
+      model: config.model,
+      baseUrl: config.baseUrl,
+    };
+
+    if (config.apiKey === undefined) {
+      return baseConfig;
+    }
+
+    return {
+      ...baseConfig,
+      apiKey: config.apiKey,
+    };
+  });
+
+export const OpenRouterRequestMetadataSchema = z
+  .object({
+    usageContext: z.enum(["reviewer-assessment", "follow-up-answer"]),
+    requestId: z.string().min(1).optional(),
+    repository: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type OpenRouterRequestMetadata = z.infer<
+  typeof OpenRouterRequestMetadataSchema
+>;
+
+export function parseOpenRouterProviderConfig(
+  input: unknown,
+): OpenRouterProviderConfig {
+  return OpenRouterProviderConfigSchema.parse(input);
+}
+
+function normalizeTextInput(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue === "" ? undefined : trimmedValue;
+}

--- a/test/infrastructure/llm/openrouter-chat-provider.test.ts
+++ b/test/infrastructure/llm/openrouter-chat-provider.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenRouterDefaultModelId } from "../../../src/infrastructure/llm/openrouter-config";
+import {
+  OpenRouterChatCompletionProvider,
+  type OpenRouterChatFetcher,
+} from "../../../src/infrastructure/llm/openrouter-chat-provider";
+
+describe("OpenRouterChatCompletionProvider", () => {
+  it("posts an OpenAI-compatible chat completion request with request-scoped credentials", async () => {
+    const requests: Request[] = [];
+    const fetcher: OpenRouterChatFetcher = async (request) => {
+      requests.push(request);
+      return new Response(
+        JSON.stringify({
+          id: "completion-1",
+          model: OpenRouterDefaultModelId,
+          choices: [{ message: { content: "structured assessment" } }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const provider = new OpenRouterChatCompletionProvider({ fetcher });
+
+    const result = await provider.complete({
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-request-scoped",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      metadata: { usageContext: "reviewer-assessment" },
+      messages: [{ role: "user", content: "Review this evidence." }],
+    });
+
+    expect(result).toEqual({
+      kind: "completed",
+      provider: "openrouter",
+      model: OpenRouterDefaultModelId,
+      content: "structured assessment",
+      rawResponseId: "completion-1",
+    });
+    expect(requests).toHaveLength(1);
+    const request = requests[0];
+    expect(request?.url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(request?.headers.get("authorization")).toBe(
+      "Bearer sk-or-v1-request-scoped",
+    );
+    expect(request?.headers.get("content-type")).toBe("application/json");
+    expect(await request?.json()).toEqual({
+      model: OpenRouterDefaultModelId,
+      messages: [{ role: "user", content: "Review this evidence." }],
+      metadata: { usageContext: "reviewer-assessment" },
+    });
+  });
+
+  it("returns a provider failure without calling fetch when the API key is absent", async () => {
+    const fetcher: OpenRouterChatFetcher = async () => {
+      throw new Error("fetch should not be called");
+    };
+    const provider = new OpenRouterChatCompletionProvider({ fetcher });
+
+    await expect(
+      provider.complete({
+        config: {
+          provider: "openrouter",
+          model: OpenRouterDefaultModelId,
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+        metadata: { usageContext: "follow-up-answer" },
+        messages: [{ role: "user", content: "What changed?" }],
+      }),
+    ).resolves.toEqual({
+      kind: "provider-failure",
+      provider: "openrouter",
+      model: OpenRouterDefaultModelId,
+      code: "missing-api-key",
+      userFacingCaveat:
+        "OpenRouter reviewer output is unavailable because OPENROUTER_API_KEY is not configured for this request.",
+    });
+  });
+
+  it("maps non-2xx provider responses to redacted provider failures", async () => {
+    const provider = new OpenRouterChatCompletionProvider({
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({ error: { message: "quota exceeded for secret" } }),
+          { status: 429, headers: { "content-type": "application/json" } },
+        ),
+    });
+
+    await expect(
+      provider.complete({
+        config: {
+          provider: "openrouter",
+          apiKey: "sk-or-v1-request-scoped",
+          model: OpenRouterDefaultModelId,
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+        metadata: { usageContext: "reviewer-assessment" },
+        messages: [{ role: "user", content: "Review this evidence." }],
+      }),
+    ).resolves.toEqual({
+      kind: "provider-failure",
+      provider: "openrouter",
+      model: OpenRouterDefaultModelId,
+      code: "provider-error",
+      status: 429,
+      userFacingCaveat:
+        "OpenRouter reviewer output is unavailable because the provider request failed.",
+    });
+  });
+
+  it("treats empty or reasoning-only responses as provider failures", async () => {
+    const provider = new OpenRouterChatCompletionProvider({
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            id: "completion-2",
+            model: OpenRouterDefaultModelId,
+            choices: [{ message: { reasoning: "internal chain omitted" } }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    });
+
+    await expect(
+      provider.complete({
+        config: {
+          provider: "openrouter",
+          apiKey: "sk-or-v1-request-scoped",
+          model: OpenRouterDefaultModelId,
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+        metadata: { usageContext: "reviewer-assessment" },
+        messages: [{ role: "user", content: "Review this evidence." }],
+      }),
+    ).resolves.toEqual({
+      kind: "provider-failure",
+      provider: "openrouter",
+      model: OpenRouterDefaultModelId,
+      code: "empty-response",
+      userFacingCaveat:
+        "OpenRouter reviewer output is unavailable because the provider returned no usable message content.",
+    });
+  });
+});

--- a/test/infrastructure/llm/openrouter-chat-provider.test.ts
+++ b/test/infrastructure/llm/openrouter-chat-provider.test.ts
@@ -144,4 +144,34 @@ describe("OpenRouterChatCompletionProvider", () => {
         "OpenRouter reviewer output is unavailable because the provider returned no usable message content.",
     });
   });
+
+  it("maps invalid JSON responses to typed provider failures", async () => {
+    const provider = new OpenRouterChatCompletionProvider({
+      fetcher: async () =>
+        new Response("{not json", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+
+    await expect(
+      provider.complete({
+        config: {
+          provider: "openrouter",
+          apiKey: "sk-or-v1-request-scoped",
+          model: OpenRouterDefaultModelId,
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+        metadata: { usageContext: "reviewer-assessment" },
+        messages: [{ role: "user", content: "Review this evidence." }],
+      }),
+    ).resolves.toEqual({
+      kind: "provider-failure",
+      provider: "openrouter",
+      model: OpenRouterDefaultModelId,
+      code: "invalid-response",
+      userFacingCaveat:
+        "OpenRouter reviewer output is unavailable because the provider returned an unexpected response shape.",
+    });
+  });
 });

--- a/test/infrastructure/llm/openrouter-config.test.ts
+++ b/test/infrastructure/llm/openrouter-config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OpenRouterDefaultModelId,
+  OpenRouterModelIdSchema,
+  OpenRouterProviderConfigSchema,
+  OpenRouterRequestMetadataSchema,
+  parseOpenRouterProviderConfig,
+} from "../../../src/infrastructure/llm/openrouter-config";
+
+describe("OpenRouter provider configuration", () => {
+  it("defaults empty model input to the documented free model", () => {
+    expect(OpenRouterModelIdSchema.parse(undefined)).toBe(
+      OpenRouterDefaultModelId,
+    );
+    expect(OpenRouterModelIdSchema.parse("")).toBe(OpenRouterDefaultModelId);
+    expect(OpenRouterModelIdSchema.parse("   ")).toBe(OpenRouterDefaultModelId);
+  });
+
+  it("trims provided model ids and rejects whitespace inside ids", () => {
+    expect(OpenRouterModelIdSchema.parse(" anthropic/claude-3-haiku ")).toBe(
+      "anthropic/claude-3-haiku",
+    );
+
+    expect(() => OpenRouterModelIdSchema.parse("bad model")).toThrow();
+  });
+
+  it("parses request-scoped API key configuration without requiring storage", () => {
+    const config = parseOpenRouterProviderConfig({
+      apiKey: " sk-or-v1-request-scoped ",
+      model: "",
+    });
+
+    expect(config).toEqual({
+      provider: "openrouter",
+      apiKey: "sk-or-v1-request-scoped",
+      model: OpenRouterDefaultModelId,
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  it("normalizes missing API key to an explicit unavailable configuration", () => {
+    expect(
+      OpenRouterProviderConfigSchema.parse({ apiKey: " ", model: "" }),
+    ).toEqual({
+      provider: "openrouter",
+      model: OpenRouterDefaultModelId,
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  it("validates request metadata separately from the domain reviewer contract", () => {
+    expect(
+      OpenRouterRequestMetadataSchema.parse({
+        usageContext: "reviewer-assessment",
+        requestId: "request-123",
+        repository: "lightstrikelabs/repo-analyzer-green",
+      }),
+    ).toEqual({
+      usageContext: "reviewer-assessment",
+      requestId: "request-123",
+      repository: "lightstrikelabs/repo-analyzer-green",
+    });
+
+    expect(() =>
+      OpenRouterRequestMetadataSchema.parse({ usageContext: "unsupported" }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add Zod runtime schemas for OpenRouter model ids, request-scoped provider config, and provider request metadata
- add a fetch-backed OpenRouter chat completion boundary with typed success/failure results and fake-fetch contract coverage
- document defaulting, request-scoped key handling, and provider failure caveats

## Tests
- pnpm exec vitest run test/infrastructure/llm/openrouter-config.test.ts test/infrastructure/llm/openrouter-chat-provider.test.ts
- pnpm run ci

Closes #75