### PR TITLE
test(fixtures): add multi-archetype calibration fixtures (#40)

### DIFF
--- a/docs/fixture-calibration-notes.md
+++ b/docs/fixture-calibration-notes.md
@@ -1,0 +1,37 @@
+# Fixture Calibration Notes
+
+These fixtures are calibrated to keep repository analysis from overfitting to one language or project type.
+
+## `minimal-node-library`
+
+- Archetype: `node-library`
+- Languages: TypeScript, Markdown
+- Expected signals: package manifest, reusable source module, one unit test, small source surface
+- Caveats: intentionally narrow scope, no release history, no deployment signals, no persistence or auth evidence
+
+## `nextjs-web-app`
+
+- Archetype: `web-app`
+- Languages: TypeScript, Markdown
+- Expected signals: Next.js package metadata, `src/app/` route files, browser application entrypoints
+- Caveats: minimal UI surface, no production auth flow, no API routes, no database evidence
+
+## `go-cli-tool`
+
+- Archetype: `cli`
+- Languages: Go, Markdown
+- Expected signals: executable path under `bin/`, Go source files, command-line structure
+- Caveats: no package manager manifest, no release automation, no integration test harness, no external dependency story
+
+## `mkdocs-docs-site`
+
+- Archetype: `docs-heavy`
+- Languages: Markdown, YAML
+- Expected signals: MkDocs configuration, documentation pages outnumbering source, docs-first repository shape
+- Caveats: little to no executable code, so maintainability and testability conclusions should stay limited to documentation structure
+
+## Calibration Intent
+
+- The suite should span at least three languages and four archetypes.
+- The registry should make the fixture mix visible to tests instead of burying it in file-system conventions.
+- Report interpretation should stay cautious when a fixture lacks release, deployment, or operational evidence.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/fixtures/fixture-calibration.test.ts
+++ b/test/fixtures/fixture-calibration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { repositoryFixtures } from "../support/fixtures";
+
+describe("repository fixture calibration", () => {
+  it("covers multiple languages and archetypes without collapsing into one bucket", () => {
+    const fixtures = Object.values(repositoryFixtures);
+    const languages = new Set(fixtures.flatMap((fixture) => fixture.languages));
+    const archetypes = new Set(fixtures.map((fixture) => fixture.archetype));
+    const archetypeCounts = fixtures.reduce<Record<string, number>>(
+      (accumulator, fixture) => {
+        accumulator[fixture.archetype] =
+          (accumulator[fixture.archetype] ?? 0) + 1;
+        return accumulator;
+      },
+      {},
+    );
+    const largestArchetypeBucket = Math.max(...Object.values(archetypeCounts));
+
+    expect(fixtures).toHaveLength(4);
+    expect(languages).toEqual(
+      new Set(["Go", "Markdown", "TypeScript", "YAML"]),
+    );
+    expect(languages.size).toBeGreaterThanOrEqual(3);
+    expect(archetypes.size).toBeGreaterThanOrEqual(4);
+    expect(largestArchetypeBucket).toBeLessThan(fixtures.length);
+  });
+});

--- a/test/fixtures/repositories/go-cli-tool/README.md
+++ b/test/fixtures/repositories/go-cli-tool/README.md
@@ -1,0 +1,9 @@
+# Go CLI Tool
+
+Small deterministic fixture used to calibrate CLI detection.
+
+The fixture represents a command-line tool with:
+
+- Go source files
+- An executable `bin/` entrypoint
+- No network, database, auth, or deployment dependency

--- a/test/fixtures/repositories/go-cli-tool/bin/repo-analyzer.go
+++ b/test/fixtures/repositories/go-cli-tool/bin/repo-analyzer.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		fmt.Println("repo-analyzer-go-cli fixture")
+		return
+	}
+
+	fmt.Println("repo-analyzer-go-cli fixture")
+}

--- a/test/fixtures/repositories/go-cli-tool/go.mod
+++ b/test/fixtures/repositories/go-cli-tool/go.mod
@@ -1,0 +1,3 @@
+module example.com/repo-analyzer-go-cli
+
+go 1.22

--- a/test/fixtures/repositories/mkdocs-docs-site/README.md
+++ b/test/fixtures/repositories/mkdocs-docs-site/README.md
@@ -1,0 +1,9 @@
+# MkDocs Docs Site
+
+Small deterministic fixture used to calibrate docs-heavy detection.
+
+The fixture represents a documentation-first repository with:
+
+- Markdown documentation pages
+- MkDocs configuration
+- No network, database, auth, or deployment dependency

--- a/test/fixtures/repositories/mkdocs-docs-site/docs/index.md
+++ b/test/fixtures/repositories/mkdocs-docs-site/docs/index.md
@@ -1,0 +1,3 @@
+# Home
+
+This fixture exists to keep docs-heavy calibration explicit.

--- a/test/fixtures/repositories/mkdocs-docs-site/docs/reference.md
+++ b/test/fixtures/repositories/mkdocs-docs-site/docs/reference.md
@@ -1,0 +1,3 @@
+# Reference
+
+The fixture intentionally stays documentation-first and code-light.

--- a/test/fixtures/repositories/mkdocs-docs-site/mkdocs.yml
+++ b/test/fixtures/repositories/mkdocs-docs-site/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: Repo Analyzer Green Fixture Docs
+theme:
+  name: material
+nav:
+  - Home: docs/index.md
+  - Reference: docs/reference.md

