### PR TITLE
feat(chat): retrieve follow-up evidence

### DIFF
--- a/src/domain/chat/evidence-retrieval.test.ts
+++ b/src/domain/chat/evidence-retrieval.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  retrieveEvidenceForFollowUp,
+  type EvidenceContentSource,
+} from "./evidence-retrieval";
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportFinding,
+} from "../report/report-card";
+import type { EvidenceReference } from "../shared/evidence-reference";
+
+const packageReference: EvidenceReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+  lineStart: 2,
+  lineEnd: 5,
+};
+
+const workflowReference: EvidenceReference = {
+  id: "evidence:ci-workflow",
+  kind: "file",
+  label: "CI workflow",
+  path: ".github/workflows/ci.yml",
+};
+
+const collectorReference: EvidenceReference = {
+  id: "evidence:collector",
+  kind: "collector",
+  label: "Evidence collector summary",
+  notes:
+    "File inventory and omissions were collected without reading generated output.",
+};
+
+const securityFinding: ReportFinding = {
+  id: "finding:security:risk:0",
+  dimension: "security",
+  severity: "high",
+  title: "Secret-shaped token requires review",
+  summary: "A bounded scan found a secret-shaped token.",
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "Direct evidence supports the finding.",
+  },
+  evidenceReferences: [packageReference],
+};
+
+const securityAssessment: DimensionAssessment = {
+  dimension: "security",
+  title: "Security",
+  summary: "Security has a high-risk finding.",
+  rating: "weak",
+  score: 45,
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "Direct evidence supports the dimension.",
+  },
+  evidenceReferences: [collectorReference],
+  findings: [securityFinding],
+  caveatIds: ["caveat:security:manual-review"],
+};
+
+const operabilityAssessment: DimensionAssessment = {
+  dimension: "operability",
+  title: "Operability",
+  summary: "CI evidence is present, but deployment history is missing.",
+  rating: "fair",
+  score: 64,
+  confidence: {
+    level: "medium",
+    score: 0.64,
+    rationale: "Workflow evidence is available.",
+  },
+  evidenceReferences: [workflowReference],
+  findings: [],
+  caveatIds: [],
+};
+
+const reportCard: ReportCard = {
+  id: "report:repo-analyzer-green",
+  schemaVersion: "report-card.v1",
+  generatedAt: "2026-04-26T09:30:00-07:00",
+  scoringPolicy: {
+    name: "repo-analyzer-green scoring policy",
+    version: "0.1.0",
+  },
+  repository: {
+    provider: "github",
+    owner: "lightstrikelabs",
+    name: "repo-analyzer-green",
+    url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+    revision: "main",
+  },
+  assessedArchetype: "web-app",
+  reviewerMetadata: {
+    kind: "fake",
+    name: "Fixture reviewer",
+    reviewedAt: "2026-04-26T09:30:00-07:00",
+  },
+  evidenceReferences: [packageReference, workflowReference, collectorReference],
+  dimensionAssessments: [securityAssessment, operabilityAssessment],
+  caveats: [
+    {
+      id: "caveat:security:manual-review",
+      title: "Manual security review needed",
+      summary: "Secret-shaped tokens require human review.",
+      affectedDimensions: ["security"],
+      missingEvidence: ["Secret scanning result"],
+    },
+  ],
+  recommendedNextQuestions: [],
+};
+
+const contentSource: EvidenceContentSource = {
+  readEvidence: async (reference) => {
+    if (reference.path === "package.json") {
+      return {
+        kind: "content",
+        text: [
+          "{",
+          '  "scripts": {',
+          '    "test": "vitest",',
+          '    "lint": "oxlint ."',
+          "  }",
+          "}",
+        ].join("\n"),
+      };
+    }
+
+    if (reference.path === ".github/workflows/ci.yml") {
+      return {
+        kind: "content",
+        text: [
+          "name: CI",
+          "jobs:",
+          "  quality:",
+          "    steps:",
+          "      - run: pnpm test",
+        ].join("\n"),
+      };
+    }
+
+    return {
+      kind: "missing",
+      reason: "not available",
+    };
+  },
+};
+
+describe("retrieveEvidenceForFollowUp", () => {
+  it("retrieves and ranks snippets connected to a finding target and question text", async () => {
+    const result = await retrieveEvidenceForFollowUp({
+      reportCard,
+      target: {
+        kind: "finding",
+        findingId: "finding:security:risk:0",
+        dimension: "security",
+      },
+      question: "Which package scripts should we review for secret risk?",
+      contentSource,
+    });
+
+    expect(result.snippets[0]).toMatchObject({
+      evidenceReference: packageReference,
+      source: "fresh-content",
+      targetRelevance: "finding",
+    });
+    expect(result.snippets[0]?.text).toContain('"test": "vitest"');
+    expect(result.snippets[0]?.rank).toBeGreaterThan(
+      result.snippets[1]?.rank ?? 0,
+    );
+  });
+
+  it("retrieves dimension evidence and related finding evidence for a dimension target", async () => {
+    const result = await retrieveEvidenceForFollowUp({
+      reportCard,
+      target: {
+        kind: "dimension",
+        dimension: "security",
+      },
+      question: "What evidence supports the security assessment?",
+      contentSource,
+    });
+
+    expect(
+      result.snippets.map((snippet) => snippet.evidenceReference.id),
+    ).toEqual(["evidence:collector", "evidence:package-json"]);
+    expect(result.snippets[0]?.source).toBe("saved-metadata");
+    expect(result.snippets[0]?.text).toContain("File inventory");
+  });
+
+  it("uses saved metadata when fresh repository content is unavailable", async () => {
+    const result = await retrieveEvidenceForFollowUp({
+      reportCard,
+      target: {
+        kind: "evidence",
+        evidenceReference: workflowReference,
+      },
+      question: "How does CI run tests?",
+      contentSource: {
+        readEvidence: async () => ({
+          kind: "missing",
+          reason: "repository snapshot was not saved",
+        }),
+      },
+    });
+
+    expect(result.snippets).toEqual([
+      expect.objectContaining({
+        evidenceReference: workflowReference,
+        source: "saved-metadata",
+        text: "CI workflow\n.github/workflows/ci.yml",
+        targetRelevance: "evidence",
+      }),
+    ]);
+    expect(result.missingContext).toEqual([
+      {
+        evidenceReference: workflowReference,
+        reason: "repository snapshot was not saved",
+      },
+    ]);
+  });
+
+  it("falls back to report evidence for whole-report questions", async () => {
+    const result = await retrieveEvidenceForFollowUp({
+      reportCard,
+      target: {
+        kind: "report",
+      },
+      question: "What should we inspect first?",
+      contentSource,
+    });
+
+    expect(result.snippets).toHaveLength(3);
+    expect(
+      result.snippets.map((snippet) => snippet.evidenceReference.id),
+    ).toContain("evidence:ci-workflow");
+  });
+});

