### PR TITLE
feat(api): add analyze route

### DIFF
--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  AnalyzeRepositoryReportCardResult,
+  AnalyzeRepositoryResult,
+} from "../../../application/analyze-repository/analyze-repository";
+import { RepositorySourceError } from "../../../domain/repository/repository-source";
+import { handleAnalyzeRequest } from "./route";
+
+const validRequestBody = {
+  repository: {
+    provider: "local-fixture",
+    name: "minimal-node-library",
+    revision: "fixture",
+  },
+} as const;
+
+const reportResult: AnalyzeRepositoryReportCardResult = {
+  kind: "report-card",
+  reportCard: {
+    id: "report:minimal-node-library",
+    schemaVersion: "report-card.v1",
+    generatedAt: "2026-04-25T20:05:00-07:00",
+    scoringPolicy: {
+      name: "repo-analyzer-green scoring policy",
+      version: "0.1.0",
+    },
+    repository: validRequestBody.repository,
+    assessedArchetype: "library",
+    reviewerMetadata: {
+      kind: "fake",
+      name: "Fake reviewer",
+      reviewedAt: "2026-04-25T20:00:00-07:00",
+    },
+    evidenceReferences: [
+      {
+        id: "evidence:package-json",
+        kind: "file",
+        label: "Package manifest",
+        path: "package.json",
+      },
+    ],
+    dimensionAssessments: [
+      {
+        dimension: "verifiability",
+        title: "Verifiability",
+        summary: "A focused unit test exercises exported behavior.",
+        rating: "good",
+        score: 90,
+        confidence: {
+          level: "high",
+          score: 0.9,
+          rationale: "The fixture includes a deterministic unit test.",
+        },
+        evidenceReferences: [
+          {
+            id: "evidence:test-file",
+            kind: "file",
+            label: "Unit test file",
+            path: "test/add.spec.ts",
+          },
+        ],
+        findings: [],
+        caveatIds: [],
+      },
+    ],
+    caveats: [],
+    recommendedNextQuestions: [],
+  },
+  evidenceBundle: {
+    repository: validRequestBody.repository,
+    fileInventory: {
+      files: [],
+      omissions: [],
+    },
+    manifestWorkflowSignals: {
+      packageManifests: [],
+      dependencySignals: [],
+      scriptSignals: [],
+      workflowSignals: [],
+      unsupportedManifests: [],
+      omissions: [],
+    },
+    projectArchetypeSignals: {
+      primaryArchetype: "library",
+      candidates: [],
+    },
+    languageCodeShapeMetrics: {
+      summary: {
+        analyzedFileCount: 0,
+        sourceFileCount: 0,
+        testFileCount: 0,
+        documentationFileCount: 0,
+        largeFileCount: 0,
+        skippedFileCount: 0,
+        unsupportedFileCount: 0,
+        totalTextLineCount: 0,
+        totalCodeLineCount: 0,
+        totalDeferredWorkMarkerCount: 0,
+        totalBranchLikeTokenCount: 0,
+      },
+      languageMix: [],
+      files: [],
+      deferredWorkMarkers: [],
+      branchLikeTokens: [],
+      largeFiles: [],
+      omissions: [],
+      caveats: [],
+    },
+    securityHygieneSignals: {
+      lockfileSignals: [],
+      dependencyCountSignals: [],
+      envExampleSignals: [],
+      secretRiskSignals: [],
+      limitations: [],
+    },
+    evidenceReferences: [],
+    evidenceSummary: "Files analyzed: 0",
+  },
+  reviewerAssessment: {
+    schemaVersion: "reviewer-assessment.v1",
+    reviewer: {
+      kind: "fake",
+      name: "Fake reviewer",
+      reviewedAt: "2026-04-25T20:00:00-07:00",
+    },
+    assessedArchetype: {
+      value: "library",
+      confidence: {
+        level: "high",
+        score: 0.9,
+        rationale: "Fixture reviewer.",
+      },
+      evidenceReferences: [],
+      rationale: "Fixture reviewer.",
+    },
+    dimensions: [
+      {
+        dimension: "verifiability",
+        summary: "A focused unit test exercises exported behavior.",
+        confidence: {
+          level: "high",
+          score: 0.9,
+          rationale: "Fixture reviewer.",
+        },
+        evidenceReferences: [],
+        strengths: [],
+        risks: [],
+        missingEvidence: [],
+      },
+    ],
+    caveats: [],
+    followUpQuestions: [],
+  },
+};
+
+describe("POST /api/analyze", () => {
+  it("validates the request and returns the report card from the analyzer", async () => {
+    const response = await handleAnalyzeRequest(jsonRequest(validRequestBody), {
+      analyze: async () => reportResult,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      reportCard: reportResult.reportCard,
+    });
+  });
+
+  it("returns 400 for invalid request bodies", async () => {
+    const response = await handleAnalyzeRequest(
+      jsonRequest({
+        repository: {
+          provider: "local-fixture",
+          name: "",
+        },
+      }),
+      {
+        analyze: async () => reportResult,
+      },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("invalid-request");
+    expect(body.error.issues[0]).toMatchObject({
+      path: ["repository", "name"],
+    });
+  });
+
+  it("maps missing repositories to 404 without leaking implementation details", async () => {
+    const response = await handleAnalyzeRequest(jsonRequest(validRequestBody), {
+      analyze: async () => {
+        throw new RepositorySourceError(
+          "Repository fixture is not registered.",
+          "repository-not-found",
+          validRequestBody.repository,
+        );
+      },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({
+      error: {
+        code: "repository-not-found",
+        message: "Repository could not be found.",
+      },
+    });
+  });
+
+  it("maps malformed reviewer output to a bad gateway response", async () => {
+    const malformedResult: AnalyzeRepositoryResult = {
+      kind: "reviewer-malformed-response",
+      evidenceBundle: reportResult.evidenceBundle,
+      reviewer: {
+        kind: "fake",
+        name: "Malformed fake reviewer",
+        reviewedAt: "2026-04-25T20:00:00-07:00",
+      },
+      rawResponse: "{}",
+      validationIssues: [
+        {
+          path: ["dimensions"],
+          message: "Required",
+        },
+      ],
+    };
+
+    const response = await handleAnalyzeRequest(jsonRequest(validRequestBody), {
+      analyze: async () => malformedResult,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: {
+        code: "reviewer-malformed-response",
+        message: "Reviewer response could not be validated.",
+        issues: malformedResult.validationIssues,
+      },
+    });
+  });
+});
+
+function jsonRequest(body: object): Request {
+  return new Request("http://localhost/api/analyze", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -1,0 +1,291 @@
+import path from "node:path";
+
+import { z } from "zod";
+
+import {
+  analyzeRepository,
+  type AnalyzeRepositoryInput,
+  type AnalyzeRepositoryResult,
+} from "../../../application/analyze-repository/analyze-repository";
+import { LocalFixtureRepositorySource } from "../../../infrastructure/filesystem/local-fixture-repository-source";
+import { FakeReviewer } from "../../../infrastructure/reviewer/fake-reviewer";
+import {
+  RepositorySourceError,
+  type RepositoryReference,
+} from "../../../domain/repository/repository-source";
+import {
+  ReviewerAssessmentSchemaVersion,
+  type ReviewerAssessment,
+} from "../../../domain/reviewer/reviewer-assessment";
+
+type AnalyzeRouteDependencies = {
+  readonly analyze: (
+    input: AnalyzeRepositoryInput,
+  ) => Promise<AnalyzeRepositoryResult>;
+};
+
+type ApiValidationIssue = {
+  readonly path: readonly (string | number)[];
+  readonly message: string;
+};
+
+const AnalyzeRepositoryRequestSchema = z
+  .object({
+    repository: z
+      .object({
+        provider: z.enum(["github", "local-fixture"]),
+        name: z.string().min(1),
+        owner: z.string().min(1).optional(),
+        url: z.url().optional(),
+        revision: z.string().min(1).optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+type AnalyzeRepositoryRequest = z.infer<typeof AnalyzeRepositoryRequestSchema>;
+
+export async function POST(request: Request): Promise<Response> {
+  return handleAnalyzeRequest(request, {
+    analyze: analyzeWithDefaultDependencies,
+  });
+}
+
+export async function handleAnalyzeRequest(
+  request: Request,
+  dependencies: AnalyzeRouteDependencies,
+): Promise<Response> {
+  const bodyResult = await readRequestBody(request);
+
+  if (bodyResult.kind === "invalid-json") {
+    return jsonError(400, {
+      code: "invalid-json",
+      message: "Request body must be valid JSON.",
+    });
+  }
+
+  const parseResult = AnalyzeRepositoryRequestSchema.safeParse(bodyResult.body);
+
+  if (!parseResult.success) {
+    return jsonError(400, {
+      code: "invalid-request",
+      message: "Request body did not match the analyze contract.",
+      issues: parseResult.error.issues.map(toApiValidationIssue),
+    });
+  }
+
+  try {
+    const result = await dependencies.analyze({
+      repository: toRepositoryReference(parseResult.data.repository),
+    });
+
+    if (result.kind === "reviewer-malformed-response") {
+      return jsonError(502, {
+        code: "reviewer-malformed-response",
+        message: "Reviewer response could not be validated.",
+        issues: result.validationIssues,
+      });
+    }
+
+    return Response.json({
+      reportCard: result.reportCard,
+    });
+  } catch (error) {
+    if (error instanceof RepositorySourceError) {
+      return repositorySourceErrorResponse(error);
+    }
+
+    return jsonError(500, {
+      code: "internal-error",
+      message: "Repository analysis failed unexpectedly.",
+    });
+  }
+}
+
+function toRepositoryReference(
+  repository: AnalyzeRepositoryRequest["repository"],
+): RepositoryReference {
+  return {
+    provider: repository.provider,
+    name: repository.name,
+    ...(repository.owner === undefined ? {} : { owner: repository.owner }),
+    ...(repository.url === undefined ? {} : { url: repository.url }),
+    ...(repository.revision === undefined
+      ? {}
+      : { revision: repository.revision }),
+  };
+}
+
+async function analyzeWithDefaultDependencies(
+  input: AnalyzeRepositoryInput,
+): Promise<AnalyzeRepositoryResult> {
+  return analyzeRepository(input, {
+    repositorySource: new LocalFixtureRepositorySource({
+      fixtures: {
+        "minimal-node-library": {
+          id: "minimal-node-library",
+          rootPath: path.join(
+            process.cwd(),
+            "test/fixtures/repositories/minimal-node-library",
+          ),
+        },
+      },
+    }),
+    reviewer: new FakeReviewer({
+      result: {
+        kind: "assessment",
+        assessment: defaultReviewerAssessment,
+      },
+    }),
+  });
+}
+
+function repositorySourceErrorResponse(error: RepositorySourceError): Response {
+  switch (error.code) {
+    case "invalid-repository-reference":
+      return jsonError(400, {
+        code: error.code,
+        message: "Repository reference is invalid.",
+      });
+    case "file-not-found":
+    case "repository-not-found":
+      return jsonError(404, {
+        code: error.code,
+        message: "Repository could not be found.",
+      });
+    case "download-failed":
+    case "extraction-failed":
+      return jsonError(502, {
+        code: error.code,
+        message: "Repository source could not be acquired.",
+      });
+  }
+}
+
+async function readRequestBody(request: Request): Promise<
+  | {
+      readonly kind: "body";
+      readonly body: unknown;
+    }
+  | {
+      readonly kind: "invalid-json";
+    }
+> {
+  try {
+    const body: unknown = await request.json();
+    return {
+      kind: "body",
+      body,
+    };
+  } catch {
+    return {
+      kind: "invalid-json",
+    };
+  }
+}
+
+function toApiValidationIssue(issue: z.core.$ZodIssue): ApiValidationIssue {
+  return {
+    path: issue.path.map((segment) =>
+      typeof segment === "number" ? segment : String(segment),
+    ),
+    message: issue.message,
+  };
+}
+
+function jsonError(
+  status: number,
+  error: {
+    readonly code: string;
+    readonly message: string;
+    readonly issues?: readonly ApiValidationIssue[];
+  },
+): Response {
+  return Response.json(
+    {
+      error,
+    },
+    {
+      status,
+    },
+  );
+}
+
+const defaultReviewerAssessment: ReviewerAssessment = {
+  schemaVersion: ReviewerAssessmentSchemaVersion,
+  reviewer: {
+    kind: "fake",
+    name: "Default fixture reviewer",
+    reviewedAt: "2026-04-25T20:00:00-07:00",
+  },
+  assessedArchetype: {
+    value: "library",
+    confidence: {
+      level: "high",
+      score: 0.9,
+      rationale:
+        "The default route fixture contains package metadata and reusable TypeScript source.",
+    },
+    evidenceReferences: [
+      {
+        id: "evidence:package-json",
+        kind: "file",
+        label: "Package manifest",
+        path: "package.json",
+      },
+    ],
+    rationale:
+      "The default fixture is a TypeScript library used for deterministic route behavior.",
+  },
+  dimensions: [
+    {
+      dimension: "maintainability",
+      summary: "The default fixture has a small, readable source surface.",
+      confidence: {
+        level: "high",
+        score: 0.9,
+        rationale: "The fixture source is intentionally minimal.",
+      },
+      evidenceReferences: [
+        {
+          id: "evidence:source-file",
+          kind: "file",
+          label: "Source file",
+          path: "src/add.ts",
+        },
+      ],
+      strengths: ["The source module is small and explicit."],
+      risks: [],
+      missingEvidence: [],
+    },
+    {
+      dimension: "verifiability",
+      summary: "A focused unit test exercises the exported behavior.",
+      confidence: {
+        level: "high",
+        score: 0.9,
+        rationale: "The fixture includes a deterministic unit test.",
+      },
+      evidenceReferences: [
+        {
+          id: "evidence:test-file",
+          kind: "file",
+          label: "Unit test file",
+          path: "test/add.spec.ts",
+        },
+      ],
+      strengths: ["The public add function is covered by a unit test."],
+      risks: [],
+      missingEvidence: [],
+    },
+  ],
+  caveats: [],
+  followUpQuestions: [
+    {
+      id: "question:test-depth",
+      question: "What behavior remains untested?",
+      targetDimension: "verifiability",
+      rationale: "The deterministic fixture is intentionally narrow.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add `POST /api/analyze` with Zod request validation
- delegate repository analysis to the application service
- map repository-source and malformed-reviewer failures to explicit HTTP responses
- cover the route handler with focused tests

## Validation
- `pnpm run ci`

Closes #30