### PR TITLE
feat(chat): resolve conversation targets

### DIFF
--- a/src/domain/chat/conversation-target-resolver.test.ts
+++ b/src/domain/chat/conversation-target-resolver.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportFinding,
+} from "../report/report-card";
+import type { EvidenceReference } from "../shared/evidence-reference";
+import { resolveConversationTarget } from "./conversation-target-resolver";
+
+const packageManifestReference: EvidenceReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+};
+
+const securityFinding: ReportFinding = {
+  id: "finding:security:risk:0",
+  dimension: "security",
+  severity: "high",
+  title: "Secret-shaped token requires review",
+  summary: "A bounded scan found an access-key-shaped token.",
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "Direct file evidence supports the finding.",
+  },
+  evidenceReferences: [packageManifestReference],
+};
+
+const securityAssessment: DimensionAssessment = {
+  dimension: "security",
+  title: "Security",
+  summary: "Security evidence has a high-risk finding.",
+  rating: "weak",
+  score: 45,
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "Direct file evidence supports the dimension.",
+  },
+  evidenceReferences: [packageManifestReference],
+  findings: [securityFinding],
+  caveatIds: ["caveat:security:manual-review"],
+};
+
+const reportCard: ReportCard = {
+  id: "report:repo-analyzer-green",
+  schemaVersion: "report-card.v1",
+  generatedAt: "2026-04-26T09:00:00-07:00",
+  scoringPolicy: {
+    name: "repo-analyzer-green scoring policy",
+    version: "0.1.0",
+  },
+  repository: {
+    provider: "github",
+    owner: "lightstrikelabs",
+    name: "repo-analyzer-green",
+    url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+    revision: "main",
+  },
+  assessedArchetype: "web-app",
+  reviewerMetadata: {
+    kind: "fake",
+    name: "Fixture reviewer",
+    reviewedAt: "2026-04-26T09:00:00-07:00",
+  },
+  evidenceReferences: [packageManifestReference],
+  dimensionAssessments: [securityAssessment],
+  caveats: [
+    {
+      id: "caveat:security:manual-review",
+      title: "Manual security review needed",
+      summary: "Secret-shaped tokens require human review.",
+      affectedDimensions: ["security"],
+      missingEvidence: ["Secret scanning result"],
+    },
+  ],
+  recommendedNextQuestions: [],
+};
+
+describe("resolveConversationTarget", () => {
+  it("resolves the full report target", () => {
+    expect(resolveConversationTarget(reportCard, { kind: "report" })).toEqual({
+      kind: "resolved",
+      target: {
+        kind: "report",
+      },
+    });
+  });
+
+  it("resolves dimensions, findings, caveats, and evidence references from report identifiers", () => {
+    expect(
+      resolveConversationTarget(reportCard, {
+        kind: "dimension",
+        dimension: "security",
+      }),
+    ).toEqual({
+      kind: "resolved",
+      target: {
+        kind: "dimension",
+        dimension: "security",
+      },
+    });
+    expect(
+      resolveConversationTarget(reportCard, {
+        kind: "finding",
+        findingId: "finding:security:risk:0",
+      }),
+    ).toEqual({
+      kind: "resolved",
+      target: {
+        kind: "finding",
+        findingId: "finding:security:risk:0",
+        dimension: "security",
+      },
+    });
+    expect(
+      resolveConversationTarget(reportCard, {
+        kind: "caveat",
+        caveatId: "caveat:security:manual-review",
+      }),
+    ).toEqual({
+      kind: "resolved",
+      target: {
+        kind: "caveat",
+        caveatId: "caveat:security:manual-review",
+      },
+    });
+    expect(
+      resolveConversationTarget(reportCard, {
+        kind: "evidence",
+        evidenceReferenceId: "evidence:package-json",
+      }),
+    ).toEqual({
+      kind: "resolved",
+      target: {
+        kind: "evidence",
+        evidenceReference: packageManifestReference,
+      },
+    });
+  });
+
+  it("rejects invalid target identifiers without manufacturing context", () => {
+    expect(
+      resolveConversationTarget(reportCard, {
+        kind: "finding",
+        findingId: "finding:missing",
+      }),
+    ).toEqual({
+      kind: "invalid-target",
+      reason: "finding-not-found",
+      targetId: "finding:missing",
+    });
+    expect(
+      resolveConversationTarget(reportCard, {
+        kind: "evidence",
+        evidenceReferenceId: "evidence:missing",
+      }),
+    ).toEqual({
+      kind: "invalid-target",
+      reason: "evidence-not-found",
+      targetId: "evidence:missing",
+    });
+  });
+});

