### PR TITLE
feat(persistence): add in-memory conversation repository (#39)

### DIFF
--- a/src/components/chat/follow-up-panel.tsx
+++ b/src/components/chat/follow-up-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { z } from "zod";
 
 import type { AnalyzeRepositoryResponse } from "../../application/analyze-repository/analyze-repository-response";
@@ -8,7 +8,6 @@ import {
   continueFollowUpConversation,
   startFollowUpConversation,
   type ChatReviewer,
-  type ConversationRepository,
   type FollowUpChatDependencies,
 } from "../../application/follow-up-chat/follow-up-chat";
 import type {
@@ -25,6 +24,7 @@ import {
 import type { ConversationTargetSelector } from "../../domain/chat/conversation-target-resolver";
 import type { EvidenceContentResult } from "../../domain/chat/evidence-retrieval";
 import type { EvidenceReference } from "../../domain/shared/evidence-reference";
+import { InMemoryConversationRepository } from "../../infrastructure/persistence/in-memory-conversation-repository";
 
 type FollowUpSession = {
   readonly conversation: Conversation;
@@ -72,7 +72,10 @@ export function FollowUpPanel({
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [hydrated, setHydrated] = useState(false);
-  const repositoryRef = useRef<Map<string, Conversation>>(new Map());
+  const conversationRepository = useMemo(
+    () => new InMemoryConversationRepository(),
+    [],
+  );
   const contentSource = useMemo(() => createContentSource(), []);
 
   useEffect(() => {
@@ -83,14 +86,11 @@ export function FollowUpPanel({
         stored.sessions[0]?.conversation.id ??
         null,
     );
-    repositoryRef.current = new Map(
-      stored.sessions.map((session) => [
-        session.conversation.id,
-        session.conversation,
-      ]),
+    conversationRepository.replaceAll(
+      stored.sessions.map((session) => session.conversation),
     );
     setHydrated(true);
-  }, [reportCard.id]);
+  }, [conversationRepository, reportCard.id]);
 
   useEffect(() => {
     if (!hydrated) {
@@ -98,20 +98,11 @@ export function FollowUpPanel({
     }
 
     persistState(reportCard.id, { sessions, activeConversationId });
-    repositoryRef.current = new Map(
-      sessions.map((session) => [
-        session.conversation.id,
-        session.conversation,
-      ]),
-    );
   }, [activeConversationId, hydrated, reportCard.id, sessions]);
 
   const dependencies = useMemo<FollowUpChatDependencies>(
     () => ({
-      conversationRepository: createConversationRepository(
-        repositoryRef,
-        setSessions,
-      ),
+      conversationRepository,
       chatReviewer: createDemoChatReviewer(),
       contentSource,
       now: () => new Date(),
@@ -120,7 +111,7 @@ export function FollowUpPanel({
         return (prefix: string) => `${prefix}:${++index}`;
       })(),
     }),
-    [contentSource],
+    [contentSource, conversationRepository],
   );
 
   const activeSession =
@@ -714,30 +705,6 @@ function readStoredState(reportId: string): StoredFollowUpState {
 
 function storageKey(reportId: string): string {
   return `${storagePrefix}:${reportId}`;
-}
-
-function createConversationRepository(
-  repositoryRef: React.MutableRefObject<Map<string, Conversation>>,
-  setSessions: React.Dispatch<React.SetStateAction<FollowUpSession[]>>,
-): ConversationRepository {
-  return {
-    async get(id: string) {
-      return repositoryRef.current.get(id);
-    },
-    async save(conversation: Conversation) {
-      repositoryRef.current.set(conversation.id, conversation);
-      setSessions((current) =>
-        current.map((session) =>
-          session.conversation.id === conversation.id
-            ? {
-                ...session,
-                conversation,
-              }
-            : session,
-        ),
-      );
-    },
-  };
 }
 
 function createDemoChatReviewer(): ChatReviewer {

--- a/src/infrastructure/persistence/in-memory-conversation-repository.test.ts
+++ b/src/infrastructure/persistence/in-memory-conversation-repository.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { InMemoryConversationRepository } from "./in-memory-conversation-repository";
+import type { Conversation } from "../../domain/chat/conversation";
+
+const conversation: Conversation = {
+  id: "conversation:1",
+  schemaVersion: "conversation.v1",
+  reportCardId: "report:1",
+  repository: {
+    provider: "local-fixture",
+    name: "minimal-node-library",
+    revision: "fixture",
+  },
+  target: {
+    kind: "report",
+  },
+  messages: [
+    {
+      id: "message:1",
+      role: "user",
+      content: "What should we inspect first?",
+      citations: [],
+      assumptions: [],
+      createdAt: "2026-04-26T10:00:00-07:00",
+    },
+  ],
+  createdAt: "2026-04-26T10:00:00-07:00",
+  updatedAt: "2026-04-26T10:01:00-07:00",
+};
+
+describe("InMemoryConversationRepository", () => {
+  it("stores and retrieves conversations through the shared repository port", async () => {
+    const repository = new InMemoryConversationRepository();
+
+    await repository.save(conversation);
+
+    await expect(repository.get(conversation.id)).resolves.toEqual(
+      conversation,
+    );
+  });
+
+  it("can replace all stored conversations for browser hydration", async () => {
+    const repository = new InMemoryConversationRepository([conversation]);
+    const nextConversation = {
+      ...conversation,
+      id: "conversation:2",
+    } satisfies Conversation;
+
+    repository.replaceAll([nextConversation]);
+
+    await expect(repository.get(conversation.id)).resolves.toBeUndefined();
+    await expect(repository.get(nextConversation.id)).resolves.toEqual(
+      nextConversation,
+    );
+  });
+});

--- a/src/infrastructure/persistence/in-memory-conversation-repository.ts
+++ b/src/infrastructure/persistence/in-memory-conversation-repository.ts
@@ -1,0 +1,25 @@
+import type { Conversation } from "../../domain/chat/conversation";
+import type { ConversationRepository } from "../../application/follow-up-chat/follow-up-chat";
+
+export class InMemoryConversationRepository implements ConversationRepository {
+  private readonly conversations = new Map<string, Conversation>();
+
+  constructor(initialConversations: readonly Conversation[] = []) {
+    this.replaceAll(initialConversations);
+  }
+
+  async get(id: string): Promise<Conversation | undefined> {
+    return this.conversations.get(id);
+  }
+
+  async save(conversation: Conversation): Promise<void> {
+    this.conversations.set(conversation.id, conversation);
+  }
+
+  replaceAll(conversations: readonly Conversation[]): void {
+    this.conversations.clear();
+    for (const conversation of conversations) {
+      this.conversations.set(conversation.id, conversation);
+    }
+  }
+}


### PR DESCRIPTION
Extracts the follow-up conversation store behind the shared repository port so conversation state can be hydrated and persisted without keeping storage plumbing inside the component.

Validation:
- pnpm check
- pnpm exec vitest run src/infrastructure/persistence/in-memory-conversation-repository.test.ts src/components/chat/follow-up-panel.test.tsx

Issue: #39