### PR TITLE
feat(ui): build report dashboard parity view

### DIFF
--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -19,5 +19,7 @@ test("runs the repository analysis workflow", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "Caveats And Missing Evidence" }),
   ).toBeVisible();
-  await expect(page.getByText("evidence:test-file")).toBeVisible();
+  await expect(
+    page.getByLabel("Dimensions").getByText("evidence:test-file").first(),
+  ).toBeVisible();
 });

--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -4,6 +4,7 @@ import type {
   AnalyzeRepositoryReportCardResult,
   AnalyzeRepositoryResult,
 } from "../../../application/analyze-repository/analyze-repository";
+import { buildAnalyzeRepositoryResponse } from "../../../application/analyze-repository/analyze-repository-response";
 import { RepositorySourceError } from "../../../domain/repository/repository-source";
 import { handleAnalyzeRequest } from "./route";
 
@@ -87,19 +88,36 @@ const reportResult: AnalyzeRepositoryReportCardResult = {
     },
     languageCodeShapeMetrics: {
       summary: {
-        analyzedFileCount: 0,
-        sourceFileCount: 0,
-        testFileCount: 0,
+        analyzedFileCount: 2,
+        sourceFileCount: 1,
+        testFileCount: 1,
         documentationFileCount: 0,
         largeFileCount: 0,
         skippedFileCount: 0,
         unsupportedFileCount: 0,
-        totalTextLineCount: 0,
-        totalCodeLineCount: 0,
+        totalTextLineCount: 12,
+        totalCodeLineCount: 10,
         totalDeferredWorkMarkerCount: 0,
         totalBranchLikeTokenCount: 0,
       },
-      languageMix: [],
+      languageMix: [
+        {
+          language: "TypeScript",
+          extensions: [".ts"],
+          fileCount: 2,
+          sourceFileCount: 1,
+          textLineCount: 12,
+          codeLineCount: 10,
+          evidenceReferences: [
+            {
+              id: "language-code-shape:file:src/add.ts",
+              kind: "file",
+              label: "TypeScript file",
+              path: "src/add.ts",
+            },
+          ],
+        },
+      ],
       files: [],
       deferredWorkMarkers: [],
       branchLikeTokens: [],
@@ -162,9 +180,7 @@ describe("POST /api/analyze", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual({
-      reportCard: reportResult.reportCard,
-    });
+    expect(body).toEqual(buildAnalyzeRepositoryResponse(reportResult));
   });
 
   it("returns 400 for invalid request bodies", async () => {

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -7,6 +7,7 @@ import {
   type AnalyzeRepositoryInput,
   type AnalyzeRepositoryResult,
 } from "../../../application/analyze-repository/analyze-repository";
+import { buildAnalyzeRepositoryResponse } from "../../../application/analyze-repository/analyze-repository-response";
 import { LocalFixtureRepositorySource } from "../../../infrastructure/filesystem/local-fixture-repository-source";
 import { FakeReviewer } from "../../../infrastructure/reviewer/fake-reviewer";
 import {
@@ -87,9 +88,7 @@ export async function handleAnalyzeRequest(
       });
     }
 
-    return Response.json({
-      reportCard: result.reportCard,
-    });
+    return Response.json(buildAnalyzeRepositoryResponse(result));
   } catch (error) {
     if (error instanceof RepositorySourceError) {
       return repositorySourceErrorResponse(error);

--- a/src/application/analyze-repository/analyze-repository-response.ts
+++ b/src/application/analyze-repository/analyze-repository-response.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+import { ReportCardSchema } from "../../domain/report/report-card";
+import type { AnalyzeRepositoryReportCardResult } from "./analyze-repository";
+
+export const DashboardLanguageMixItemSchema = z
+  .object({
+    language: z.string().min(1),
+    fileCount: z.number().int().min(0),
+    sourceFileCount: z.number().int().min(0),
+    textLineCount: z.number().int().min(0),
+    codeLineCount: z.number().int().min(0),
+    percentOfCode: z.number().min(0).max(100),
+    evidenceReferenceIds: z.array(z.string().min(1)),
+  })
+  .strict();
+
+export type DashboardLanguageMixItem = z.infer<
+  typeof DashboardLanguageMixItemSchema
+>;
+
+export const DashboardCodeShapeSummarySchema = z
+  .object({
+    analyzedFileCount: z.number().int().min(0),
+    sourceFileCount: z.number().int().min(0),
+    testFileCount: z.number().int().min(0),
+    documentationFileCount: z.number().int().min(0),
+    largeFileCount: z.number().int().min(0),
+    skippedFileCount: z.number().int().min(0),
+    unsupportedFileCount: z.number().int().min(0),
+    totalTextLineCount: z.number().int().min(0),
+    totalCodeLineCount: z.number().int().min(0),
+    totalDeferredWorkMarkerCount: z.number().int().min(0),
+    totalBranchLikeTokenCount: z.number().int().min(0),
+  })
+  .strict();
+
+export type DashboardCodeShapeSummary = z.infer<
+  typeof DashboardCodeShapeSummarySchema
+>;
+
+export const DashboardInsightsSchema = z
+  .object({
+    evidenceSummary: z.string().min(1),
+    languageMix: z.array(DashboardLanguageMixItemSchema),
+    codeShapeSummary: DashboardCodeShapeSummarySchema,
+  })
+  .strict();
+
+export type DashboardInsights = z.infer<typeof DashboardInsightsSchema>;
+
+export const AnalyzeRepositoryResponseSchema = z
+  .object({
+    reportCard: ReportCardSchema,
+    dashboardInsights: DashboardInsightsSchema,
+  })
+  .strict();
+
+export type AnalyzeRepositoryResponse = z.infer<
+  typeof AnalyzeRepositoryResponseSchema
+>;
+
+export function buildAnalyzeRepositoryResponse(
+  result: AnalyzeRepositoryReportCardResult,
+): AnalyzeRepositoryResponse {
+  const codeShapeMetrics = result.evidenceBundle.languageCodeShapeMetrics;
+  const totalCodeLineCount = Math.max(
+    codeShapeMetrics.languageMix.reduce(
+      (total, item) => total + item.codeLineCount,
+      0,
+    ),
+    1,
+  );
+
+  return AnalyzeRepositoryResponseSchema.parse({
+    reportCard: result.reportCard,
+    dashboardInsights: {
+      evidenceSummary: result.evidenceBundle.evidenceSummary,
+      languageMix: codeShapeMetrics.languageMix.map((item) => ({
+        language: item.language,
+        fileCount: item.fileCount,
+        sourceFileCount: item.sourceFileCount,
+        textLineCount: item.textLineCount,
+        codeLineCount: item.codeLineCount,
+        percentOfCode: Math.round(
+          (item.codeLineCount / totalCodeLineCount) * 100,
+        ),
+        evidenceReferenceIds: item.evidenceReferences.map(
+          (reference) => reference.id,
+        ),
+      })),
+      codeShapeSummary: codeShapeMetrics.summary,
+    },
+  });
+}

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-import type { ReportCard } from "../../domain/report/report-card";
+import {
+  AnalyzeRepositoryResponseSchema,
+  type AnalyzeRepositoryResponse,
+} from "../../application/analyze-repository/analyze-repository-response";
 import { ReportCardView } from "./report-card-view";
 
 type AnalyzeState =
@@ -14,15 +17,60 @@ type AnalyzeState =
     }
   | {
       readonly kind: "loaded";
-      readonly reportCard: ReportCard;
+      readonly analysis: AnalyzeRepositoryResponse;
     }
   | {
       readonly kind: "error";
       readonly message: string;
     };
 
+type LoadingPhase = {
+  readonly title: string;
+  readonly detail: string;
+  readonly progress: number;
+};
+
+const loadingPhases: readonly [LoadingPhase, ...LoadingPhase[]] = [
+  {
+    title: "Collecting repository evidence",
+    detail: "Inventorying files, manifests, workflows, and omissions.",
+    progress: 28,
+  },
+  {
+    title: "Measuring code shape",
+    detail: "Summarizing language mix, code lines, tests, and caveats.",
+    progress: 52,
+  },
+  {
+    title: "Reviewing dimensions",
+    detail: "Combining deterministic evidence with reviewer assessment.",
+    progress: 76,
+  },
+  {
+    title: "Preparing report card",
+    detail: "Linking findings, confidence, caveats, and evidence references.",
+    progress: 92,
+  },
+];
+
 export function AnalyzeRepositoryPanel() {
   const [state, setState] = useState<AnalyzeState>({ kind: "idle" });
+  const [loadingPhaseIndex, setLoadingPhaseIndex] = useState(0);
+
+  useEffect(() => {
+    if (state.kind !== "loading") {
+      setLoadingPhaseIndex(0);
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setLoadingPhaseIndex((current) =>
+        Math.min(current + 1, loadingPhases.length - 1),
+      );
+    }, 1_200);
+
+    return () => window.clearInterval(intervalId);
+  }, [state.kind]);
 
   async function analyzeRepository() {
     setState({ kind: "loading" });
@@ -41,8 +89,9 @@ export function AnalyzeRepositoryPanel() {
       }),
     });
     const body: unknown = await response.json();
