### PR TITLE
feat(ui): add initial report view

### DIFF
--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -1,12 +1,23 @@
 import { expect, test } from "@playwright/test";
 
-test("renders the initial analysis shell", async ({ page }) => {
+test("runs the fixture analysis workflow", async ({ page }) => {
   await page.goto("/");
 
   await expect(
-    page.getByRole("heading", {
-      name: "Evidence-backed repository quality analysis.",
-    }),
+    page.getByRole("heading", { name: "Repository analysis" }),
   ).toBeVisible();
-  await expect(page.getByText("Repo Analyzer Green")).toBeVisible();
+
+  await page.getByRole("button", { name: "Analyze fixture" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Evidence-backed report" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("local-fixture:minimal-node-library @ fixture"),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Dimensions" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Caveats And Missing Evidence" }),
+  ).toBeVisible();
+  await expect(page.getByText("evidence:test-file")).toBeVisible();
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,5 @@
+import { AnalyzeRepositoryPanel } from "../components/report/analyze-repository-panel";
+
 export default function Home() {
-  return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col justify-center gap-8 px-6 py-16">
-      <section className="space-y-5">
-        <p className="text-sm font-medium uppercase tracking-wide text-emerald-700">
-          Repo Analyzer Green
-        </p>
-        <h1 className="max-w-3xl text-4xl font-semibold text-slate-950 sm:text-5xl">
-          Evidence-backed repository quality analysis.
-        </h1>
-        <p className="max-w-2xl text-lg leading-8 text-slate-700">
-          This scaffold is ready for the first domain slice: collecting
-          repository evidence, running a structured reviewer, and composing a
-          confidence-aware report card.
-        </p>
-      </section>
-    </main>
-  );
+  return <AnalyzeRepositoryPanel />;
 }

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+
+import type { ReportCard } from "../../domain/report/report-card";
+import { ReportCardView } from "./report-card-view";
+
+type AnalyzeState =
+  | {
+      readonly kind: "idle";
+    }
+  | {
+      readonly kind: "loading";
+    }
+  | {
+      readonly kind: "loaded";
+      readonly reportCard: ReportCard;
+    }
+  | {
+      readonly kind: "error";
+      readonly message: string;
+    };
+
+export function AnalyzeRepositoryPanel() {
+  const [state, setState] = useState<AnalyzeState>({ kind: "idle" });
+
+  async function analyzeFixture() {
+    setState({ kind: "loading" });
+
+    const response = await fetch("/api/analyze", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        repository: {
+          provider: "local-fixture",
+          name: "minimal-node-library",
+          revision: "fixture",
+        },
+      }),
+    });
+    const body: unknown = await response.json();
+
+    if (!response.ok || !isReportResponse(body)) {
+      setState({
+        kind: "error",
+        message:
+          "Analysis failed. Check the repository evidence and try again.",
+      });
+      return;
+    }
+
+    setState({
+      kind: "loaded",
+      reportCard: body.reportCard,
+    });
+  }
+
+  return (
+    <div className="grid min-h-screen gap-6 px-6 py-6 lg:grid-cols-[340px_1fr]">
+      <aside className="rounded-md border border-slate-200 bg-white p-5">
+        <p className="text-sm font-medium uppercase text-emerald-700">
+          Repo Analyzer Green
+        </p>
+        <h1 className="mt-3 text-2xl font-semibold text-slate-950">
+          Repository analysis
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-slate-700">
+          Run the deterministic fixture path to produce a report card with
+          dimensions, evidence, confidence, caveats, and follow-up questions.
+        </p>
+        <button
+          type="button"
+          onClick={analyzeFixture}
+          disabled={state.kind === "loading"}
+          className="mt-5 w-full rounded-md bg-slate-950 px-4 py-2.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-400"
+        >
+          {state.kind === "loading" ? "Analyzing..." : "Analyze fixture"}
+        </button>
+        {state.kind === "error" ? (
+          <p role="alert" className="mt-4 text-sm text-red-700">
+            {state.message}
+          </p>
+        ) : null}
+      </aside>
+
+      <main className="min-w-0 rounded-md border border-slate-200 bg-slate-50 p-5">
+        {state.kind === "loaded" ? (
+          <ReportCardView reportCard={state.reportCard} />
+        ) : (
+          <section className="flex min-h-[520px] items-center justify-center rounded-md border border-dashed border-slate-300 bg-white p-6 text-center">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-950">
+                No report generated yet
+              </h2>
+              <p className="mt-2 max-w-md text-sm leading-6 text-slate-700">
+                Start with the fixture workflow while GitHub, live reviewer, and
+                persistence adapters continue to evolve behind stable contracts.
+              </p>
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function isReportResponse(
+  value: unknown,
+): value is { readonly reportCard: ReportCard } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "reportCard" in value &&
+    typeof value.reportCard === "object" &&
+    value.reportCard !== null
+  );
+}

--- a/src/components/report/report-card-view.test.tsx
+++ b/src/components/report/report-card-view.test.tsx
@@ -1,0 +1,124 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { ReportCard } from "../../domain/report/report-card";
+import { ReportCardView } from "./report-card-view";
+
+const reportCard: ReportCard = {
+  id: "report:minimal-node-library",
+  schemaVersion: "report-card.v1",
+  generatedAt: "2026-04-26T07:00:00-07:00",
+  scoringPolicy: {
+    name: "repo-analyzer-green scoring policy",
+    version: "0.1.0",
+  },
+  repository: {
+    provider: "local-fixture",
+    name: "minimal-node-library",
+    revision: "fixture",
+  },
+  assessedArchetype: "library",
+  reviewerMetadata: {
+    kind: "fake",
+    name: "Fixture reviewer",
+    reviewedAt: "2026-04-26T07:00:00-07:00",
+  },
+  evidenceReferences: [
+    {
+      id: "evidence:package-json",
+      kind: "file",
+      label: "Package manifest",
+      path: "package.json",
+    },
+  ],
+  dimensionAssessments: [
+    {
+      dimension: "verifiability",
+      title: "Verifiability",
+      summary: "A focused unit test exercises exported behavior.",
+      rating: "good",
+      score: 90,
+      confidence: {
+        level: "high",
+        score: 0.9,
+        rationale: "The fixture includes a deterministic unit test.",
+      },
+      evidenceReferences: [
+        {
+          id: "evidence:test-file",
+          kind: "file",
+          label: "Unit test file",
+          path: "test/add.spec.ts",
+        },
+      ],
+      findings: [
+        {
+          id: "finding:test-depth",
+          dimension: "verifiability",
+          severity: "info",
+          title: "Test depth",
+          summary: "The exported add function has a focused test.",
+          confidence: {
+            level: "high",
+            score: 0.9,
+            rationale: "The test file directly supports this finding.",
+          },
+          evidenceReferences: [
+            {
+              id: "evidence:test-file",
+              kind: "file",
+              label: "Unit test file",
+              path: "test/add.spec.ts",
+            },
+          ],
+        },
+      ],
+      caveatIds: ["caveat:limited-fixture"],
+    },
+  ],
+  caveats: [
+    {
+      id: "caveat:limited-fixture",
+      title: "Limited fixture evidence",
+      summary: "Release and incident history are unavailable.",
+      affectedDimensions: ["operability", "verifiability"],
+      missingEvidence: ["Release workflow history", "Incident history"],
+    },
+  ],
+  recommendedNextQuestions: [
+    {
+      id: "question:release-process",
+      question: "How is this package released and verified?",
+      targetDimension: "operability",
+      rationale: "Release readiness is not visible in the fixture.",
+    },
+  ],
+};
+
+describe("ReportCardView", () => {
+  it("renders dimensions, confidence, findings, caveats, missing evidence, and evidence references", () => {
+    const html = renderToStaticMarkup(
+      <ReportCardView reportCard={reportCard} />,
+    );
+
+    expect(html).toContain("minimal-node-library");
+    expect(html).toContain("library");
+    expect(html).toContain("Verifiability");
+    expect(html).toContain("good");
+    expect(html).toContain("high confidence");
+    expect(html).toContain("Test depth");
+    expect(html).toContain("Limited fixture evidence");
+    expect(html).toContain("Release workflow history");
+    expect(html).toContain("evidence:test-file");
+    expect(html).toContain("How is this package released and verified?");
+  });
+
+  it("does not collapse the report into a single overall score", () => {
+    const html = renderToStaticMarkup(
+      <ReportCardView reportCard={reportCard} />,
+    );
+
+    expect(html).not.toContain("Overall score");
+    expect(html).not.toContain("Total score");
+  });
+});

--- a/src/components/report/report-card-view.tsx
+++ b/src/components/report/report-card-view.tsx
@@ -1,0 +1,210 @@
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportCaveat,
+  ReportFinding,
+} from "../../domain/report/report-card";
+import type { EvidenceReference } from "../../domain/shared/evidence-reference";
+
+export function ReportCardView({
+  reportCard,
+}: {
+  readonly reportCard: ReportCard;
+}) {
+  return (
+    <article className="space-y-6" aria-labelledby="report-title">
+      <header className="border-b border-slate-200 pb-5">
+        <p className="text-sm font-medium text-slate-600">
+          {repositoryLabel(reportCard)}
+        </p>
+        <div className="mt-2 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2
+              id="report-title"
+              className="text-2xl font-semibold text-slate-950"
+            >
+              Evidence-backed report
+            </h2>
+            <p className="mt-2 text-sm text-slate-700">
+              Archetype:{" "}
+              <span className="font-medium text-slate-950">
+                {reportCard.assessedArchetype}
+              </span>
+            </p>
+          </div>
+          <p className="text-sm text-slate-600">
+            Reviewer: {reportCard.reviewerMetadata.name}
+          </p>
+        </div>
+      </header>
+
+      <section aria-labelledby="dimensions-title" className="space-y-3">
+        <h3
+          id="dimensions-title"
+          className="text-lg font-semibold text-slate-950"
+        >
+          Dimensions
+        </h3>
+        <div className="grid gap-3 lg:grid-cols-2">
+          {reportCard.dimensionAssessments.map((assessment) => (
+            <DimensionCard key={assessment.dimension} assessment={assessment} />
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="findings-title" className="space-y-3">
+        <h3
+          id="findings-title"
+          className="text-lg font-semibold text-slate-950"
+        >
+          Findings
+        </h3>
+        <div className="space-y-2">
+          {reportCard.dimensionAssessments.flatMap((assessment) =>
+            assessment.findings.map((finding) => (
+              <FindingRow key={finding.id} finding={finding} />
+            )),
+          )}
+        </div>
+      </section>
+
+      <section aria-labelledby="caveats-title" className="space-y-3">
+        <h3 id="caveats-title" className="text-lg font-semibold text-slate-950">
+          Caveats And Missing Evidence
+        </h3>
+        {reportCard.caveats.length === 0 ? (
+          <p className="text-sm text-slate-600">No caveats were reported.</p>
+        ) : (
+          <div className="space-y-2">
+            {reportCard.caveats.map((caveat) => (
+              <CaveatRow key={caveat.id} caveat={caveat} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section aria-labelledby="evidence-title" className="space-y-3">
+        <h3
+          id="evidence-title"
+          className="text-lg font-semibold text-slate-950"
+        >
+          Evidence References
+        </h3>
+        <ul className="grid gap-2 lg:grid-cols-2">
+          {reportCard.evidenceReferences.map((reference) => (
+            <EvidenceReferenceItem key={reference.id} reference={reference} />
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="questions-title" className="space-y-3">
+        <h3
+          id="questions-title"
+          className="text-lg font-semibold text-slate-950"
+        >
+          Follow-Up Questions
+        </h3>
+        <ul className="space-y-2">
+          {reportCard.recommendedNextQuestions.map((question) => (
+            <li
+              key={question.id}
+              className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-800"
+            >
+              <p className="font-medium text-slate-950">{question.question}</p>
+              <p className="mt-1 text-slate-600">{question.rationale}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </article>
+  );
+}
+
+function DimensionCard({
+  assessment,
+}: {
+  readonly assessment: DimensionAssessment;
+}) {
+  return (
+    <section className="rounded-md border border-slate-200 bg-white p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="font-semibold text-slate-950">{assessment.title}</h4>
+        <span className="rounded border border-slate-300 px-2 py-1 text-xs font-medium uppercase text-slate-700">
+          {assessment.rating}
+        </span>
+      </div>
+      <p className="mt-3 text-sm leading-6 text-slate-700">
+        {assessment.summary}
+      </p>
+      <p className="mt-3 text-sm font-medium text-slate-900">
+        {assessment.confidence.level} confidence
+      </p>
+      <p className="mt-1 text-xs leading-5 text-slate-600">
+        {assessment.confidence.rationale}
+      </p>
+    </section>
+  );
+}
+
+function FindingRow({ finding }: { readonly finding: ReportFinding }) {
+  return (
+    <section className="rounded-md border border-slate-200 bg-white p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="font-medium text-slate-950">{finding.title}</h4>
+        <span className="text-xs font-medium uppercase text-slate-600">
+          {finding.severity}
+        </span>
+      </div>
+      <p className="mt-1 text-sm leading-6 text-slate-700">{finding.summary}</p>
+      <p className="mt-2 text-xs text-slate-600">
+        Evidence:{" "}
+        {finding.evidenceReferences.map((reference) => reference.id).join(", ")}
+      </p>
+    </section>
+  );
+}
+
+function CaveatRow({ caveat }: { readonly caveat: ReportCaveat }) {
+  return (
+    <section className="rounded-md border border-amber-200 bg-amber-50 p-3">
+      <h4 className="font-medium text-slate-950">{caveat.title}</h4>
+      <p className="mt-1 text-sm leading-6 text-slate-700">{caveat.summary}</p>
+      {caveat.missingEvidence.length > 0 ? (
+        <ul className="mt-2 list-inside list-disc text-sm text-slate-700">
+          {caveat.missingEvidence.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function EvidenceReferenceItem({
+  reference,
+}: {
+  readonly reference: EvidenceReference;
+}) {
+  return (
+    <li className="rounded-md border border-slate-200 bg-white p-3 text-sm">
+      <p className="font-medium text-slate-950">{reference.id}</p>
+      <p className="mt-1 text-slate-700">{reference.label}</p>
+      {reference.path === undefined ? null : (
+        <p className="mt-1 font-mono text-xs text-slate-600">
+          {reference.path}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function repositoryLabel(reportCard: ReportCard): string {
+  const owner = reportCard.repository.owner;
+  const ownerPrefix = owner === undefined ? "" : `${owner}/`;
+  const revision =
+    reportCard.repository.revision === undefined
+      ? ""
+      : ` @ ${reportCard.repository.revision}`;
+
+  return `${reportCard.repository.provider}:${ownerPrefix}${reportCard.repository.name}${revision}`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });


### PR DESCRIPTION
## Summary
- replace the static shell with a usable fixture analysis screen
- add reusable report card presentation components
- render dimensions, findings, confidence, caveats, missing evidence, evidence references, and follow-up questions
- update the foundational E2E to run the analysis workflow
- allow colocated `*.test.tsx` component tests in Vitest

## Validation
- `pnpm run ci`

Closes #31