### PR TITLE
feat(chat): generate suggested follow-up questions

### DIFF
--- a/src/domain/chat/suggested-follow-up-question.test.ts
+++ b/src/domain/chat/suggested-follow-up-question.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  DimensionAssessment,
+  ReportFinding,
+  ReportCard,
+} from "../report/report-card";
+import type { EvidenceReference } from "../shared/evidence-reference";
+import { generateSuggestedFollowUpQuestions } from "./suggested-follow-up-question";
+
+const evidenceReference: EvidenceReference = {
+  id: "evidence:ci-workflow",
+  kind: "file",
+  label: "CI workflow",
+  path: ".github/workflows/ci.yml",
+};
+
+const operabilityAssessment: DimensionAssessment = {
+  dimension: "operability",
+  title: "Operability",
+  summary: "Release and runtime evidence is limited.",
+  rating: "not-assessed",
+  confidence: {
+    level: "low",
+    score: 0.2,
+    rationale: "No deployment or incident evidence was available.",
+  },
+  evidenceReferences: [evidenceReference],
+  findings: [],
+  caveatIds: ["caveat:operability:missing-evidence"],
+};
+
+const securityFinding: ReportFinding = {
+  id: "finding:security:risk:0",
+  dimension: "security",
+  severity: "high",
+  title: "Secret-shaped token requires review",
+  summary:
+    "A bounded scan found an access-key-shaped token without exposing the value.",
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "The finding has direct file evidence.",
+  },
+  evidenceReferences: [evidenceReference],
+};
+
+const securityAssessment: DimensionAssessment = {
+  dimension: "security",
+  title: "Security",
+  summary: "A secret-shaped token was found in a bounded scan.",
+  rating: "weak",
+  score: 45,
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "The finding has direct file evidence.",
+  },
+  evidenceReferences: [evidenceReference],
+  findings: [securityFinding],
+  caveatIds: [],
+};
+
+const baseReportCard: ReportCard = {
+  id: "report:repo-analyzer-green",
+  schemaVersion: "report-card.v1",
+  generatedAt: "2026-04-26T08:30:00-07:00",
+  scoringPolicy: {
+    name: "repo-analyzer-green scoring policy",
+    version: "0.1.0",
+  },
+  repository: {
+    provider: "github",
+    owner: "lightstrikelabs",
+    name: "repo-analyzer-green",
+    url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+    revision: "main",
+  },
+  assessedArchetype: "web-app",
+  reviewerMetadata: {
+    kind: "fake",
+    name: "Fixture reviewer",
+    reviewedAt: "2026-04-26T08:30:00-07:00",
+  },
+  evidenceReferences: [evidenceReference],
+  dimensionAssessments: [operabilityAssessment, securityAssessment],
+  caveats: [
+    {
+      id: "caveat:operability:missing-evidence",
+      title: "Missing operability evidence",
+      summary: "No deployment or incident evidence was collected.",
+      affectedDimensions: ["operability"],
+      missingEvidence: ["Deployment history", "Incident history"],
+    },
+  ],
+  recommendedNextQuestions: [],
+};
+
+describe("generateSuggestedFollowUpQuestions", () => {
+  it("generates targeted questions from low-confidence dimensions, caveats, and high-risk findings", () => {
+    const questions = generateSuggestedFollowUpQuestions(baseReportCard);
+
+    expect(questions).toEqual([
+      expect.objectContaining({
+        id: "suggested-question:dimension:operability:low-confidence",
+        target: {
+          kind: "dimension",
+          dimension: "operability",
+        },
+      }),
+      expect.objectContaining({
+        id: "suggested-question:finding:finding:security:risk:0",
+        target: {
+          kind: "finding",
+          findingId: "finding:security:risk:0",
+          dimension: "security",
+        },
+      }),
+      expect.objectContaining({
+        id: "suggested-question:caveat:caveat:operability:missing-evidence",
+        target: {
+          kind: "caveat",
+          caveatId: "caveat:operability:missing-evidence",
+        },
+      }),
+    ]);
+    expect(questions.map((question) => question.question).join(" ")).toContain(
+      "Operability",
+    );
+    expect(questions.map((question) => question.question).join(" ")).toContain(
+      "Secret-shaped token requires review",
+    );
+  });
+
+  it("does not generate caveat questions for report areas that are not assessed", () => {
+    const questions = generateSuggestedFollowUpQuestions({
+      ...baseReportCard,
+      caveats: [
+        {
+          id: "caveat:documentation:missing-evidence",
+          title: "Missing documentation evidence",
+          summary: "No docs evidence was collected.",
+          affectedDimensions: ["documentation"],
+          missingEvidence: ["README"],
+        },
+      ],
+    });
+
+    expect(
+      questions.some(
+        (question) =>
+          question.id ===
+          "suggested-question:caveat:caveat:documentation:missing-evidence",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns no questions when there is no low-confidence, high-risk, or caveated area", () => {
+    const questions = generateSuggestedFollowUpQuestions({
+      ...baseReportCard,
+      dimensionAssessments: [
+        {
+          ...securityAssessment,
+          findings: [
+            {
+              ...securityFinding,
+              severity: "low",
+            },
+          ],
+        },
+      ],
+      caveats: [],
+    });
+
+    expect(questions).toEqual([]);
+  });
+});

--- a/src/domain/chat/suggested-follow-up-question.ts
+++ b/src/domain/chat/suggested-follow-up-question.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportCaveat,
+  ReportDimensionKey,
+  ReportFinding,
+} from "../report/report-card";
+import { ConversationTargetSchema } from "./conversation";
+
+export const SuggestedQuestionSourceSchema = z.enum([
+  "low-confidence-dimension",
+  "high-risk-finding",
+  "caveat",
+]);
+
+export type SuggestedQuestionSource = z.infer<
+  typeof SuggestedQuestionSourceSchema
+>;
+
+export const SuggestedFollowUpQuestionSchema = z
+  .object({
+    id: z.string().min(1),
+    question: z.string().min(1),
+    rationale: z.string().min(1),
+    source: SuggestedQuestionSourceSchema,
+    target: ConversationTargetSchema,
+  })
+  .strict();
+
+export type SuggestedFollowUpQuestion = z.infer<
+  typeof SuggestedFollowUpQuestionSchema
+>;
+
+export function generateSuggestedFollowUpQuestions(
+  reportCard: ReportCard,
+): readonly SuggestedFollowUpQuestion[] {
+  const assessedDimensions = new Set(
+    reportCard.dimensionAssessments.map((assessment) => assessment.dimension),
+  );
+  const questions = [
+    ...reportCard.dimensionAssessments
+      .filter(isLowConfidenceDimension)
+      .map(questionForLowConfidenceDimension),
+    ...reportCard.dimensionAssessments.flatMap(questionForHighRiskFindings),
+    ...reportCard.caveats
+      .filter((caveat) =>
+        hasAssessedAffectedDimension(caveat, assessedDimensions),
+      )
+      .map(questionForCaveat),
+  ];
+
+  return questions.map((question) =>
+    SuggestedFollowUpQuestionSchema.parse(question),
+  );
+}
+
+function isLowConfidenceDimension(assessment: DimensionAssessment): boolean {
+  return (
+    assessment.confidence.level === "low" ||
+    assessment.rating === "not-assessed"
+  );
+}
+
+function questionForLowConfidenceDimension(
+  assessment: DimensionAssessment,
+): SuggestedFollowUpQuestion {
+  return {
+    id: `suggested-question:dimension:${assessment.dimension}:low-confidence`,
+    question: `What evidence would increase confidence in ${assessment.title}?`,
+    rationale: assessment.confidence.rationale,
+    source: "low-confidence-dimension",
+    target: {
+      kind: "dimension",
+      dimension: assessment.dimension,
+    },
+  };
+}
+
+function questionForHighRiskFindings(
+  assessment: DimensionAssessment,
+): readonly SuggestedFollowUpQuestion[] {
+  return assessment.findings
+    .filter(isHighRiskFinding)
+    .map((finding) =>
+      questionForHighRiskFinding(finding, assessment.dimension),
+    );
+}
+
+function isHighRiskFinding(finding: ReportFinding): boolean {
+  return finding.severity === "high" || finding.severity === "critical";
+}
+
+function questionForHighRiskFinding(
+  finding: ReportFinding,
+  dimension: ReportDimensionKey,
+): SuggestedFollowUpQuestion {
+  return {
+    id: `suggested-question:finding:${finding.id}`,
+    question: `What should be done first about ${finding.title}?`,
+    rationale: finding.summary,
+    source: "high-risk-finding",
+    target: {
+      kind: "finding",
+      findingId: finding.id,
+      dimension,
+    },
+  };
+}
+
+function hasAssessedAffectedDimension(
+  caveat: ReportCaveat,
+  assessedDimensions: ReadonlySet<ReportDimensionKey>,
+): boolean {
+  return caveat.affectedDimensions.some((dimension) =>
+    assessedDimensions.has(dimension),
+  );
+}
+
+function questionForCaveat(caveat: ReportCaveat): SuggestedFollowUpQuestion {
+  return {
+    id: `suggested-question:caveat:${caveat.id}`,
+    question: `What evidence is needed to resolve ${caveat.title}?`,
+    rationale: caveat.summary,
+    source: "caveat",
+    target: {
+      kind: "caveat",
+      caveatId: caveat.id,
+    },
+  };
+}


### PR DESCRIPTION
## Scope
- Add the #33 suggested follow-up question domain service.
- Generate targeted questions from low-confidence dimensions, high-risk findings, and caveats.
- Skip caveat questions when the referenced report area is not assessed.

## Non-goals
- No chat API or persistence.
- No UI rendering of generated suggestions yet.
- No LLM-generated question behavior in this slice.

## Verification
- pnpm test -- src/domain/chat/suggested-follow-up-question.test.ts
- pnpm run ci

Closes #33