--- a/test/fixtures/repositories/nextjs-web-app/README.md
+++ b/test/fixtures/repositories/nextjs-web-app/README.md
@@ -1,0 +1,9 @@
+# Next.js Web App
+
+Small deterministic fixture used to calibrate web-app detection.
+
+The fixture represents a browser application with:
+
+- Next.js package metadata
+- App Router entrypoints
+- No network, database, auth, or deployment dependency

--- a/test/fixtures/repositories/nextjs-web-app/package.json
+++ b/test/fixtures/repositories/nextjs-web-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "nextjs-web-app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/test/fixtures/repositories/nextjs-web-app/src/app/layout.tsx
+++ b/test/fixtures/repositories/nextjs-web-app/src/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/test/fixtures/repositories/nextjs-web-app/src/app/page.tsx
+++ b/test/fixtures/repositories/nextjs-web-app/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>Repo Analyzer Green</h1>
+      <p>Fixture web app.</p>
+    </main>
+  );
+}

--- a/test/fixtures/repository-fixtures.test.ts
+++ b/test/fixtures/repository-fixtures.test.ts
@@ -17,6 +17,34 @@ describe("repository fixtures", () => {
     ]);
   });
 
+  it("registers the additional calibration fixtures", () => {
+    expect(getRepositoryFixture("nextjs-web-app")).toMatchObject({
+      archetype: "web-app",
+      languages: ["Markdown", "TypeScript"],
+      expectedFiles: [
+        "README.md",
+        "package.json",
+        "src/app/layout.tsx",
+        "src/app/page.tsx",
+      ],
+    });
+    expect(getRepositoryFixture("go-cli-tool")).toMatchObject({
+      archetype: "cli",
+      languages: ["Go", "Markdown"],
+      expectedFiles: ["README.md", "bin/repo-analyzer.go", "go.mod"],
+    });
+    expect(getRepositoryFixture("mkdocs-docs-site")).toMatchObject({
+      archetype: "docs-heavy",
+      languages: ["Markdown", "YAML"],
+      expectedFiles: [
+        "README.md",
+        "docs/index.md",
+        "docs/reference.md",
+        "mkdocs.yml",
+      ],
+    });
+  });
+
   it("keeps registered fixture files present on disk", async () => {
     for (const fixture of Object.values(repositoryFixtures)) {
       for (const expectedFile of fixture.expectedFiles) {

--- a/test/support/fixtures.ts
+++ b/test/support/fixtures.ts
@@ -1,10 +1,27 @@
 import path from "node:path";
 
-export type RepositoryFixtureId = "minimal-node-library";
+export type RepositoryFixtureId =
+  | "minimal-node-library"
+  | "nextjs-web-app"
+  | "go-cli-tool"
+  | "mkdocs-docs-site";
+
+export type RepositoryFixtureArchetype =
+  | "node-library"
+  | "web-app"
+  | "cli"
+  | "docs-heavy";
+
+export type RepositoryFixtureLanguage =
+  | "Go"
+  | "Markdown"
+  | "TypeScript"
+  | "YAML";
 
 export type RepositoryFixture = {
   readonly id: RepositoryFixtureId;
-  readonly archetype: "node-library";
+  readonly archetype: RepositoryFixtureArchetype;
+  readonly languages: readonly RepositoryFixtureLanguage[];
   readonly rootPath: string;
   readonly expectedFiles: readonly string[];
 };
@@ -18,12 +35,44 @@ export const repositoryFixtures: Record<
   "minimal-node-library": {
     id: "minimal-node-library",
     archetype: "node-library",
+    languages: ["Markdown", "TypeScript"],
     rootPath: path.join(fixtureRoot, "minimal-node-library"),
     expectedFiles: [
       "README.md",
       "package.json",
       "src/add.ts",
       "test/add.spec.ts",
+    ],
+  },
+  "nextjs-web-app": {
+    id: "nextjs-web-app",
+    archetype: "web-app",
+    languages: ["Markdown", "TypeScript"],
+    rootPath: path.join(fixtureRoot, "nextjs-web-app"),
+    expectedFiles: [
+      "README.md",
+      "package.json",
+      "src/app/layout.tsx",
+      "src/app/page.tsx",
+    ],
+  },
+  "go-cli-tool": {
+    id: "go-cli-tool",
+    archetype: "cli",
+    languages: ["Go", "Markdown"],
+    rootPath: path.join(fixtureRoot, "go-cli-tool"),
+    expectedFiles: ["README.md", "bin/repo-analyzer.go", "go.mod"],
+  },
+  "mkdocs-docs-site": {
+    id: "mkdocs-docs-site",
+    archetype: "docs-heavy",
+    languages: ["Markdown", "YAML"],
+    rootPath: path.join(fixtureRoot, "mkdocs-docs-site"),
+    expectedFiles: [
+      "README.md",
+      "docs/index.md",
+      "docs/reference.md",
+      "mkdocs.yml",
     ],
   },
 };


### PR DESCRIPTION
Adds three additional repository fixtures so analysis can calibrate across multiple languages and archetypes instead of overfitting to the minimal Node library.

Includes:
- Next.js web app fixture
- Go CLI fixture
- MkDocs docs site fixture
- Calibration assertions and notes

Validation:
- pnpm check
- pnpm exec vitest run test/fixtures/repository-fixtures.test.ts test/fixtures/fixture-calibration.test.ts

Issue: #40