### PR TITLE
feat(reviewer): add prompt contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See [docs/commit-messages.md](docs/commit-messages.md) for commit and PR title s
 See [docs/fixtures.md](docs/fixtures.md) for repository fixture rules.
 See [docs/architecture.md](docs/architecture.md#test-placement) for test placement rules.
 See [docs/e2e.md](docs/e2e.md) for E2E setup and configuration rules.
+See [docs/reviewer-prompt-contract.md](docs/reviewer-prompt-contract.md) for the structured reviewer prompt rules.
 See [docs/deployment.md](docs/deployment.md) for Vercel deployment and preview E2E setup.
 See [docs/how-tos/vercel-preview-e2e.md](docs/how-tos/vercel-preview-e2e.md) for protected Vercel preview E2E setup.
 See [docs/how-tos/openrouter-e2e.md](docs/how-tos/openrouter-e2e.md) for OpenRouter-backed E2E secret setup.

--- a/docs/reviewer-prompt-contract.md
+++ b/docs/reviewer-prompt-contract.md
@@ -1,0 +1,31 @@
+# Reviewer Prompt Contract
+
+The reviewer prompt contract turns deterministic repository evidence into a structured reviewer assessment. It is provider-neutral and lives in the reviewer domain so OpenRouter, future model providers, human review tools, and fake reviewers can share the same expectations.
+
+## Contract Rules
+
+- Return only JSON matching `reviewer-assessment.v1`.
+- Use only supplied repository evidence, evidence references, and evidence summary.
+- Do not make unsupported claims.
+- Treat missing evidence as uncertainty, not as an automatic quality defect.
+- Treat static metrics as evidence, not direct quality judgments.
+- Treat security hygiene signals as indicators requiring review, not confirmed vulnerabilities.
+- Include caveats for low confidence, bounded scans, unsupported ecosystems, unavailable evidence, and provider limitations.
+- Include follow-up questions tied to uncertainty or risk.
+
+## Required Dimensions
+
+The reviewer must assess:
+
+- `architecture-boundaries`
+- `maintainability`
+- `verifiability`
+- `security`
+- `operability`
+- `documentation`
+
+Each dimension should include confidence, evidence references where evidence exists, strengths, risks, and missing evidence.
+
+## Implementation
+
+The renderer is [reviewer-prompt.ts](/Users/wunderpro/lightstrike/lightstrike/ai-slop-prevention-q2-2026/green/src/domain/reviewer/reviewer-prompt.ts). Provider adapters should pass its messages to the model without weakening the structured-output or evidence-grounding rules.

--- a/src/domain/reviewer/reviewer-prompt.test.ts
+++ b/src/domain/reviewer/reviewer-prompt.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ReviewerAssessmentSchemaVersion,
+  ReviewerDimensionAssessmentSchema,
+} from "./reviewer-assessment";
+import { renderReviewerPrompt } from "./reviewer-prompt";
+
+const repository = {
+  provider: "github",
+  owner: "lightstrikelabs",
+  name: "repo-analyzer-green",
+  url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+  revision: "main",
+} as const;
+
+const evidenceReferences = [
+  {
+    id: "evidence:package-json",
+    kind: "file",
+    label: "Package manifest",
+    path: "package.json",
+  },
+  {
+    id: "evidence:security-human-review",
+    kind: "collector",
+    label: "Security hygiene limitation",
+    notes: "Security hygiene signals require human review.",
+  },
+] as const;
+
+describe("renderReviewerPrompt", () => {
+  it("renders a structured-output-only prompt grounded in the reviewer assessment schema", () => {
+    const prompt = renderReviewerPrompt({
+      repository,
+      evidenceReferences,
+      evidenceSummary: [
+        "Files analyzed: 42",
+        "Primary archetype signal: web-app",
+        "Security hygiene signals: 2",
+      ].join("\n"),
+    });
+
+    expect(prompt.system).toContain("Return only JSON");
+    expect(prompt.system).toContain(ReviewerAssessmentSchemaVersion);
+    expect(prompt.system).toContain("Do not make unsupported claims");
+    expect(prompt.system).toContain("Missing evidence is not a defect");
+    expect(prompt.system).toContain("follow-up questions");
+    expect(prompt.user).toContain("lightstrikelabs/repo-analyzer-green");
+    expect(prompt.user).toContain("Files analyzed: 42");
+    expect(prompt.user).toContain("evidence:package-json");
+    expect(prompt.user).toContain(
+      "Security hygiene signals require human review",
+    );
+    expect(prompt.responseContractJson).toContain(
+      '"schemaVersion":"reviewer-assessment.v1"',
+    );
+    expect(prompt.messages).toEqual([
+      {
+        role: "system",
+        content: prompt.system,
+      },
+      {
+        role: "user",
+        content: prompt.user,
+      },
+    ]);
+  });
+
+  it("keeps every required dimension visible to the reviewer", () => {
+    const prompt = renderReviewerPrompt({
+      repository,
+      evidenceReferences,
+    });
+
+    const dimensions =
+      ReviewerDimensionAssessmentSchema.shape.dimension.options;
+
+    for (const dimension of dimensions) {
+      expect(prompt.system).toContain(dimension);
+    }
+  });
+
+  it("bounds the evidence summary to keep prompt size predictable", () => {
+    const prompt = renderReviewerPrompt({
+      repository,
+      evidenceReferences,
+      evidenceSummary: "x".repeat(20_000),
+      maxEvidenceSummaryCharacters: 120,
+    });
+
+    expect(prompt.user).toContain("Evidence Summary");
+    expect(prompt.user).toContain("truncated");
+    expect(prompt.user.length).toBeLessThan(3_000);
+  });
+});

