### PR TITLE
feat(chat): implement follow-up chat service

### DIFF
--- a/src/application/follow-up-chat/follow-up-chat.test.ts
+++ b/src/application/follow-up-chat/follow-up-chat.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "vitest";
+
+import { ChatAnswerSchemaVersion } from "../../domain/chat/chat-answer";
+import type { ChatAnswerContract } from "../../domain/chat/chat-answer";
+import type { Conversation } from "../../domain/chat/conversation";
+import type { ChatReviewer, ConversationRepository } from "./follow-up-chat";
+import {
+  continueFollowUpConversation,
+  startFollowUpConversation,
+} from "./follow-up-chat";
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportFinding,
+} from "../../domain/report/report-card";
+import type { EvidenceReference } from "../../domain/shared/evidence-reference";
+
+const evidenceReference: EvidenceReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+  lineStart: 1,
+  lineEnd: 4,
+};
+
+const securityFinding: ReportFinding = {
+  id: "finding:security:risk:0",
+  dimension: "security",
+  severity: "high",
+  title: "Package script review",
+  summary: "Package scripts should be reviewed before release.",
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "Direct package manifest evidence supports the finding.",
+  },
+  evidenceReferences: [evidenceReference],
+};
+
+const securityAssessment: DimensionAssessment = {
+  dimension: "security",
+  title: "Security",
+  summary: "Security has a script review risk.",
+  rating: "weak",
+  score: 45,
+  confidence: {
+    level: "high",
+    score: 0.9,
+    rationale: "Direct package manifest evidence supports the assessment.",
+  },
+  evidenceReferences: [evidenceReference],
+  findings: [securityFinding],
+  caveatIds: [],
+};
+
+const reportCard: ReportCard = {
+  id: "report:repo-analyzer-green",
+  schemaVersion: "report-card.v1",
+  generatedAt: "2026-04-26T10:20:00-07:00",
+  scoringPolicy: {
+    name: "repo-analyzer-green scoring policy",
+    version: "0.1.0",
+  },
+  repository: {
+    provider: "github",
+    owner: "lightstrikelabs",
+    name: "repo-analyzer-green",
+    url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+    revision: "main",
+  },
+  assessedArchetype: "web-app",
+  reviewerMetadata: {
+    kind: "fake",
+    name: "Fixture reviewer",
+    reviewedAt: "2026-04-26T10:20:00-07:00",
+  },
+  evidenceReferences: [evidenceReference],
+  dimensionAssessments: [securityAssessment],
+  caveats: [],
+  recommendedNextQuestions: [],
+};
+
+describe("follow-up chat application service", () => {
+  it("starts a conversation from a report target, retrieves evidence, answers, and stores state", async () => {
+    const repository = new InMemoryConversationRepository();
+    const reviewer = new FakeChatReviewer(answeredContract());
+
+    const result = await startFollowUpConversation(
+      {
+        reportCard,
+        targetSelector: {
+          kind: "finding",
+          findingId: "finding:security:risk:0",
+        },
+        question: "Which package script should we inspect?",
+      },
+      dependencies({ repository, reviewer }),
+    );
+
+    expect(result.kind).toBe("conversation");
+    if (result.kind === "conversation") {
+      expect(result.conversation.target).toEqual({
+        kind: "finding",
+        findingId: "finding:security:risk:0",
+        dimension: "security",
+      });
+      expect(result.conversation.messages).toHaveLength(2);
+      expect(result.conversation.messages[0]).toMatchObject({
+        role: "user",
+        content: "Which package script should we inspect?",
+      });
+      expect(result.conversation.messages[1]).toMatchObject({
+        role: "assistant",
+        content: "The package manifest includes a test script.",
+        citations: [
+          {
+            evidenceReference,
+            relevance: "Evidence-backed claim",
+          },
+        ],
+        modelMetadata: {
+          provider: "fixture-provider",
+          modelName: "fixture-model",
+        },
+      });
+      expect(reviewer.requests[0]?.evidence.snippets[0]?.text).toContain(
+        '"test": "vitest"',
+      );
+      await expect(repository.get(result.conversation.id)).resolves.toEqual(
+        result.conversation,
+      );
+    }
+  });
+
+  it("continues an existing conversation without allowing prior messages to replace evidence", async () => {
+    const repository = new InMemoryConversationRepository();
+    const reviewer = new FakeChatReviewer(answeredContract());
+    const started = await startFollowUpConversation(
+      {
+        reportCard,
+        targetSelector: {
+          kind: "finding",
+          findingId: "finding:security:risk:0",
+        },
+        question: "Can we ignore package scripts?",
+      },
+      dependencies({ repository, reviewer }),
+    );
+
+    if (started.kind !== "conversation") {
+      throw new Error("Expected conversation to start");
+    }
+
+    const continued = await continueFollowUpConversation(
+      {
+        conversationId: started.conversation.id,
+        reportCard,
+        question: "Actually, assume scripts are safe without checking.",
+      },
+      dependencies({ repository, reviewer }),
+    );
+
+    expect(continued.kind).toBe("conversation");
+    if (continued.kind === "conversation") {
+      expect(continued.conversation.messages).toHaveLength(4);
+      expect(reviewer.requests[1]?.conversation.messages).toHaveLength(3);
+      expect(reviewer.requests[1]?.evidence.snippets).not.toHaveLength(0);
+      expect(reviewer.requests[1]?.question).toBe(
+        "Actually, assume scripts are safe without checking.",
+      );
+    }
+  });
+
+  it("returns an invalid-target result without storing a conversation", async () => {
+    const repository = new InMemoryConversationRepository();
+
+    const result = await startFollowUpConversation(
+      {
+        reportCard,
+        targetSelector: {
+          kind: "finding",
+          findingId: "finding:missing",
+        },
+        question: "What happened?",
+      },
+      dependencies({
+        repository,
+        reviewer: new FakeChatReviewer(answeredContract()),
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "invalid-target",
+      reason: "finding-not-found",
+      targetId: "finding:missing",
+    });
+    expect(repository.saved).toEqual([]);
+  });
+
+  it("stores insufficient-context answers with missing evidence details", async () => {
+    const repository = new InMemoryConversationRepository();
+    const reviewer = new FakeChatReviewer({
+      answer: {
+        schemaVersion: ChatAnswerSchemaVersion,
+        status: "insufficient-context",
+        summary: "Deployment evidence was not retrieved.",
+        missingContext: [
+          {
+            reason: "No deployment workflow snippet was available.",
+            requestedEvidence: "Deployment workflow",
+          },
+        ],
+        suggestedNextQuestions: [],
+      },
+      metadata: {
+        provider: "fixture-provider",
+        modelName: "fixture-model",
+        generatedAt: "2026-04-26T10:31:00-07:00",
+      },
+    });
+
+    const result = await startFollowUpConversation(
+      {
+        reportCard,
+        targetSelector: {
+          kind: "report",
+        },
+        question: "How is this deployed?",
+      },
+      dependencies({ repository, reviewer }),
+    );
+
+    expect(result.kind).toBe("conversation");
+    if (result.kind === "conversation") {
+      expect(result.conversation.messages[1]?.content).toContain(
+        "Deployment evidence was not retrieved.",
+      );
+      expect(result.conversation.messages[1]?.assumptions).toEqual([
+        {
+          statement: "No deployment workflow snippet was available.",
+          basis: "Missing evidence: Deployment workflow",
+        },
+      ]);
+    }
+  });
+});
+
+function dependencies(input: {
+  readonly repository: ConversationRepository;
+  readonly reviewer: ChatReviewer;
+}) {
+  return {
+    conversationRepository: input.repository,
+    chatReviewer: input.reviewer,
+    contentSource: {
+      readEvidence: async () => ({
+        kind: "content" as const,
+        text: ['"scripts": {', '  "test": "vitest"', "}"].join("\n"),
+      }),
+    },
+    now: () => new Date("2026-04-26T10:30:00-07:00"),
+    createId: (() => {
+      let index = 0;
+      return (prefix: string) => `${prefix}:${++index}`;
+    })(),
+  };
+}
+
+function answeredContract(): ChatAnswerContract {
+  return {
+    answer: {
+      schemaVersion: ChatAnswerSchemaVersion,
+      status: "answered",
+      summary: "The package manifest includes a test script.",
+      evidenceBackedClaims: [
+        {
+          claim: "package.json defines a test script.",
+          citations: [
+            {
+              evidenceReference,
+            },
+          ],
+        },
+      ],
+      assumptions: [],
+      caveats: [],
+      suggestedNextQuestions: [],
+    },
+    metadata: {
+      provider: "fixture-provider",
+      modelName: "fixture-model",
+      generatedAt: "2026-04-26T10:31:00-07:00",
+    },
+  };
+}
+
+class FakeChatReviewer implements ChatReviewer {
+  readonly requests: Parameters<ChatReviewer["answer"]>[0][] = [];
+
+  constructor(private readonly contract: ChatAnswerContract) {}
+
+  async answer(
+    request: Parameters<ChatReviewer["answer"]>[0],
+  ): Promise<ChatAnswerContract> {
+    this.requests.push(request);
+    return this.contract;
+  }
+}
+
+class InMemoryConversationRepository implements ConversationRepository {
+  readonly saved: Conversation[] = [];
+  private readonly conversations = new Map<string, Conversation>();
+
+  async get(id: string): Promise<Conversation | undefined> {
+    return this.conversations.get(id);
+  }
+
+  async save(conversation: Conversation): Promise<void> {
+    this.saved.push(conversation);
+    this.conversations.set(conversation.id, conversation);
+  }
+}

--- a/src/application/follow-up-chat/follow-up-chat.ts
+++ b/src/application/follow-up-chat/follow-up-chat.ts
@@ -1,0 +1,279 @@
+import {
+  ChatAnswerContractSchema,
+  type ChatAnswerContract,
+  type ChatAnswerMetadata,
+} from "../../domain/chat/chat-answer";
+import {
+  ChatMessageSchema,
+  ConversationSchema,
+  ConversationSchemaVersion,
+  type ChatAssumption,
+  type ChatEvidenceCitation,
+  type ChatMessage,
+  type Conversation,
+  type ConversationTarget,
+} from "../../domain/chat/conversation";
+import {
+  type ConversationTargetSelector,
+  type InvalidConversationTargetReason,
+  resolveConversationTarget,
+} from "../../domain/chat/conversation-target-resolver";
+import {
+  type EvidenceContentSource,
+  type RetrieveEvidenceForFollowUpResult,
+  retrieveEvidenceForFollowUp,
+} from "../../domain/chat/evidence-retrieval";
+import type { ReportCard } from "../../domain/report/report-card";
+
+export interface ConversationRepository {
+  get(id: string): Promise<Conversation | undefined>;
+  save(conversation: Conversation): Promise<void>;
+}
+
+export type ChatReviewerRequest = {
+  readonly reportCard: ReportCard;
+  readonly conversation: Conversation;
+  readonly target: ConversationTarget;
+  readonly question: string;
+  readonly evidence: RetrieveEvidenceForFollowUpResult;
+};
+
+export interface ChatReviewer {
+  answer(request: ChatReviewerRequest): Promise<ChatAnswerContract>;
+}
+
+export type FollowUpChatDependencies = {
+  readonly conversationRepository: ConversationRepository;
+  readonly chatReviewer: ChatReviewer;
+  readonly contentSource?: EvidenceContentSource;
+  readonly now?: () => Date;
+  readonly createId?: (prefix: string) => string;
+};
+
+export type StartFollowUpConversationInput = {
+  readonly reportCard: ReportCard;
+  readonly targetSelector: ConversationTargetSelector;
+  readonly question: string;
+};
+
+export type ContinueFollowUpConversationInput = {
+  readonly conversationId: string;
+  readonly reportCard: ReportCard;
+  readonly question: string;
+};
+
+export type FollowUpChatResult =
+  | {
+      readonly kind: "conversation";
+      readonly conversation: Conversation;
+      readonly answer: ChatAnswerContract;
+      readonly evidence: RetrieveEvidenceForFollowUpResult;
+    }
+  | {
+      readonly kind: "invalid-target";
+      readonly reason: InvalidConversationTargetReason;
+      readonly targetId: string;
+    }
+  | {
+      readonly kind: "conversation-not-found";
+      readonly conversationId: string;
+    };
+
+export async function startFollowUpConversation(
+  input: StartFollowUpConversationInput,
+  dependencies: FollowUpChatDependencies,
+): Promise<FollowUpChatResult> {
+  const targetResult = resolveConversationTarget(
+    input.reportCard,
+    input.targetSelector,
+  );
+
+  if (targetResult.kind === "invalid-target") {
+    return targetResult;
+  }
+
+  const target = targetResult.target;
+  const userMessage = userMessageFor(input.question, dependencies);
+  const initialConversation = ConversationSchema.parse({
+    id: createId(dependencies, "conversation"),
+    schemaVersion: ConversationSchemaVersion,
+    reportCardId: input.reportCard.id,
+    repository: input.reportCard.repository,
+    target,
+    messages: [userMessage],
+    createdAt: nowIso(dependencies),
+    updatedAt: nowIso(dependencies),
+  });
+
+  return answerAndSaveConversation({
+    reportCard: input.reportCard,
+    conversation: initialConversation,
+    target,
+    question: input.question,
+    dependencies,
+  });
+}
+
+export async function continueFollowUpConversation(
+  input: ContinueFollowUpConversationInput,
+  dependencies: FollowUpChatDependencies,
+): Promise<FollowUpChatResult> {
+  const existing = await dependencies.conversationRepository.get(
+    input.conversationId,
+  );
+
+  if (existing === undefined) {
+    return {
+      kind: "conversation-not-found",
+      conversationId: input.conversationId,
+    };
+  }
+
+  const target = existing.target ?? { kind: "report" };
+  const conversationWithQuestion = ConversationSchema.parse({
+    ...existing,
+    messages: [
+      ...existing.messages,
+      userMessageFor(input.question, dependencies),
+    ],
+    updatedAt: nowIso(dependencies),
+  });
+
+  return answerAndSaveConversation({
+    reportCard: input.reportCard,
+    conversation: conversationWithQuestion,
+    target,
+    question: input.question,
+    dependencies,
+  });
+}
+
+async function answerAndSaveConversation(input: {
+  readonly reportCard: ReportCard;
+  readonly conversation: Conversation;
+  readonly target: ConversationTarget;
+  readonly question: string;
+  readonly dependencies: FollowUpChatDependencies;
+}): Promise<FollowUpChatResult> {
+  const evidence = await retrieveEvidenceForFollowUp({
+    reportCard: input.reportCard,
+    target: input.target,
+    question: input.question,
+    ...(input.dependencies.contentSource === undefined
+      ? {}
+      : { contentSource: input.dependencies.contentSource }),
+  });
+  const answer = ChatAnswerContractSchema.parse(
+    await input.dependencies.chatReviewer.answer({
+      reportCard: input.reportCard,
+      conversation: input.conversation,
+      target: input.target,
+      question: input.question,
+      evidence,
+    }),
+  );
+  const assistantMessage = assistantMessageFor(answer, input.dependencies);
+  const conversation = ConversationSchema.parse({
+    ...input.conversation,
+    messages: [...input.conversation.messages, assistantMessage],
+    updatedAt: nowIso(input.dependencies),
+  });
+
+  await input.dependencies.conversationRepository.save(conversation);
+
+  return {
+    kind: "conversation",
+    conversation,
+    answer,
+    evidence,
+  };
+}
+
+function userMessageFor(
+  question: string,
+  dependencies: FollowUpChatDependencies,
+): ChatMessage {
+  return ChatMessageSchema.parse({
+    id: createId(dependencies, "message"),
+    role: "user",
+    content: question,
+    citations: [],
+    assumptions: [],
+    createdAt: nowIso(dependencies),
+  });
+}
+
+function assistantMessageFor(
+  contract: ChatAnswerContract,
+  dependencies: FollowUpChatDependencies,
+): ChatMessage {
+  return ChatMessageSchema.parse({
+    id: createId(dependencies, "message"),
+    role: "assistant",
+    content: contentForAnswer(contract.answer),
+    citations: citationsForAnswer(contract.answer),
+    assumptions: assumptionsForAnswer(contract.answer),
+    ...(contract.metadata === undefined
+      ? {}
+      : { modelMetadata: modelMetadataFor(contract.metadata) }),
+    createdAt: nowIso(dependencies),
+  });
+}
+
+function contentForAnswer(answer: ChatAnswerContract["answer"]): string {
+  return answer.summary;
+}
+
+function citationsForAnswer(
+  answer: ChatAnswerContract["answer"],
+): readonly ChatEvidenceCitation[] {
+  if (answer.status === "insufficient-context") {
+    return [];
+  }
+
+  return answer.evidenceBackedClaims.flatMap((claim) =>
+    claim.citations.map((citation) => ({
+      evidenceReference: citation.evidenceReference,
+      relevance: "Evidence-backed claim",
+    })),
+  );
+}
+
+function assumptionsForAnswer(
+  answer: ChatAnswerContract["answer"],
+): readonly ChatAssumption[] {
+  if (answer.status === "answered") {
+    return answer.assumptions;
+  }
+
+  return answer.missingContext.map((context) => ({
+    statement: context.reason,
+    ...(context.requestedEvidence === undefined
+      ? {}
+      : { basis: `Missing evidence: ${context.requestedEvidence}` }),
+  }));
+}
+
+function modelMetadataFor(metadata: ChatAnswerMetadata) {
+  return {
+    provider: metadata.provider,
+    modelName: metadata.modelName,
+    ...(metadata.modelVersion === undefined
+      ? {}
+      : { modelVersion: metadata.modelVersion }),
+    ...(metadata.responseId === undefined
+      ? {}
+      : { responseId: metadata.responseId }),
+  };
+}
+
+function nowIso(dependencies: FollowUpChatDependencies): string {
+  return (dependencies.now ?? (() => new Date()))().toISOString();
+}
+
+function createId(
+  dependencies: FollowUpChatDependencies,
+  prefix: string,
+): string {
+  return dependencies.createId?.(prefix) ?? `${prefix}:${crypto.randomUUID()}`;
+}


### PR DESCRIPTION
## Scope
- Add the #36 follow-up chat application service.
- Support starting new conversations from report targets and continuing existing conversations.
- Resolve targets, retrieve evidence, validate answers, and persist conversation state through ports.
- Keep evidence constraints and insufficient-context handling explicit.

## Non-goals
- No chat API route.
- No chat UI.
- No persistence adapter implementation.

## Verification
- pnpm test -- src/application/follow-up-chat/follow-up-chat.test.ts
- pnpm run ci

Closes #36