--- a/src/domain/chat/conversation-target-resolver.ts
+++ b/src/domain/chat/conversation-target-resolver.ts
@@ -1,0 +1,170 @@
+import { z } from "zod";
+
+import type { ReportCard, ReportDimensionKey } from "../report/report-card";
+import { ReportDimensionKeySchema } from "../report/report-card";
+import { ConversationTargetSchema } from "./conversation";
+import type { ConversationTarget } from "./conversation";
+
+export const ConversationTargetSelectorSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("report"),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("dimension"),
+      dimension: ReportDimensionKeySchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("finding"),
+      findingId: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("caveat"),
+      caveatId: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("evidence"),
+      evidenceReferenceId: z.string().min(1),
+    })
+    .strict(),
+]);
+
+export type ConversationTargetSelector = z.infer<
+  typeof ConversationTargetSelectorSchema
+>;
+
+export type InvalidConversationTargetReason =
+  | "dimension-not-found"
+  | "finding-not-found"
+  | "caveat-not-found"
+  | "evidence-not-found";
+
+export type ResolveConversationTargetResult =
+  | {
+      readonly kind: "resolved";
+      readonly target: ConversationTarget;
+    }
+  | {
+      readonly kind: "invalid-target";
+      readonly reason: InvalidConversationTargetReason;
+      readonly targetId: string;
+    };
+
+export function resolveConversationTarget(
+  reportCard: ReportCard,
+  selector: ConversationTargetSelector,
+): ResolveConversationTargetResult {
+  switch (selector.kind) {
+    case "report":
+      return resolved({ kind: "report" });
+    case "dimension":
+      return resolveDimensionTarget(reportCard, selector.dimension);
+    case "finding":
+      return resolveFindingTarget(reportCard, selector.findingId);
+    case "caveat":
+      return resolveCaveatTarget(reportCard, selector.caveatId);
+    case "evidence":
+      return resolveEvidenceTarget(reportCard, selector.evidenceReferenceId);
+  }
+}
+
+function resolveDimensionTarget(
+  reportCard: ReportCard,
+  dimension: ReportDimensionKey,
+): ResolveConversationTargetResult {
+  const assessment = reportCard.dimensionAssessments.find(
+    (candidate) => candidate.dimension === dimension,
+  );
+
+  if (assessment === undefined) {
+    return invalid("dimension-not-found", dimension);
+  }
+
+  return resolved({
+    kind: "dimension",
+    dimension,
+  });
+}
+
+function resolveFindingTarget(
+  reportCard: ReportCard,
+  findingId: string,
+): ResolveConversationTargetResult {
+  for (const assessment of reportCard.dimensionAssessments) {
+    const finding = assessment.findings.find(
+      (candidate) => candidate.id === findingId,
+    );
+
+    if (finding !== undefined) {
+      return resolved({
+        kind: "finding",
+        findingId,
+        dimension: assessment.dimension,
+      });
+    }
+  }
+
+  return invalid("finding-not-found", findingId);
+}
+
+function resolveCaveatTarget(
+  reportCard: ReportCard,
+  caveatId: string,
+): ResolveConversationTargetResult {
+  const caveat = reportCard.caveats.find(
+    (candidate) => candidate.id === caveatId,
+  );
+
+  if (caveat === undefined) {
+    return invalid("caveat-not-found", caveatId);
+  }
+
+  return resolved({
+    kind: "caveat",
+    caveatId,
+  });
+}
+
+function resolveEvidenceTarget(
+  reportCard: ReportCard,
+  evidenceReferenceId: string,
+): ResolveConversationTargetResult {
+  const evidenceReference = reportCard.evidenceReferences.find(
+    (candidate) => candidate.id === evidenceReferenceId,
+  );
+
+  if (evidenceReference === undefined) {
+    return invalid("evidence-not-found", evidenceReferenceId);
+  }
+
+  return resolved({
+    kind: "evidence",
+    evidenceReference,
+  });
+}
+
+function resolved(target: ConversationTarget): ResolveConversationTargetResult {
+  return {
+    kind: "resolved",
+    target: ConversationTargetSchema.parse(target),
+  };
+}
+
+function invalid(
+  reason: InvalidConversationTargetReason,
+  targetId: string,
+): ResolveConversationTargetResult {
+  return {
+    kind: "invalid-target",
+    reason,
+    targetId,
+  };
+}


### PR DESCRIPTION
## Scope
- Add the #34 conversation target resolver.
- Resolve full report, dimension, finding, caveat, and evidence selectors against a report card.
- Return explicit invalid-target results for unknown identifiers.

## Non-goals
- No chat API route.
- No evidence retrieval implementation.
- No answer composition or UI behavior.

## Verification
- pnpm test -- src/domain/chat/conversation-target-resolver.test.ts
- pnpm run ci

Closes #34