--- a/src/domain/reviewer/reviewer-prompt.ts
+++ b/src/domain/reviewer/reviewer-prompt.ts
@@ -1,0 +1,181 @@
+import type { RepositoryIdentity } from "../report/report-card";
+import type { EvidenceReference } from "../shared/evidence-reference";
+
+import { ReviewerAssessmentSchemaVersion } from "./reviewer-assessment";
+
+export type ReviewerPromptInput = {
+  readonly repository: RepositoryIdentity;
+  readonly evidenceReferences: readonly EvidenceReference[];
+  readonly evidenceSummary?: string;
+  readonly maxEvidenceSummaryCharacters?: number;
+};
+
+export type ReviewerPromptMessage = {
+  readonly role: "system" | "user";
+  readonly content: string;
+};
+
+export type ReviewerPrompt = {
+  readonly system: string;
+  readonly user: string;
+  readonly responseContractJson: string;
+  readonly messages: readonly ReviewerPromptMessage[];
+};
+
+const defaultMaxEvidenceSummaryCharacters = 12_000;
+
+const requiredDimensions = [
+  "architecture-boundaries",
+  "maintainability",
+  "verifiability",
+  "security",
+  "operability",
+  "documentation",
+] as const;
+
+export function renderReviewerPrompt(
+  input: ReviewerPromptInput,
+): ReviewerPrompt {
+  const responseContractJson = JSON.stringify(responseContract());
+  const system = [
+    "You are a repository quality reviewer for Repo Analyzer Green.",
+    "Return only JSON. Do not wrap the response in Markdown or explanatory prose.",
+    `The JSON must match schemaVersion ${ReviewerAssessmentSchemaVersion}.`,
+    "Use only the supplied repository evidence and evidence summary.",
+    "Do not make unsupported claims. If evidence is absent, record missingEvidence and lower confidence.",
+    "Missing evidence is not a defect and must not be treated as an automatic quality penalty.",
+    "Static metrics are evidence, not final judgments.",
+    "Security hygiene signals are indicators that require review, not confirmed vulnerabilities.",
+    "Every dimension assessment must cite evidenceReferences when evidence exists, or explain missingEvidence when it does not.",
+    `Assess these dimensions exactly: ${requiredDimensions.join(", ")}.`,
+    "Include caveats for low confidence, unavailable evidence, unsupported ecosystems, bounded scans, and provider limitations.",
+    "Include follow-up questions tied to uncertainty or risk, not generic advice.",
+    "Use confidence.score between 0 and 1 and confidence.level as low, medium, or high.",
+    "Use concise strings. Preserve evidence reference ids exactly as supplied.",
+    `Response contract JSON example: ${responseContractJson}`,
+  ].join("\n");
+  const user = [
+    `Repository: ${repositoryLabel(input.repository)}`,
+    "",
+    "Evidence Summary:",
+    boundedEvidenceSummary(input),
+    "",
+    "Evidence References:",
+    ...input.evidenceReferences.map(formatEvidenceReference),
+  ].join("\n");
+
+  return {
+    system,
+    user,
+    responseContractJson,
+    messages: [
+      {
+        role: "system",
+        content: system,
+      },
+      {
+        role: "user",
+        content: user,
+      },
+    ],
+  };
+}
+
+function responseContract() {
+  return {
+    schemaVersion: ReviewerAssessmentSchemaVersion,
+    reviewer: {
+      kind: "llm",
+      name: "string",
+      reviewerVersion: "string",
+      modelProvider: "string",
+      modelName: "string",
+      modelVersion: "string",
+      reviewedAt: "ISO-8601 datetime with offset",
+    },
+    assessedArchetype: {
+      value:
+        "web-app | cli | library | service | infrastructure | docs-heavy | research-notebook | generated-sdk | embedded | unknown",
+      confidence: {
+        level: "low | medium | high",
+        score: 0.5,
+        rationale: "string",
+      },
+      evidenceReferences: ["EvidenceReference objects copied from input"],
+      rationale: "string",
+    },
+    dimensions: requiredDimensions.map((dimension) => ({
+      dimension,
+      summary: "string",
+      confidence: {
+        level: "low | medium | high",
+        score: 0.5,
+        rationale: "string",
+      },
+      evidenceReferences: ["EvidenceReference objects copied from input"],
+      strengths: ["evidence-backed strength"],
+      risks: ["evidence-backed risk"],
+      missingEvidence: ["evidence that would change confidence"],
+    })),
+    caveats: [
+      {
+        id: "caveat:dimension:reason",
+        summary: "string",
+        affectedDimensions: ["maintainability"],
+        missingEvidence: ["string"],
+        confidence: {
+          level: "low | medium | high",
+          score: 0.5,
+          rationale: "string",
+        },
+        evidenceReferences: ["EvidenceReference objects copied from input"],
+      },
+    ],
+    followUpQuestions: [
+      {
+        id: "question:short-slug",
+        question: "string",
+        targetDimension: "maintainability",
+        rationale: "why this question addresses uncertainty or risk",
+      },
+    ],
+  };
+}
+
+function boundedEvidenceSummary(input: ReviewerPromptInput): string {
+  const summary = input.evidenceSummary?.trim();
+
+  if (summary === undefined || summary === "") {
+    return "No evidence summary was provided. Use evidence references and mark missing context where needed.";
+  }
+
+  const maxCharacters =
+    input.maxEvidenceSummaryCharacters ?? defaultMaxEvidenceSummaryCharacters;
+
+  if (summary.length <= maxCharacters) {
+    return summary;
+  }
+
+  return `${summary.slice(0, maxCharacters)}\n[Evidence summary truncated at ${maxCharacters} characters.]`;
+}
+
+function repositoryLabel(repository: RepositoryIdentity): string {
+  const ownerPrefix =
+    repository.owner === undefined ? "" : `${repository.owner}/`;
+  const revisionSuffix =
+    repository.revision === undefined ? "" : ` @ ${repository.revision}`;
+
+  return `${repository.provider}:${ownerPrefix}${repository.name}${revisionSuffix}`;
+}
+
+function formatEvidenceReference(reference: EvidenceReference): string {
+  const path = reference.path === undefined ? "" : ` path=${reference.path}`;
+  const notes =
+    reference.notes === undefined ? "" : ` notes=${reference.notes}`;
+  const lineRange =
+    reference.lineStart === undefined
+      ? ""
+      : ` lines=${reference.lineStart}-${reference.lineEnd ?? reference.lineStart}`;
+
+  return `- id=${reference.id} kind=${reference.kind} label=${reference.label}${path}${lineRange}${notes}`;
+}


### PR DESCRIPTION
## Summary
- add a provider-neutral reviewer prompt renderer
- require structured JSON output matching `reviewer-assessment.v1`
- encode grounding rules around unsupported claims, caveats, missing evidence, and follow-up questions
- document the prompt contract and link it from README

## Validation
- `pnpm run ci`

Closes #27