+    const parseResult = AnalyzeRepositoryResponseSchema.safeParse(body);
 
-    if (!response.ok || !isReportResponse(body)) {
+    if (!response.ok || !parseResult.success) {
       setState({
         kind: "error",
         message:
@@ -53,7 +102,7 @@ export function AnalyzeRepositoryPanel() {
 
     setState({
       kind: "loaded",
-      reportCard: body.reportCard,
+      analysis: parseResult.data,
     });
   }
 
@@ -89,7 +138,11 @@ export function AnalyzeRepositoryPanel() {
 
       <main className="min-w-0 rounded-md border border-slate-200 bg-slate-50 p-5">
         {state.kind === "loaded" ? (
-          <ReportCardView reportCard={state.reportCard} />
+          <ReportCardView analysis={state.analysis} />
+        ) : state.kind === "loading" ? (
+          <AnalysisLoadingState
+            phase={loadingPhases[loadingPhaseIndex] ?? loadingPhases[0]}
+          />
         ) : (
           <section className="flex min-h-[520px] items-center justify-center rounded-md border border-dashed border-slate-300 bg-white p-6 text-center">
             <div>
@@ -108,14 +161,27 @@ export function AnalyzeRepositoryPanel() {
   );
 }
 
-function isReportResponse(
-  value: unknown,
-): value is { readonly reportCard: ReportCard } {
+function AnalysisLoadingState({ phase }: { readonly phase: LoadingPhase }) {
   return (
-    typeof value === "object" &&
-    value !== null &&
-    "reportCard" in value &&
-    typeof value.reportCard === "object" &&
-    value.reportCard !== null
+    <section className="flex min-h-[520px] items-center justify-center rounded-md border border-dashed border-slate-300 bg-white p-6 text-center">
+      <div className="w-full max-w-md">
+        <p className="text-sm font-medium uppercase text-emerald-700">
+          Analysis in progress
+        </p>
+        <h2 className="mt-3 text-lg font-semibold text-slate-950">
+          {phase.title}
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-slate-700">{phase.detail}</p>
+        <div
+          className="mt-5 h-2 overflow-hidden rounded-full bg-slate-200"
+          aria-label={`Analysis ${phase.progress}% complete`}
+        >
+          <div
+            className="h-full rounded-full bg-emerald-600 transition-[width]"
+            style={{ width: `${phase.progress}%` }}
+          />
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/report/report-card-view.test.tsx
+++ b/src/components/report/report-card-view.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import type { AnalyzeRepositoryResponse } from "../../application/analyze-repository/analyze-repository-response";
 import type { ReportCard } from "../../domain/report/report-card";
 import { ReportCardView } from "./report-card-view";
 
@@ -95,17 +96,63 @@ const reportCard: ReportCard = {
   ],
 };
 
+const analysis: AnalyzeRepositoryResponse = {
+  reportCard,
+  dashboardInsights: {
+    evidenceSummary:
+      "Files analyzed: 3. Source files: 1. Test files: 1. Documentation files: 1.",
+    languageMix: [
+      {
+        language: "TypeScript",
+        fileCount: 2,
+        sourceFileCount: 1,
+        textLineCount: 16,
+        codeLineCount: 12,
+        percentOfCode: 80,
+        evidenceReferenceIds: ["language-code-shape:file:src/add.ts"],
+      },
+      {
+        language: "Markdown",
+        fileCount: 1,
+        sourceFileCount: 0,
+        textLineCount: 4,
+        codeLineCount: 3,
+        percentOfCode: 20,
+        evidenceReferenceIds: ["language-code-shape:file:README.md"],
+      },
+    ],
+    codeShapeSummary: {
+      analyzedFileCount: 3,
+      sourceFileCount: 1,
+      testFileCount: 1,
+      documentationFileCount: 1,
+      largeFileCount: 0,
+      skippedFileCount: 0,
+      unsupportedFileCount: 0,
+      totalTextLineCount: 20,
+      totalCodeLineCount: 15,
+      totalDeferredWorkMarkerCount: 0,
+      totalBranchLikeTokenCount: 1,
+    },
+  },
+};
+
 describe("ReportCardView", () => {
-  it("renders dimensions, confidence, findings, caveats, missing evidence, and evidence references", () => {
-    const html = renderToStaticMarkup(
-      <ReportCardView reportCard={reportCard} />,
-    );
+  it("renders dashboard summary, language mix, dimensions, findings, caveats, missing evidence, and evidence references", () => {
+    const html = renderToStaticMarkup(<ReportCardView analysis={analysis} />);
 
     expect(html).toContain("minimal-node-library");
     expect(html).toContain("library");
+    expect(html).toContain("Report overview");
+    expect(html).toContain("Language Mix");
+    expect(html).toContain("TypeScript");
+    expect(html).toContain("80% of code");
+    expect(html).toContain("Reviewer Notes");
+    expect(html).toContain("Dimensions");
     expect(html).toContain("Verifiability");
     expect(html).toContain("good");
     expect(html).toContain("high confidence");
+    expect(html).toContain("Dimension score");
     expect(html).toContain("Test depth");
     expect(html).toContain("Limited fixture evidence");
     expect(html).toContain("Release workflow history");
@@ -114,11 +161,32 @@ describe("ReportCardView", () => {
   });
 
   it("does not collapse the report into a single overall score", () => {
-    const html = renderToStaticMarkup(
-      <ReportCardView reportCard={reportCard} />,
-    );
+    const html = renderToStaticMarkup(<ReportCardView analysis={analysis} />);
 
     expect(html).not.toContain("Overall score");
     expect(html).not.toContain("Total score");
+  });
+
+  it("renders explicit empty states when language mix and caveats are absent", () => {
+    const html = renderToStaticMarkup(
+      <ReportCardView
+        analysis={{
+          ...analysis,
+          reportCard: {
+            ...reportCard,
+            caveats: [],
+          },
+          dashboardInsights: {
+            ...analysis.dashboardInsights,
+            languageMix: [],
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain(
+      "No language mix was available in the collected evidence.",
+    );
+    expect(html).toContain("No caveats were reported.");
   });
 });

--- a/src/components/report/report-card-view.tsx
+++ b/src/components/report/report-card-view.tsx
@@ -3,14 +3,49 @@ import type {
   ReportCard,
   ReportCaveat,
   ReportFinding,
+  ReportRating,
 } from "../../domain/report/report-card";
 import type { EvidenceReference } from "../../domain/shared/evidence-reference";
+import type {
+  AnalyzeRepositoryResponse,
+  DashboardLanguageMixItem,
+} from "../../application/analyze-repository/analyze-repository-response";
 
 export function ReportCardView({
-  reportCard,
+  analysis,
 }: {
-  readonly reportCard: ReportCard;
+  readonly analysis: AnalyzeRepositoryResponse;
 }) {
+  const reportCard = analysis.reportCard;
+  const findings = reportCard.dimensionAssessments.flatMap(
+    (assessment) => assessment.findings,
+  );
+  const strongestDimension = strongestAssessedDimension(
+    reportCard.dimensionAssessments,
+  );
+  const bigNumbers = [
+    {
+      label: "Dimensions",
+      value: String(reportCard.dimensionAssessments.length),
+      caption: "Assessed with reviewer confidence",
+    },
+    {
+      label: "Findings",
+      value: String(findings.length),
+      caption: "Linked to evidence references",
+    },
+    {
+      label: "Evidence",
+      value: String(reportCard.evidenceReferences.length),
+      caption: "References preserved for follow-up",
+    },
+    {
+      label: "Caveats",
+      value: String(reportCard.caveats.length),
+      caption: "Missing context stays visible",
+    },
+  ] as const;
+
   return (
     <article className="space-y-6" aria-labelledby="report-title">
       <header className="border-b border-slate-200 pb-5">
@@ -38,6 +73,71 @@ export function ReportCardView({
         </div>
       </header>
 
+      <section
+        aria-labelledby="overview-title"
+        className="grid gap-4 lg:grid-cols-[minmax(260px,0.9fr)_minmax(0,1.1fr)]"
+      >
+        <div className="rounded-md border border-slate-200 bg-white p-5">
+          <p className="text-sm font-medium uppercase text-emerald-700">
+            Report overview
+          </p>
+          <h3
+            id="overview-title"
+            className="mt-2 text-xl font-semibold text-slate-950"
+          >
+            {reportCard.assessedArchetype} quality assessment
+          </h3>
+          <p className="mt-4 text-sm leading-6 text-slate-700">
+            {analysis.dashboardInsights.evidenceSummary}
+          </p>
+          <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
+            <MetadataItem
+              label="Generated"
+              value={formatDateTime(reportCard.generatedAt)}
+            />
+            <MetadataItem
+              label="Scoring policy"
+              value={`${reportCard.scoringPolicy.name} ${reportCard.scoringPolicy.version}`}
+            />
+            <MetadataItem
+              label="Reviewer kind"
+              value={reportCard.reviewerMetadata.kind}
+            />
+            <MetadataItem
+              label="Strongest dimension"
+              value={strongestDimension?.title ?? "Not scored"}
+            />
+          </dl>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {bigNumbers.map((item) => (
+            <div
+              key={item.label}
+              className="rounded-md border border-slate-200 bg-white p-4"
+            >
+              <p className="text-sm font-medium text-slate-600">{item.label}</p>
+              <p className="mt-2 text-3xl font-semibold text-slate-950">
+                {item.value}
+              </p>
+              <p className="mt-1 text-sm leading-5 text-slate-600">
+                {item.caption}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+        <LanguageMixPanel
+          languageMix={analysis.dashboardInsights.languageMix}
+          totalCodeLineCount={
+            analysis.dashboardInsights.codeShapeSummary.totalCodeLineCount
+          }
+        />
+        <ReviewerNotesPanel findings={findings} />
+      </section>
+
       <section aria-labelledby="dimensions-title" className="space-y-3">
         <h3
           id="dimensions-title"
@@ -45,56 +145,20 @@ export function ReportCardView({
         >
           Dimensions
         </h3>
-        <div className="grid gap-3 lg:grid-cols-2">
+        <div className="space-y-3">
           {reportCard.dimensionAssessments.map((assessment) => (
-            <DimensionCard key={assessment.dimension} assessment={assessment} />
+            <DimensionPanel
+              key={assessment.dimension}
+              assessment={assessment}
+              caveats={reportCard.caveats}
+            />
           ))}
         </div>
       </section>
 
-      <section aria-labelledby="findings-title" className="space-y-3">
-        <h3
-          id="findings-title"
-          className="text-lg font-semibold text-slate-950"
-        >
-          Findings
-        </h3>
-        <div className="space-y-2">
-          {reportCard.dimensionAssessments.flatMap((assessment) =>
-            assessment.findings.map((finding) => (
-              <FindingRow key={finding.id} finding={finding} />
-            )),
-          )}
-        </div>
-      </section>
-
-      <section aria-labelledby="caveats-title" className="space-y-3">
-        <h3 id="caveats-title" className="text-lg font-semibold text-slate-950">
-          Caveats And Missing Evidence
-        </h3>
-        {reportCard.caveats.length === 0 ? (
-          <p className="text-sm text-slate-600">No caveats were reported.</p>
-        ) : (
-          <div className="space-y-2">
-            {reportCard.caveats.map((caveat) => (
-              <CaveatRow key={caveat.id} caveat={caveat} />
-            ))}
-          </div>
-        )}
-      </section>
-
-      <section aria-labelledby="evidence-title" className="space-y-3">
-        <h3
-          id="evidence-title"
-          className="text-lg font-semibold text-slate-950"
-        >
-          Evidence References
-        </h3>
-        <ul className="grid gap-2 lg:grid-cols-2">
-          {reportCard.evidenceReferences.map((reference) => (
-            <EvidenceReferenceItem key={reference.id} reference={reference} />
-          ))}
-        </ul>
+      <section className="grid gap-4 xl:grid-cols-2">
+        <CaveatsPanel caveats={reportCard.caveats} />
+        <EvidencePanel references={reportCard.evidenceReferences} />
       </section>
 
       <section aria-labelledby="questions-title" className="space-y-3">
@@ -104,7 +168,7 @@ export function ReportCardView({
         >
           Follow-Up Questions
         </h3>
-        <ul className="space-y-2">
+        <ul className="grid gap-2 lg:grid-cols-2">
           {reportCard.recommendedNextQuestions.map((question) => (
             <li
               key={question.id}
@@ -120,46 +184,298 @@ export function ReportCardView({
   );
 }
 
-function DimensionCard({
-  assessment,
+function MetadataItem({
+  label,
+  value,
 }: {
-  readonly assessment: DimensionAssessment;
+  readonly label: string;
+  readonly value: string;
 }) {
   return (
-    <section className="rounded-md border border-slate-200 bg-white p-4">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h4 className="font-semibold text-slate-950">{assessment.title}</h4>
-        <span className="rounded border border-slate-300 px-2 py-1 text-xs font-medium uppercase text-slate-700">
-          {assessment.rating}
-        </span>
+    <div>
+      <dt className="text-xs font-semibold uppercase text-slate-500">
+        {label}
+      </dt>
+      <dd className="mt-1 break-words text-slate-900">{value}</dd>
+    </div>
+  );
+}
+
+function LanguageMixPanel({
+  languageMix,
+  totalCodeLineCount,
+}: {
+  readonly languageMix: readonly DashboardLanguageMixItem[];
+  readonly totalCodeLineCount: number;
+}) {
+  return (
+    <section
+      aria-labelledby="language-mix-title"
+      className="rounded-md border border-slate-200 bg-white p-5"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium uppercase text-emerald-700">
+            Static evidence
+          </p>
+          <h3
+            id="language-mix-title"
+            className="mt-1 text-lg font-semibold text-slate-950"
+          >
+            Language Mix
+          </h3>
+        </div>
+        <p className="text-sm text-slate-600">
+          {formatNumber(totalCodeLineCount)} code lines
+        </p>
       </div>
-      <p className="mt-3 text-sm leading-6 text-slate-700">
-        {assessment.summary}
-      </p>
-      <p className="mt-3 text-sm font-medium text-slate-900">
-        {assessment.confidence.level} confidence
-      </p>
-      <p className="mt-1 text-xs leading-5 text-slate-600">
-        {assessment.confidence.rationale}
-      </p>
+
+      {languageMix.length === 0 ? (
+        <p className="mt-5 text-sm leading-6 text-slate-700">
+          No language mix was available in the collected evidence.
+        </p>
+      ) : (
+        <div className="mt-5 grid gap-4">
+          {languageMix.map((item, index) => (
+            <div key={item.language}>
+              <div className="flex items-center justify-between gap-3 text-sm">
+                <span className="font-medium text-slate-900">
+                  {item.language}
+                </span>
+                <span className="text-slate-600">
+                  {item.percentOfCode}% of code
+                </span>
+              </div>
+              <div className="mt-2 h-3 overflow-hidden rounded-full bg-slate-200">
+                <div
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${Math.max(item.percentOfCode, 3)}%`,
+                    backgroundColor: languageColor(index),
+                  }}
+                />
+              </div>
+              <p className="mt-2 text-xs text-slate-600">
+                {formatNumber(item.fileCount)} files,{" "}
+                {formatNumber(item.sourceFileCount)} source files,{" "}
+                {formatNumber(item.codeLineCount)} code lines
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
     </section>
   );
 }
 
-function FindingRow({ finding }: { readonly finding: ReportFinding }) {
+function ReviewerNotesPanel({
+  findings,
+}: {
+  readonly findings: readonly ReportFinding[];
+}) {
   return (
-    <section className="rounded-md border border-slate-200 bg-white p-3">
+    <section
+      aria-labelledby="reviewer-notes-title"
+      className="rounded-md border border-slate-200 bg-white p-5"
+    >
+      <p className="text-sm font-medium uppercase text-blue-700">
+        Reviewer assessment
+      </p>
+      <h3
+        id="reviewer-notes-title"
+        className="mt-1 text-lg font-semibold text-slate-950"
+      >
+        Reviewer Notes
+      </h3>
+      {findings.length === 0 ? (
+        <p className="mt-5 text-sm leading-6 text-slate-700">
+          No findings were reported by the reviewer.
+        </p>
+      ) : (
+        <div className="mt-5 divide-y divide-slate-200">
+          {findings.map((finding) => (
+            <FindingRow key={finding.id} finding={finding} compact />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DimensionPanel({
+  assessment,
+  caveats,
+}: {
+  readonly assessment: DimensionAssessment;
+  readonly caveats: readonly ReportCaveat[];
+}) {
+  const relevantCaveats = caveats.filter((caveat) =>
+    caveat.affectedDimensions.includes(assessment.dimension),
+  );
+
+  return (
+    <section className="rounded-md border border-slate-200 bg-white p-5">
+      <div className="grid gap-5 lg:grid-cols-[240px_minmax(0,1fr)]">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="text-lg font-semibold text-slate-950">
+              {assessment.title}
+            </h4>
+            <RatingBadge rating={assessment.rating} />
+          </div>
+          <ScoreStrip score={assessment.score} />
+          <p className="mt-4 text-sm font-medium text-slate-900">
+            {assessment.confidence.level} confidence
+          </p>
+          <p className="mt-1 text-xs leading-5 text-slate-600">
+            {assessment.confidence.rationale}
+          </p>
+        </div>
+
+        <div>
+          <p className="text-sm leading-6 text-slate-700">
+            {assessment.summary}
+          </p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            <MetricTile
+              label="Evidence"
+              value={String(assessment.evidenceReferences.length)}
+              detail="References for this dimension"
+            />
+            <MetricTile
+              label="Findings"
+              value={String(assessment.findings.length)}
+              detail="Reviewer observations"
+            />
+            <MetricTile
+              label="Caveats"
+              value={String(relevantCaveats.length)}
+              detail="Known missing context"
+            />
+          </div>
+
+          {assessment.findings.length === 0 ? null : (
+            <div className="mt-5 space-y-2">
+              {assessment.findings.map((finding) => (
+                <FindingRow key={finding.id} finding={finding} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ScoreStrip({ score }: { readonly score: number | undefined }) {
+  if (score === undefined) {
+    return (
+      <p className="mt-4 text-sm text-slate-600">
+        No numeric score assigned for this dimension.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-4" aria-label={`Dimension score ${score}`}>
+      <div className="flex items-end justify-between text-sm">
+        <span className="font-medium text-slate-700">Dimension score</span>
+        <span className="text-2xl font-semibold text-slate-950">{score}</span>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-200">
+        <div
+          className="h-full rounded-full bg-emerald-600"
+          style={{ width: `${score}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function RatingBadge({ rating }: { readonly rating: ReportRating }) {
+  return (
+    <span
+      className={`rounded border px-2 py-1 text-xs font-medium uppercase ${ratingStyle(
+        rating,
+      )}`}
+    >
+      {rating}
+    </span>
+  );
+}
+
+function MetricTile({
+  label,
+  value,
+  detail,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly detail: string;
+}) {
+  return (
+    <div className="border-t border-slate-200 pt-3">
+      <p className="text-xs font-semibold uppercase text-slate-500">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-slate-950">{value}</p>
+      <p className="mt-1 text-xs text-slate-600">{detail}</p>
+    </div>
+  );
+}
+
+function FindingRow({
+  finding,
+  compact = false,
+}: {
+  readonly finding: ReportFinding;
+  readonly compact?: boolean;
+}) {
+  return (
+    <section
+      className={
+        compact
+          ? "py-3 first:pt-0 last:pb-0"
+          : "rounded-md border border-slate-200 bg-slate-50 p-3"
+      }
+    >
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h4 className="font-medium text-slate-950">{finding.title}</h4>
-        <span className="text-xs font-medium uppercase text-slate-600">
+        <h5 className="font-medium text-slate-950">{finding.title}</h5>
+        <span
+          className={`rounded px-2 py-1 text-xs font-medium uppercase ${severityStyle(
+            finding.severity,
+          )}`}
+        >
           {finding.severity}
         </span>
       </div>
       <p className="mt-1 text-sm leading-6 text-slate-700">{finding.summary}</p>
       <p className="mt-2 text-xs text-slate-600">
-        Evidence:{" "}
-        {finding.evidenceReferences.map((reference) => reference.id).join(", ")}
+        Evidence: {referenceIds(finding.evidenceReferences)}
       </p>
+    </section>
+  );
+}
+
+function CaveatsPanel({
+  caveats,
+}: {
+  readonly caveats: readonly ReportCaveat[];
+}) {
+  return (
+    <section aria-labelledby="caveats-title" className="space-y-3">
+      <h3 id="caveats-title" className="text-lg font-semibold text-slate-950">
+        Caveats And Missing Evidence
+      </h3>
+      {caveats.length === 0 ? (
+        <p className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-600">
+          No caveats were reported.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {caveats.map((caveat) => (
+            <CaveatRow key={caveat.id} caveat={caveat} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }
@@ -180,6 +496,25 @@ function CaveatRow({ caveat }: { readonly caveat: ReportCaveat }) {
   );
 }
 
+function EvidencePanel({
+  references,
+}: {
+  readonly references: readonly EvidenceReference[];
+}) {
+  return (
+    <section aria-labelledby="evidence-title" className="space-y-3">
+      <h3 id="evidence-title" className="text-lg font-semibold text-slate-950">
+        Evidence References
+      </h3>
+      <ul className="grid gap-2">
+        {references.map((reference) => (
+          <EvidenceReferenceItem key={reference.id} reference={reference} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
 function EvidenceReferenceItem({
   reference,
 }: {
@@ -190,12 +525,24 @@ function EvidenceReferenceItem({
       <p className="font-medium text-slate-950">{reference.id}</p>
       <p className="mt-1 text-slate-700">{reference.label}</p>
       {reference.path === undefined ? null : (
-        <p className="mt-1 font-mono text-xs text-slate-600">
+        <p className="mt-1 break-all font-mono text-xs text-slate-600">
           {reference.path}
         </p>
       )}
     </li>
   );
+}
+
+function strongestAssessedDimension(
+  assessments: readonly DimensionAssessment[],
+): DimensionAssessment | undefined {
+  return assessments
+    .filter((assessment) => assessment.score !== undefined)
+    .toSorted((left, right) => {
+      const leftScore = left.score ?? 0;
+      const rightScore = right.score ?? 0;
+      return rightScore - leftScore;
+    })[0];
 }
 
 function repositoryLabel(reportCard: ReportCard): string {
@@ -207,4 +554,56 @@ function repositoryLabel(reportCard: ReportCard): string {
       : ` @ ${reportCard.repository.revision}`;
 
   return `${reportCard.repository.provider}:${ownerPrefix}${reportCard.repository.name}${revision}`;
+}
+
+function referenceIds(references: readonly EvidenceReference[]): string {
+  return references.map((reference) => reference.id).join(", ");
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function languageColor(index: number): string {
+  const colors = ["#047857", "#2563eb", "#d97706", "#be123c", "#7c3aed"];
+  return colors[index % colors.length] ?? "#047857";
+}
+
+function ratingStyle(rating: ReportRating): string {
+  switch (rating) {
+    case "excellent":
+      return "border-emerald-300 bg-emerald-50 text-emerald-800";
+    case "good":
+      return "border-blue-300 bg-blue-50 text-blue-800";
+    case "fair":
+      return "border-amber-300 bg-amber-50 text-amber-800";
+    case "weak":
+      return "border-orange-300 bg-orange-50 text-orange-800";
+    case "poor":
+      return "border-red-300 bg-red-50 text-red-800";
+    case "not-assessed":
+      return "border-slate-300 bg-slate-50 text-slate-700";
+  }
+}
+
+function severityStyle(severity: ReportFinding["severity"]): string {
+  switch (severity) {
+    case "info":
+      return "bg-slate-100 text-slate-700";
+    case "low":
+      return "bg-blue-100 text-blue-800";
+    case "medium":
+      return "bg-amber-100 text-amber-800";
+    case "high":
+      return "bg-orange-100 text-orange-800";
+    case "critical":
+      return "bg-red-100 text-red-800";
+  }
 }


### PR DESCRIPTION
## Scope
- Build the report dashboard parity slice for #73.
- Add a typed analyze response DTO for dashboard-specific language/code-shape insights.
- Render overview metadata, big numbers, language mix, reviewer notes, dimension panels, caveats, evidence references, and follow-up questions.

## Non-goals
- No chat UI or conversation persistence; those remain in #38/#74/#39.
- No scoring policy changes or single overall score.
- No live GitHub form changes in this PR.

## Verification
- pnpm test:e2e
- pnpm run ci
- Playwright desktop screenshot sanity check
- Playwright mobile screenshot sanity check

Closes #73