### PR TITLE
feat(chat): define answer contract

### DIFF
--- a/src/domain/chat/chat-answer.test.ts
+++ b/src/domain/chat/chat-answer.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ChatAnswerContractSchema,
+  ChatAnswerSchema,
+  ChatAnswerSchemaVersion,
+} from "./chat-answer";
+
+const evidenceReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+  lineStart: 1,
+  lineEnd: 20,
+} as const;
+
+describe("chat answer contract", () => {
+  it("parses an evidence-backed answer with claims, assumptions, caveats, citations, and next questions", () => {
+    const parsed = ChatAnswerSchema.parse({
+      schemaVersion: ChatAnswerSchemaVersion,
+      status: "answered",
+      summary:
+        "The package manifest shows test and lint scripts, but release evidence is not available.",
+      evidenceBackedClaims: [
+        {
+          claim: "package.json defines test and lint scripts.",
+          citations: [
+            {
+              evidenceReference,
+              quote: '"test": "vitest"',
+            },
+          ],
+        },
+      ],
+      assumptions: [
+        {
+          statement:
+            "Release automation may be manual because no workflow evidence was retrieved.",
+          basis: "No release workflow snippet was available.",
+        },
+      ],
+      caveats: [
+        {
+          summary:
+            "This answer cannot verify whether CI passes on every branch.",
+          missingEvidence: ["Branch protection settings"],
+        },
+      ],
+      suggestedNextQuestions: [
+        {
+          question: "Where is release automation configured?",
+          rationale: "Release evidence was missing from retrieved context.",
+        },
+      ],
+    });
+
+    expect(parsed.status).toBe("answered");
+    if (parsed.status === "answered") {
+      expect(parsed.evidenceBackedClaims[0]?.citations[0]?.quote).toContain(
+        "vitest",
+      );
+      expect(parsed.assumptions[0]?.statement).toContain("Release automation");
+      expect(parsed.caveats[0]?.missingEvidence).toEqual([
+        "Branch protection settings",
+      ]);
+    }
+  });
+
+  it("rejects uncited file-specific claims", () => {
+    const result = ChatAnswerSchema.safeParse({
+      schemaVersion: ChatAnswerSchemaVersion,
+      status: "answered",
+      summary: "The repository has a package manifest.",
+      evidenceBackedClaims: [
+        {
+          claim: "package.json defines a test script.",
+          citations: [],
+        },
+      ],
+      assumptions: [],
+      caveats: [],
+      suggestedNextQuestions: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("supports explicit insufficient-context responses", () => {
+    const parsed = ChatAnswerSchema.parse({
+      schemaVersion: ChatAnswerSchemaVersion,
+      status: "insufficient-context",
+      summary:
+        "The retrieved evidence does not include deployment or incident history.",
+      missingContext: [
+        {
+          reason: "No deployment workflow evidence was retrieved.",
+          requestedEvidence: "Deployment workflow",
+        },
+      ],
+      suggestedNextQuestions: [
+        {
+          question: "Can you provide deployment workflow evidence?",
+          rationale: "The current answer cannot verify release readiness.",
+        },
+      ],
+    });
+
+    expect(parsed.status).toBe("insufficient-context");
+    if (parsed.status === "insufficient-context") {
+      expect(parsed.missingContext[0]?.requestedEvidence).toBe(
+        "Deployment workflow",
+      );
+    }
+  });
+
+  it("keeps provider metadata outside the answer payload", () => {
+    const parsed = ChatAnswerContractSchema.parse({
+      answer: {
+        schemaVersion: ChatAnswerSchemaVersion,
+        status: "answered",
+        summary: "The cited package manifest includes a test script.",
+        evidenceBackedClaims: [
+          {
+            claim: "package.json defines a test script.",
+            citations: [
+              {
+                evidenceReference,
+              },
+            ],
+          },
+        ],
+        assumptions: [],
+        caveats: [],
+        suggestedNextQuestions: [],
+      },
+      metadata: {
+        provider: "openrouter",
+        modelName: "anthropic/claude-sonnet-4.5",
+        modelVersion: "2026-04",
+        responseId: "chatcmpl_fixture",
+        generatedAt: "2026-04-26T10:00:00-07:00",
+      },
+    });
+
+    expect(parsed.answer).not.toHaveProperty("metadata");
+    expect(parsed.metadata).toBeDefined();
+    if (parsed.metadata !== undefined) {
+      expect(parsed.metadata.provider).toBe("openrouter");
+    }
+  });
+});

--- a/src/domain/chat/chat-answer.ts
+++ b/src/domain/chat/chat-answer.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import { ChatAssumptionSchema } from "./conversation";
+import { EvidenceReferenceSchema } from "../shared/evidence-reference";
+
+export const ChatAnswerSchemaVersion = "chat-answer.v1";
+
+export const ChatAnswerCitationSchema = z
+  .object({
+    evidenceReference: EvidenceReferenceSchema,
+    quote: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type ChatAnswerCitation = z.infer<typeof ChatAnswerCitationSchema>;
+
+export const EvidenceBackedClaimSchema = z
+  .object({
+    claim: z.string().min(1),
+    citations: z.array(ChatAnswerCitationSchema).default([]),
+  })
+  .strict()
+  .refine((claim) => claim.citations.length > 0, {
+    message: "Evidence-backed claims must include at least one citation.",
+    path: ["citations"],
+  });
+
+export type EvidenceBackedClaim = z.infer<typeof EvidenceBackedClaimSchema>;
+
+export const ChatAnswerCaveatSchema = z
+  .object({
+    summary: z.string().min(1),
+    missingEvidence: z.array(z.string().min(1)).default([]),
+  })
+  .strict();
+
+export type ChatAnswerCaveat = z.infer<typeof ChatAnswerCaveatSchema>;
+
+export const ChatAnswerSuggestedQuestionSchema = z
+  .object({
+    question: z.string().min(1),
+    rationale: z.string().min(1),
+  })
+  .strict();
+
+export type ChatAnswerSuggestedQuestion = z.infer<
+  typeof ChatAnswerSuggestedQuestionSchema
+>;
+
+export const ChatAnswerMissingContextSchema = z
+  .object({
+    reason: z.string().min(1),
+    requestedEvidence: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type ChatAnswerMissingContext = z.infer<
+  typeof ChatAnswerMissingContextSchema
+>;
+
+export const AnsweredChatAnswerSchema = z
+  .object({
+    schemaVersion: z.literal(ChatAnswerSchemaVersion),
+    status: z.literal("answered"),
+    summary: z.string().min(1),
+    evidenceBackedClaims: z.array(EvidenceBackedClaimSchema).min(1),
+    assumptions: z.array(ChatAssumptionSchema).default([]),
+    caveats: z.array(ChatAnswerCaveatSchema).default([]),
+    suggestedNextQuestions: z
+      .array(ChatAnswerSuggestedQuestionSchema)
+      .default([]),
+  })
+  .strict();
+
+export type AnsweredChatAnswer = z.infer<typeof AnsweredChatAnswerSchema>;
+
+export const InsufficientContextChatAnswerSchema = z
+  .object({
+    schemaVersion: z.literal(ChatAnswerSchemaVersion),
+    status: z.literal("insufficient-context"),
+    summary: z.string().min(1),
+    missingContext: z.array(ChatAnswerMissingContextSchema).min(1),
+    suggestedNextQuestions: z
+      .array(ChatAnswerSuggestedQuestionSchema)
+      .default([]),
+  })
+  .strict();
+
+export type InsufficientContextChatAnswer = z.infer<
+  typeof InsufficientContextChatAnswerSchema
+>;
+
+export const ChatAnswerSchema = z.discriminatedUnion("status", [
+  AnsweredChatAnswerSchema,
+  InsufficientContextChatAnswerSchema,
+]);
+
+export type ChatAnswer = z.infer<typeof ChatAnswerSchema>;
+
+export const ChatAnswerMetadataSchema = z
+  .object({
+    provider: z.string().min(1),
+    modelName: z.string().min(1),
+    modelVersion: z.string().min(1).optional(),
+    responseId: z.string().min(1).optional(),
+    generatedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export type ChatAnswerMetadata = z.infer<typeof ChatAnswerMetadataSchema>;
+
+export const ChatAnswerContractSchema = z
+  .object({
+    answer: ChatAnswerSchema,
+    metadata: ChatAnswerMetadataSchema.optional(),
+  })
+  .strict();
+
+export type ChatAnswerContract = z.infer<typeof ChatAnswerContractSchema>;


### PR DESCRIPTION
## Scope
- Add the #37 structured chat answer contract.
- Separate answered and insufficient-context response states.
- Model evidence-backed claims, citations, assumptions, caveats, suggested next questions, and missing context.
- Keep provider/model metadata outside the answer payload.

## Non-goals
- No chat application service.
- No provider adapter or prompt contract.
- No UI rendering.

## Verification
- pnpm test -- src/domain/chat/chat-answer.test.ts
- pnpm run ci

Closes #37