### PR TITLE
chore(tooling): add red-green PreToolUse gate (#104 PR1)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/red-green-gate.ts\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.claude/state/
 .next/
 dist/
 build/

--- a/scripts/red-green-gate.ts
+++ b/scripts/red-green-gate.ts
@@ -1,0 +1,292 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+export type LedgerEntry = {
+  readonly path: string;
+  readonly editedAtIso: string;
+};
+
+export type Ledger = {
+  readonly testEdits: readonly LedgerEntry[];
+};
+
+export type GateInput = {
+  readonly filesTouched: readonly string[];
+  readonly recentTestEdits: readonly string[];
+  readonly allowlist: readonly string[];
+  readonly overrideMarkers: ReadonlyMap<string, string>;
+};
+
+export type GateDecision =
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      readonly reason: string;
+      readonly blockedFiles: readonly string[];
+    };
+
+export function decide(input: GateInput): GateDecision {
+  const blocked: string[] = [];
+
+  for (const file of input.filesTouched) {
+    if (isAllowlisted(file, input.allowlist)) {
+      continue;
+    }
+    if (isTestFile(file)) {
+      continue;
+    }
+    if (input.overrideMarkers.has(file)) {
+      continue;
+    }
+    const colocated = colocatedTestFor(file);
+    if (colocated !== undefined && input.recentTestEdits.includes(colocated)) {
+      continue;
+    }
+    blocked.push(file);
+  }
+
+  if (blocked.length === 0) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    blockedFiles: blocked,
+    reason:
+      "Cannot edit non-test source file(s) without a recent edit to the colocated test file. " +
+      "Edit the colocated *.test.ts(x) first and observe it fail, " +
+      "or add a `// red-green:exempt — <reason>` marker for genuinely test-irrelevant changes.",
+  };
+}
+
+function isTestFile(filePath: string): boolean {
+  return /\.test\.(?:ts|tsx)$/.test(filePath);
+}
+
+function colocatedTestFor(sourcePath: string): string | undefined {
+  if (sourcePath.endsWith(".tsx")) {
+    return `${sourcePath.slice(0, -".tsx".length)}.test.tsx`;
+  }
+  if (sourcePath.endsWith(".ts")) {
+    return `${sourcePath.slice(0, -".ts".length)}.test.ts`;
+  }
+  return undefined;
+}
+
+function isAllowlisted(filePath: string, patterns: readonly string[]): boolean {
+  return patterns.some((pattern) => matchesPattern(filePath, pattern));
+}
+
+export function recentTestEditsFromLedger(
+  ledger: Ledger,
+  windowMs: number,
+  nowMs: number,
+): readonly string[] {
+  return ledger.testEdits
+    .filter((entry) => {
+      const editedMs = Date.parse(entry.editedAtIso);
+      if (!Number.isFinite(editedMs)) {
+        return false;
+      }
+      return nowMs - editedMs <= windowMs;
+    })
+    .map((entry) => entry.path);
+}
+
+function matchesPattern(filePath: string, pattern: string): boolean {
+  if (pattern.endsWith("/**")) {
+    const prefix = pattern.slice(0, -"/**".length);
+    return filePath === prefix || filePath.startsWith(`${prefix}/`);
+  }
+  if (pattern.startsWith("**/*.")) {
+    const suffix = pattern.slice("**/".length);
+    const extension = suffix.slice("*".length);
+    return filePath.endsWith(extension);
+  }
+  if (pattern.startsWith("**/")) {
+    const tail = pattern.slice("**/".length);
+    return filePath === tail || filePath.endsWith(`/${tail}`);
+  }
+  return filePath === pattern;
+}
+
+const DEFAULT_ALLOWLIST: readonly string[] = [
+  "docs/**",
+  "**/*.md",
+  "**/*.css",
+  "**/*.json",
+  "scripts/**",
+  "test/**",
+  "e2e/**",
+  ".github/**",
+  ".claude/**",
+  "AGENTS.md",
+  "CLAUDE.md",
+  "README.md",
+];
+
+const RECENCY_WINDOW_MS = 30 * 60 * 1000;
+const EXEMPT_MARKER_REGEX = /\/\/\s*red-green:exempt\b/i;
+const HANDLED_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+
+export function loadLedger(ledgerPath: string): Ledger {
+  if (!existsSync(ledgerPath)) {
+    return { testEdits: [] };
+  }
+  try {
+    const raw = readFileSync(ledgerPath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "testEdits" in parsed &&
+      Array.isArray((parsed as { testEdits: unknown }).testEdits)
+    ) {
+      return parsed as Ledger;
+    }
+  } catch {
+    // ignore malformed ledgers; treat as empty
+  }
+  return { testEdits: [] };
+}
+
+export function appendTestEditToLedger(
+  ledger: Ledger,
+  testFilePath: string,
+  nowIso: string,
+): Ledger {
+  return {
+    testEdits: [
+      ...ledger.testEdits.filter((entry) => entry.path !== testFilePath),
+      { path: testFilePath, editedAtIso: nowIso },
+    ],
+  };
+}
+
+export function saveLedger(ledger: Ledger, ledgerPath: string): void {
+  mkdirSync(dirname(ledgerPath), { recursive: true });
+  writeFileSync(ledgerPath, JSON.stringify(ledger, null, 2), "utf8");
+}
+
+async function readStdin(): Promise<string> {
+  let data = "";
+  for await (const chunk of process.stdin) {
+    data +=
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+  }
+  return data;
+}
+
+function extractFilePath(toolInput: unknown): string | undefined {
+  if (typeof toolInput !== "object" || toolInput === null) {
+    return undefined;
+  }
+  const filePath = (toolInput as { file_path?: unknown }).file_path;
+  return typeof filePath === "string" ? filePath : undefined;
+}
+
+function extractNewContent(toolName: string, toolInput: unknown): string {
+  if (typeof toolInput !== "object" || toolInput === null) {
+    return "";
+  }
+  const obj = toolInput as Record<string, unknown>;
+  if (toolName === "Write" && typeof obj.content === "string") {
+    return obj.content;
+  }
+  if (toolName === "Edit" && typeof obj.new_string === "string") {
+    return obj.new_string;
+  }
+  if (toolName === "MultiEdit" && Array.isArray(obj.edits)) {
+    return obj.edits
+      .map((edit) => {
+        if (typeof edit === "object" && edit !== null) {
+          const next = (edit as { new_string?: unknown }).new_string;
+          return typeof next === "string" ? next : "";
+        }
+        return "";
+      })
+      .join("\n");
+  }
+  return "";
+}
+
+async function main(): Promise<void> {
+  const stdin = await readStdin();
+  if (stdin.trim() === "") {
+    process.exit(0);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stdin);
+  } catch {
+    process.exit(0);
+  }
+
+  if (typeof payload !== "object" || payload === null) {
+    process.exit(0);
+  }
+  const obj = payload as Record<string, unknown>;
+  const toolName = obj.tool_name;
+  if (typeof toolName !== "string" || !HANDLED_TOOLS.has(toolName)) {
+    process.exit(0);
+  }
+
+  const absoluteFilePath = extractFilePath(obj.tool_input);
+  if (absoluteFilePath === undefined) {
+    process.exit(0);
+  }
+
+  const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+  const relativeFilePath = relative(projectDir, absoluteFilePath);
+  if (relativeFilePath.startsWith("..") || relativeFilePath === "") {
+    process.exit(0);
+  }
+
+  const ledgerPath = join(projectDir, ".claude/state/red-green-ledger.json");
+  const ledger = loadLedger(ledgerPath);
+  const recentEdits = recentTestEditsFromLedger(
+    ledger,
+    RECENCY_WINDOW_MS,
+    Date.now(),
+  );
+
+  const newContent = extractNewContent(toolName, obj.tool_input);
+  const overrideMarkers = new Map<string, string>();
+  if (EXEMPT_MARKER_REGEX.test(newContent)) {
+    overrideMarkers.set(relativeFilePath, "inline marker");
+  }
+
+  const decision = decide({
+    filesTouched: [relativeFilePath],
+    recentTestEdits: recentEdits,
+    allowlist: DEFAULT_ALLOWLIST,
+    overrideMarkers,
+  });
+
+  if (isTestFile(relativeFilePath)) {
+    const updated = appendTestEditToLedger(
+      ledger,
+      relativeFilePath,
+      new Date().toISOString(),
+    );
+    saveLedger(updated, ledgerPath);
+  }
+
+  if (decision.allowed) {
+    process.exit(0);
+  }
+
+  process.stderr.write(`${decision.reason}\n`);
+  process.stderr.write(`Blocked: ${decision.blockedFiles.join(", ")}\n`);
+  process.exit(2);
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/test/tooling/red-green-gate.test.ts
+++ b/test/tooling/red-green-gate.test.ts
@@ -1,0 +1,357 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+import { describe, expect, it } from "vitest";
+
+import {
+  decide,
+  recentTestEditsFromLedger,
+  type Ledger,
+} from "../../scripts/red-green-gate";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const scriptPath = path.join(repoRoot, "scripts/red-green-gate.ts");
+
+function runHook(
+  payload: unknown,
+  options: { readonly projectDir: string },
+): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, [scriptPath], {
+    input: JSON.stringify(payload),
+    cwd: options.projectDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: options.projectDir,
+    },
+  });
+}
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "green-rg-"));
+  mkdirSync(path.join(dir, "src"), { recursive: true });
+  mkdirSync(path.join(dir, "docs"), { recursive: true });
+  return dir;
+}
+
+const allowlist: readonly string[] = [
+  "docs/**",
+  "**/*.md",
+  "**/*.css",
+  "**/*.json",
+  "scripts/**",
+  "test/**",
+  "e2e/**",
+  ".github/**",
+  ".claude/**",
+];
+
+describe("red-green-gate decide", () => {
+  it("blocks editing a non-test source file when no colocated test was edited recently", () => {
+    const decision = decide({
+      filesTouched: ["src/components/report/print-report-button.tsx"],
+      recentTestEdits: [],
+      allowlist,
+      overrideMarkers: new Map(),
+    });
+
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.blockedFiles).toEqual([
+        "src/components/report/print-report-button.tsx",
+      ]);
+      expect(decision.reason).toMatch(/colocated test/i);
+    }
+  });
+
+  it("allows editing a non-test source file when its colocated test was edited recently", () => {
+    const decision = decide({
+      filesTouched: ["src/components/report/print-report-button.tsx"],
+      recentTestEdits: ["src/components/report/print-report-button.test.tsx"],
+      allowlist,
+      overrideMarkers: new Map(),
+    });
+
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("allows editing a colocated .ts source file when its .test.ts was edited recently", () => {
+    const decision = decide({
+      filesTouched: ["src/domain/scoring/scoring-policy.ts"],
+      recentTestEdits: ["src/domain/scoring/scoring-policy.test.ts"],
+      allowlist,
+      overrideMarkers: new Map(),
+    });
+
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("allows editing a test file directly without requiring a paired source edit", () => {
+    const decision = decide({
+      filesTouched: ["src/components/report/report-card-view.test.tsx"],
+      recentTestEdits: [],
+      allowlist,
+      overrideMarkers: new Map(),
+    });
+
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("allows editing allowlisted paths without a paired test", () => {
+    const decision = decide({
+      filesTouched: [
+        "docs/architecture.md",
+        "src/app/globals.css",
+        "AGENTS.md",
+        "package.json",
+        ".claude/settings.json",
+      ],
+      recentTestEdits: [],
+      allowlist: [...allowlist, "AGENTS.md", "CLAUDE.md"],
+      overrideMarkers: new Map(),
+    });
+
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("allows editing a non-test source file when an override marker is recorded for it", () => {
+    const decision = decide({
+      filesTouched: ["src/components/report/print-report-button.tsx"],
+      recentTestEdits: [],
+      allowlist,
+      overrideMarkers: new Map([
+        [
+          "src/components/report/print-report-button.tsx",
+          "trivial rename only, no behavior change",
+        ],
+      ]),
+    });
+
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("blocks the batch when one file is unpaired even if other files are paired or allowlisted", () => {
+    const decision = decide({
+      filesTouched: [
+        "src/components/report/print-report-button.tsx",
+        "src/components/report/report-card-view.tsx",
+        "docs/architecture.md",
+      ],
+      recentTestEdits: ["src/components/report/print-report-button.test.tsx"],
+      allowlist,
+      overrideMarkers: new Map(),
+    });
+
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.blockedFiles).toEqual([
+        "src/components/report/report-card-view.tsx",
+      ]);
+    }
+  });
+});
+
+describe("red-green-gate recentTestEditsFromLedger", () => {
+  const windowMs = 30 * 60 * 1000;
+  const nowMs = Date.parse("2026-04-26T18:00:00.000Z");
+
+  it("returns test edits made within the recency window", () => {
+    const ledger: Ledger = {
+      testEdits: [
+        {
+          path: "src/components/report/print-report-button.test.tsx",
+          editedAtIso: "2026-04-26T17:50:00.000Z",
+        },
+      ],
+    };
+
+    expect(recentTestEditsFromLedger(ledger, windowMs, nowMs)).toEqual([
+      "src/components/report/print-report-button.test.tsx",
+    ]);
+  });
+
+  it("excludes test edits older than the recency window", () => {
+    const ledger: Ledger = {
+      testEdits: [
+        {
+          path: "src/components/report/print-report-button.test.tsx",
+          editedAtIso: "2026-04-26T17:00:00.000Z",
+        },
+      ],
+    };
+
+    expect(recentTestEditsFromLedger(ledger, windowMs, nowMs)).toEqual([]);
+  });
+
+  it("ignores ledger entries with unparseable timestamps", () => {
+    const ledger: Ledger = {
+      testEdits: [
+        {
+          path: "src/components/report/print-report-button.test.tsx",
+          editedAtIso: "not-a-date",
+        },
+      ],
+    };
+
+    expect(recentTestEditsFromLedger(ledger, windowMs, nowMs)).toEqual([]);
+  });
+});
+
+describe("red-green-gate CLI", () => {
+  it("blocks Edit on a non-test source file when no colocated test was edited", () => {
+    const projectDir = makeProjectDir();
+    try {
+      writeFileSync(
+        path.join(projectDir, "src/foo.tsx"),
+        "export const a = 1;\n",
+      );
+
+      const result = runHook(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Edit",
+          tool_input: {
+            file_path: path.join(projectDir, "src/foo.tsx"),
+            old_string: "export const a = 1;",
+            new_string: "export const a = 2;",
+          },
+        },
+        { projectDir },
+      );
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toMatch(/colocated test/i);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows Edit on a non-test source file after the colocated test file was edited", () => {
+    const projectDir = makeProjectDir();
+    try {
+      writeFileSync(
+        path.join(projectDir, "src/foo.tsx"),
+        "export const a = 1;\n",
+      );
+      writeFileSync(
+        path.join(projectDir, "src/foo.test.tsx"),
+        "import { it } from 'vitest';\nit('a', () => {});\n",
+      );
+
+      const recordTest = runHook(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Edit",
+          tool_input: {
+            file_path: path.join(projectDir, "src/foo.test.tsx"),
+            old_string: "it('a', () => {});",
+            new_string: "it('a', () => { expect(1).toBe(2); });",
+          },
+        },
+        { projectDir },
+      );
+      expect(recordTest.status).toBe(0);
+
+      const ledgerPath = path.join(
+        projectDir,
+        ".claude/state/red-green-ledger.json",
+      );
+      expect(existsSync(ledgerPath)).toBe(true);
+      const ledger: Ledger = JSON.parse(readFileSync(ledgerPath, "utf8"));
+      expect(ledger.testEdits.map((entry) => entry.path)).toContain(
+        "src/foo.test.tsx",
+      );
+
+      const editSource = runHook(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Edit",
+          tool_input: {
+            file_path: path.join(projectDir, "src/foo.tsx"),
+            old_string: "export const a = 1;",
+            new_string: "export const a = 2;",
+          },
+        },
+        { projectDir },
+      );
+
+      expect(editSource.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows Write on an allowlisted path without a paired test", () => {
+    const projectDir = makeProjectDir();
+    try {
+      const result = runHook(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Write",
+          tool_input: {
+            file_path: path.join(projectDir, "docs/note.md"),
+            content: "# note\n",
+          },
+        },
+        { projectDir },
+      );
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows Write when the new content carries the red-green:exempt marker", () => {
+    const projectDir = makeProjectDir();
+    try {
+      const result = runHook(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Write",
+          tool_input: {
+            file_path: path.join(projectDir, "src/foo.tsx"),
+            content:
+              "// red-green:exempt — trivial rename, no behavior change\nexport const a = 1;\n",
+          },
+        },
+        { projectDir },
+      );
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("ignores tool calls that are not Edit, Write, or MultiEdit", () => {
+    const projectDir = makeProjectDir();
+    try {
+      const result = runHook(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "ls" },
+        },
+        { projectDir },
+      );
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Scope

Implements PR1 of #104: a Claude Code `PreToolUse` hook that blocks `Edit`/`Write`/`MultiEdit` on non-test source files unless one of:

- a colocated `*.test.{ts,tsx}` was edited within the last 30 minutes (recorded in `.claude/state/red-green-ledger.json`),
- the path is allowlisted (`docs/**`, `**/*.md`, `**/*.css`, `**/*.json`, `scripts/**`, `test/**`, `e2e/**`, `.github/**`, `.claude/**`, `AGENTS.md`, `CLAUDE.md`, `README.md`),
- the new content carries an inline `// red-green:exempt — <reason>` marker.

Closes the gap that allowed the PDF export work (#103, in flight) to ship without ever observing a red test. The gate makes "I'll TDD this... right after I write the impl" require deliberate circumvention rather than passive forgetfulness.

## Non-Goals

- The strict "must have observed vitest red" upgrade — this PR ships option (a) from the issue discussion: a recent colocated test edit is sufficient. Tracking the actual vitest pass/fail across hook events is deferred to a follow-up.
- The `PostToolUse` hook that auto-runs `pnpm vitest run <file>` after a test edit — deferred; the model can run vitest manually until the strict mode lands.
- Lefthook commit-time enforcement — that is PR2 of #104.
- CI-level git-history red→green verification.

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests
- [ ] Build (not relevant to this slice)
- [ ] Foundational E2E (not relevant to this slice)

Commands run:

\`\`\`text
pnpm check
# 31 test files, 130 tests, all green
# 15 of those are new in test/tooling/red-green-gate.test.ts
\`\`\`

The 15 new tests were authored test-first in three RED→GREEN passes, captured in commit history as `feat(tooling): add red-green-gate decision script` (single squashed commit because the test/script files are interdependent). Decision-function tests went RED with "Cannot find module"; ledger tests went RED with "is not a function"; the CLI tests went RED on exit-code mismatch and missing ledger artifact before the CLI was implemented.

## Architecture And Docs

- [x] This follows `docs/architecture.md`
- [ ] Architecture docs were updated — not needed; this PR adds tooling under `scripts/` and a Claude Code config under `.claude/`, neither of which alters the domain/application/infrastructure boundaries
- [ ] Development plan was updated — not needed
- [x] No domain/application/infrastructure boundary violations were introduced

## Type Safety

- [x] Runtime data is parsed or narrowed instead of cast — the hook payload is parsed via `JSON.parse` then narrowed via `typeof`/`in` checks before access
- [x] No `as any`, `: any`, `<any>`, or `as unknown as` was introduced (`pnpm type-escape:check` passes)
- [x] No type-escape markers added; the few `as { ... }` narrowings are on `unknown` parsed values and are safe because each is gated behind a `typeof` check

## Risk And Rollback

**Risks:**

- The hook adds a small per-edit overhead (one Node process spawn). For an idle repo this is unmeasurable; on fast-fire edits it adds tens of milliseconds each.
- If the script crashes (e.g., malformed payload), it exits 0 (allow) by design — failing open rather than blocking the agent. This means a buggy gate degrades to no-gate, which is the existing baseline.
- The 30-minute recency window is a heuristic. Edits resumed after a long break will require re-editing the test first; this is the intended tradeoff.

**Rollback:**

- Remove or comment out the `hooks` block in `.claude/settings.json`. The script remains importable for tests but stops being invoked.
- Or revert the second commit (`chore(tooling): wire red-green-gate as a PreToolUse hook`) — the script + tests remain as inert tooling.

## Dependencies

None. The script uses only `node:fs`, `node:path`, `node:url`, and `node:process`. Tests use existing `vitest` plus Node stdlib.

## Follow-ups (deferred from this PR)

- Strict mode: PostToolUse runs vitest, parses the result, and PreToolUse requires a recently-observed failing run before allowing the source edit.
- PR2 of #104: lefthook pre-commit gate using the same script (or its `decide()` export) against `git diff --cached --name-only`.
- Document the gate in `AGENTS.md` once we've used it for a slice or two and confirm the rule and override marker are right.

Issue: #104