--- a/src/domain/chat/evidence-retrieval.ts
+++ b/src/domain/chat/evidence-retrieval.ts
@@ -1,0 +1,311 @@
+import type { ConversationTarget } from "./conversation";
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportFinding,
+} from "../report/report-card";
+import type { EvidenceReference } from "../shared/evidence-reference";
+
+export type EvidenceContentResult =
+  | {
+      readonly kind: "content";
+      readonly text: string;
+    }
+  | {
+      readonly kind: "missing";
+      readonly reason: string;
+    };
+
+export interface EvidenceContentSource {
+  readEvidence(reference: EvidenceReference): Promise<EvidenceContentResult>;
+}
+
+export type RetrievedEvidenceSource = "fresh-content" | "saved-metadata";
+
+export type EvidenceTargetRelevance =
+  | "report"
+  | "dimension"
+  | "finding"
+  | "caveat"
+  | "evidence";
+
+export type RetrievedEvidenceSnippet = {
+  readonly evidenceReference: EvidenceReference;
+  readonly text: string;
+  readonly source: RetrievedEvidenceSource;
+  readonly targetRelevance: EvidenceTargetRelevance;
+  readonly rank: number;
+  readonly lineStart?: number;
+  readonly lineEnd?: number;
+};
+
+export type MissingEvidenceContext = {
+  readonly evidenceReference: EvidenceReference;
+  readonly reason: string;
+};
+
+export type RetrieveEvidenceForFollowUpInput = {
+  readonly reportCard: ReportCard;
+  readonly target: ConversationTarget;
+  readonly question: string;
+  readonly contentSource?: EvidenceContentSource;
+  readonly maxSnippets?: number;
+};
+
+export type RetrieveEvidenceForFollowUpResult = {
+  readonly snippets: readonly RetrievedEvidenceSnippet[];
+  readonly missingContext: readonly MissingEvidenceContext[];
+};
+
+type CandidateEvidence = {
+  readonly evidenceReference: EvidenceReference;
+  readonly targetRelevance: EvidenceTargetRelevance;
+  readonly priority: number;
+};
+
+const defaultMaxSnippets = 6;
+
+export async function retrieveEvidenceForFollowUp(
+  input: RetrieveEvidenceForFollowUpInput,
+): Promise<RetrieveEvidenceForFollowUpResult> {
+  const candidates = uniqueCandidates(candidatesForTarget(input));
+  const missingContext: MissingEvidenceContext[] = [];
+  const snippets = await Promise.all(
+    candidates.map(async (candidate) => {
+      const freshContent = await readFreshContent(
+        candidate.evidenceReference,
+        input.contentSource,
+      );
+
+      if (freshContent.kind === "missing") {
+        missingContext.push({
+          evidenceReference: candidate.evidenceReference,
+          reason: freshContent.reason,
+        });
+      }
+
+      return snippetForCandidate({
+        candidate,
+        question: input.question,
+        freshContent:
+          freshContent.kind === "content" ? freshContent.text : undefined,
+      });
+    }),
+  );
+
+  return {
+    snippets: snippets
+      .toSorted((left, right) => right.rank - left.rank)
+      .slice(0, input.maxSnippets ?? defaultMaxSnippets),
+    missingContext,
+  };
+}
+
+function candidatesForTarget(
+  input: RetrieveEvidenceForFollowUpInput,
+): readonly CandidateEvidence[] {
+  switch (input.target.kind) {
+    case "report":
+      return input.reportCard.evidenceReferences.map((reference) => ({
+        evidenceReference: reference,
+        targetRelevance: "report",
+        priority: 20,
+      }));
+    case "dimension":
+      return candidatesForDimension(input.reportCard, input.target.dimension);
+    case "finding":
+      return candidatesForFinding(input.reportCard, input.target.findingId);
+    case "caveat":
+      return candidatesForCaveat(input.reportCard, input.target.caveatId);
+    case "evidence":
+      return [
+        {
+          evidenceReference: input.target.evidenceReference,
+          targetRelevance: "evidence",
+          priority: 100,
+        },
+      ];
+  }
+}
+
+function candidatesForDimension(
+  reportCard: ReportCard,
+  dimension: DimensionAssessment["dimension"],
+): readonly CandidateEvidence[] {
+  const assessment = reportCard.dimensionAssessments.find(
+    (candidate) => candidate.dimension === dimension,
+  );
+
+  if (assessment === undefined) {
+    return [];
+  }
+
+  return [
+    ...assessment.evidenceReferences.map((reference) => ({
+      evidenceReference: reference,
+      targetRelevance: "dimension" as const,
+      priority: 90,
+    })),
+    ...assessment.findings.flatMap((finding) =>
+      finding.evidenceReferences.map((reference) => ({
+        evidenceReference: reference,
+        targetRelevance: "finding" as const,
+        priority: 70,
+      })),
+    ),
+  ];
+}
+
+function candidatesForFinding(
+  reportCard: ReportCard,
+  findingId: string,
+): readonly CandidateEvidence[] {
+  const finding = findReportFinding(reportCard, findingId);
+
+  if (finding === undefined) {
+    return [];
+  }
+
+  return finding.evidenceReferences.map((reference) => ({
+    evidenceReference: reference,
+    targetRelevance: "finding",
+    priority: 100,
+  }));
+}
+
+function candidatesForCaveat(
+  reportCard: ReportCard,
+  caveatId: string,
+): readonly CandidateEvidence[] {
+  const caveat = reportCard.caveats.find(
+    (candidate) => candidate.id === caveatId,
+  );
+
+  if (caveat === undefined) {
+    return [];
+  }
+
+  return reportCard.dimensionAssessments
+    .filter((assessment) =>
+      caveat.affectedDimensions.includes(assessment.dimension),
+    )
+    .flatMap((assessment) =>
+      assessment.evidenceReferences.map((reference) => ({
+        evidenceReference: reference,
+        targetRelevance: "caveat" as const,
+        priority: 80,
+      })),
+    );
+}
+
+function findReportFinding(
+  reportCard: ReportCard,
+  findingId: string,
+): ReportFinding | undefined {
+  for (const assessment of reportCard.dimensionAssessments) {
+    const finding = assessment.findings.find(
+      (candidate) => candidate.id === findingId,
+    );
+
+    if (finding !== undefined) {
+      return finding;
+    }
+  }
+
+  return undefined;
+}
+
+async function readFreshContent(
+  reference: EvidenceReference,
+  contentSource: EvidenceContentSource | undefined,
+): Promise<EvidenceContentResult> {
+  if (contentSource === undefined || reference.kind !== "file") {
+    return {
+      kind: "missing",
+      reason: "fresh repository content source was not provided",
+    };
+  }
+
+  return contentSource.readEvidence(reference);
+}
+
+function snippetForCandidate(input: {
+  readonly candidate: CandidateEvidence;
+  readonly question: string;
+  readonly freshContent: string | undefined;
+}): RetrievedEvidenceSnippet {
+  const text =
+    input.freshContent === undefined
+      ? metadataTextFor(input.candidate.evidenceReference)
+      : snippetTextFor(input.candidate.evidenceReference, input.freshContent);
+  const questionScore = questionMatchScore(input.question, text);
+
+  return {
+    evidenceReference: input.candidate.evidenceReference,
+    text,
+    source:
+      input.freshContent === undefined ? "saved-metadata" : "fresh-content",
+    targetRelevance: input.candidate.targetRelevance,
+    rank: input.candidate.priority + questionScore,
+    ...(input.candidate.evidenceReference.lineStart === undefined
+      ? {}
+      : { lineStart: input.candidate.evidenceReference.lineStart }),
+    ...(input.candidate.evidenceReference.lineEnd === undefined
+      ? {}
+      : { lineEnd: input.candidate.evidenceReference.lineEnd }),
+  };
+}
+
+function snippetTextFor(reference: EvidenceReference, text: string): string {
+  const lines = text.split(/\r?\n/);
+
+  if (reference.lineStart !== undefined) {
+    const startIndex = reference.lineStart - 1;
+    const endIndex = reference.lineEnd ?? reference.lineStart;
+    return lines.slice(startIndex, endIndex).join("\n");
+  }
+
+  return lines.slice(0, 12).join("\n");
+}
+
+function metadataTextFor(reference: EvidenceReference): string {
+  return [reference.label, reference.path, reference.notes]
+    .filter(isDefined)
+    .join("\n");
+}
+
+function questionMatchScore(question: string, text: string): number {
+  const haystack = text.toLocaleLowerCase();
+
+  return tokensFor(question).reduce(
+    (score, token) => score + (haystack.includes(token) ? 5 : 0),
+    0,
+  );
+}
+
+function tokensFor(text: string): readonly string[] {
+  return text
+    .toLocaleLowerCase()
+    .split(/[^a-z0-9]+/u)
+    .filter((token) => token.length >= 4);
+}
+
+function uniqueCandidates(
+  candidates: readonly CandidateEvidence[],
+): readonly CandidateEvidence[] {
+  const byId = new Map<string, CandidateEvidence>();
+
+  for (const candidate of candidates) {
+    const existing = byId.get(candidate.evidenceReference.id);
+
+    if (existing === undefined || candidate.priority > existing.priority) {
+      byId.set(candidate.evidenceReference.id, candidate);
+    }
+  }
+
+  return [...byId.values()];
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}


### PR DESCRIPTION
## Scope
- Add the #35 follow-up evidence retrieval service.
- Retrieve target-aware snippets for report, dimension, finding, caveat, and evidence targets.
- Rank snippets with target priority and question-token matches.
- Preserve evidence references and missing-context records.
- Support fresh repository content through a small content-source port with saved metadata fallback.

## Non-goals
- No chat answer contract.
- No chat API route or UI.
- No repository infrastructure adapter wiring yet.

## Verification
- pnpm test -- src/domain/chat/evidence-retrieval.test.ts
- pnpm run ci

Closes #35