### PR TITLE
feat(api): reject oversized repositories (#42)

### DIFF
--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -225,6 +225,29 @@ describe("POST /api/analyze", () => {
     });
   });
 
+  it("maps oversized repositories to 413 with diagnostic detail", async () => {
+    const response = await handleAnalyzeRequest(jsonRequest(validRequestBody), {
+      analyze: async () => {
+        throw new RepositorySourceError(
+          "Repository contains too many files to analyze.",
+          "repository-too-large",
+          validRequestBody.repository,
+          "File count 1201 exceeds the 1000 file inventory limit.",
+        );
+      },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(body).toEqual({
+      error: {
+        code: "repository-too-large",
+        message: "Repository is too large to analyze.",
+        detail: "File count 1201 exceeds the 1000 file inventory limit.",
+      },
+    });
+  });
+
   it("maps malformed reviewer output to a bad gateway response", async () => {
     const malformedResult: AnalyzeRepositoryResult = {
       kind: "reviewer-malformed-response",

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -146,6 +146,12 @@ function repositorySourceErrorResponse(error: RepositorySourceError): Response {
         code: error.code,
         message: "Repository reference is invalid.",
       });
+    case "repository-too-large":
+      return jsonError(413, {
+        code: error.code,
+        message: "Repository is too large to analyze.",
+        ...(error.detail === undefined ? {} : { detail: error.detail }),
+      });
     case "file-not-found":
     case "repository-not-found":
       return jsonError(404, {

--- a/src/application/analyze-repository/analyze-repository.test.ts
+++ b/src/application/analyze-repository/analyze-repository.test.ts
@@ -225,4 +225,30 @@ describe("analyzeRepository", () => {
       ],
     });
   });
+
+  it("rejects oversized repositories before reviewer calls are made", async () => {
+    await expect(
+      analyzeRepository(
+        { repository },
+        {
+          repositorySource: new LocalFixtureRepositorySource({
+            fixtures: {
+              [fixture.id]: fixture,
+            },
+          }),
+          reviewer: new FakeReviewer({
+            result: {
+              kind: "assessment",
+              assessment: reviewerAssessment,
+            },
+          }),
+          fileInventoryOptions: {
+            maxFileCount: 1,
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "repository-too-large",
+    });
+  });
 });

--- a/src/application/analyze-repository/analyze-repository.ts
+++ b/src/application/analyze-repository/analyze-repository.ts
@@ -112,9 +112,13 @@ export async function analyzeRepository(
   const evidenceBundle = await evidenceCollector({
     repository: input.repository,
     repositorySource: dependencies.repositorySource,
-    options: {
-      fileInventoryOptions: dependencies.fileInventoryOptions,
-    },
+    ...(dependencies.fileInventoryOptions === undefined
+      ? {}
+      : {
+          options: {
+            fileInventoryOptions: dependencies.fileInventoryOptions,
+          },
+        }),
   });
   const reviewerResult = await dependencies.reviewer.assess({
     repository: evidenceBundle.repository,

--- a/src/application/analyze-repository/analyze-repository.ts
+++ b/src/application/analyze-repository/analyze-repository.ts
@@ -1,5 +1,6 @@
 import {
   collectFileInventory,
+  type FileInventoryOptions,
   type FileInventory,
   type InventoryOmission,
 } from "../../domain/evidence/file-inventory";
@@ -52,6 +53,7 @@ export type AnalyzeRepositoryDependencies = {
   readonly now?: () => Date;
   readonly createReportId?: (repository: RepositoryIdentity) => string;
   readonly evidenceCollector?: RepositoryEvidenceCollector;
+  readonly fileInventoryOptions?: FileInventoryOptions;
 };
 
 export type RepositoryEvidenceCollector = (
@@ -61,6 +63,9 @@ export type RepositoryEvidenceCollector = (
 export type CollectRepositoryEvidenceInput = {
   readonly repository: RepositoryReference;
   readonly repositorySource: RepositorySource;
+  readonly options?: {
+    readonly fileInventoryOptions?: FileInventoryOptions;
+  };
 };
 
 export type RepositoryEvidenceBundle = {
@@ -107,6 +112,9 @@ export async function analyzeRepository(
   const evidenceBundle = await evidenceCollector({
     repository: input.repository,
     repositorySource: dependencies.repositorySource,
+    options: {
+      fileInventoryOptions: dependencies.fileInventoryOptions,
+    },
   });
   const reviewerResult = await dependencies.reviewer.assess({
     repository: evidenceBundle.repository,
@@ -155,6 +163,7 @@ export async function collectRepositoryEvidence(
   const fileInventory = await collectFileInventory(
     input.repository,
     input.repositorySource,
+    input.options?.fileInventoryOptions,
   );
   const textFiles = await readInventoryTextFiles(
     input.repository,

--- a/src/domain/evidence/file-inventory.test.ts
+++ b/src/domain/evidence/file-inventory.test.ts
@@ -106,6 +106,23 @@ describe("collectFileInventory", () => {
       }),
     ]);
   });
+
+  it("rejects repositories that exceed the file inventory limit", async () => {
+    await expect(
+      collectFileInventory(
+        repository,
+        new FakeRepositorySource([
+          textFile("src/a.ts", "export const a = 1;\n"),
+          textFile("src/b.ts", "export const b = 2;\n"),
+          textFile("src/c.ts", "export const c = 3;\n"),
+        ]),
+        { maxFileCount: 2 },
+      ),
+    ).rejects.toMatchObject({
+      code: "repository-too-large",
+      detail: "File count 3 exceeds the 2 file inventory limit.",
+    });
+  });
 });
 
 function textFile(path: RepositoryPath, text: string): FakeRepositoryFile {

--- a/src/domain/evidence/file-inventory.ts
+++ b/src/domain/evidence/file-inventory.ts
@@ -5,6 +5,7 @@ import type {
   RepositoryReference,
   RepositorySource,
 } from "../repository/repository-source";
+import { RepositorySourceError } from "../repository/repository-source";
 
 export type FileClassificationSignal =
   | "configuration"
@@ -42,9 +43,11 @@ export type FileInventory = {
 
 export type FileInventoryOptions = {
   readonly maxFileSizeBytes?: number;
+  readonly maxFileCount?: number;
 };
 
 const defaultMaxFileSizeBytes = 256 * 1024;
+const defaultMaxFileCount = 10_000;
 
 const ignoredDirectoryDetails = new Map<string, string>([
   [".git", "version-control metadata is ignored"],
@@ -134,9 +137,19 @@ export async function collectFileInventory(
   options: FileInventoryOptions = {},
 ): Promise<FileInventory> {
   const maxFileSizeBytes = options.maxFileSizeBytes ?? defaultMaxFileSizeBytes;
+  const maxFileCount = options.maxFileCount ?? defaultMaxFileCount;
   const entries = [...(await source.listFiles(repository))].sort(comparePaths);
   const files: InventoryFile[] = [];
   const omissions: InventoryOmission[] = [];
+
+  if (entries.length > maxFileCount) {
+    throw new RepositorySourceError(
+      "Repository contains too many files to analyze.",
+      "repository-too-large",
+      repository,
+      `File count ${entries.length} exceeds the ${maxFileCount} file inventory limit.`,
+    );
+  }
 
   for (const entry of entries) {
     const pathOmission = omissionFromPath(entry);

--- a/src/domain/repository/repository-source.ts
+++ b/src/domain/repository/repository-source.ts
@@ -47,8 +47,10 @@ export class RepositorySourceError extends Error {
       | "extraction-failed"
       | "file-not-found"
       | "invalid-repository-reference"
-      | "repository-not-found",
+      | "repository-not-found"
+      | "repository-too-large",
     readonly repository: RepositoryReference,
+    readonly detail?: string,
   ) {
     super(message);
     this.name = "RepositorySourceError";


### PR DESCRIPTION
Adds first-class handling for oversized repositories by surfacing a repository-too-large analysis error and mapping it to a 413 response with diagnostic detail.

Validation:
- pnpm check
- pnpm exec vitest run src/domain/evidence/file-inventory.test.ts src/application/analyze-repository/analyze-repository.test.ts src/app/api/analyze/route.test.ts

Issue: #42