### PR TITLE
feat(evidence): add versioned evidence bundle record (#24)

### DIFF
--- a/src/application/analyze-repository/evidence-bundle-record.test.ts
+++ b/src/application/analyze-repository/evidence-bundle-record.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import { collectRepositoryEvidence } from "./analyze-repository";
+import {
+  EvidenceBundleRecordSchemaVersion,
+  parseEvidenceBundleRecord,
+  toEvidenceBundleRecord,
+  type EvidenceArtifactRecord,
+} from "./evidence-bundle-record";
+import type {
+  RepositoryFileContent,
+  RepositoryFileEntry,
+  RepositoryPath,
+  RepositoryReference,
+  RepositorySource,
+} from "../../domain/repository/repository-source";
+
+const repository: RepositoryReference = {
+  provider: "local-fixture",
+  name: "evidence-bundle-fixture",
+  revision: "fixture",
+};
+
+describe("evidence bundle record", () => {
+  it("round-trips evidence metadata and separate raw artifact pointers", async () => {
+    const evidenceBundle = await collectRepositoryEvidence({
+      repository,
+      repositorySource: new FakeRepositorySource([
+        textFile("README.md", "# Fixture\n"),
+        textFile(
+          "package.json",
+          JSON.stringify(
+            {
+              name: "evidence-bundle-fixture",
+              private: true,
+              scripts: {
+                dev: "next dev",
+                test: "vitest",
+              },
+              dependencies: {
+                next: "^15.0.0",
+                react: "^19.0.0",
+              },
+            },
+            null,
+            2,
+          ),
+        ),
+        textFile(
+          "src/app/layout.tsx",
+          "export default function Layout() { return null; }\n",
+        ),
+        textFile(
+          "src/app/page.tsx",
+          "export default function Page() { return null; }\n",
+        ),
+        textFile(
+          "test/page.test.tsx",
+          "import { describe, it } from 'vitest';\n",
+        ),
+        textFile("dist/app.js", "export const generated = true;\n"),
+        textFile(".git/config", "[core]\n"),
+        textFile("assets/logo.png", "png\0bytes"),
+      ]),
+    });
+
+    const record = toEvidenceBundleRecord({
+      repository: evidenceBundle.repository,
+      collectedAt: "2026-04-25T20:05:00-07:00",
+      evidenceBundle,
+      rawArtifacts: [
+        {
+          id: "artifact:repository-snapshot",
+          kind: "repository-snapshot",
+          label: "Compressed repository snapshot",
+          storageKey: "evidence/evidence-bundle-fixture/snapshot.tar.zst",
+          byteSize: 4096,
+          sha256: "sha256:0123456789abcdef",
+          provenance: {
+            repository: evidenceBundle.repository,
+            sourceKind: "local-fixture",
+            sourceId: "evidence-bundle-fixture",
+            path: "snapshot.tar.zst",
+          },
+        } satisfies EvidenceArtifactRecord,
+      ],
+    });
+
+    const parsed = parseEvidenceBundleRecord(
+      JSON.parse(JSON.stringify(record)),
+    );
+
+    expect(parsed.schemaVersion).toBe(EvidenceBundleRecordSchemaVersion);
+    expect(parsed.repository).toEqual(repository);
+    expect(parsed.metadata.evidenceReferences.length).toBeGreaterThan(0);
+    expect(parsed.metadata.fileInventory.omissions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ".git/config",
+          reason: "ignored",
+        }),
+        expect.objectContaining({
+          path: "assets/logo.png",
+          reason: "binary",
+        }),
+        expect.objectContaining({
+          path: "dist/app.js",
+          reason: "generated",
+        }),
+      ]),
+    );
+    expect(parsed.rawArtifacts).toEqual([
+      expect.objectContaining({
+        id: "artifact:repository-snapshot",
+        kind: "repository-snapshot",
+        provenance: expect.objectContaining({
+          repository: expect.objectContaining({
+            name: "evidence-bundle-fixture",
+          }),
+          sourceKind: "local-fixture",
+        }),
+      }),
+    ]);
+  });
+
+  it("rejects malformed metadata and artifact records", () => {
+    expect(() =>
+      parseEvidenceBundleRecord({
+        schemaVersion: EvidenceBundleRecordSchemaVersion,
+        repository,
+        collectedAt: "2026-04-25T20:05:00-07:00",
+        metadata: {
+          evidenceSummary: "summary",
+          fileInventory: {
+            files: [],
+            omissions: [
+              {
+                path: "dist/app.js",
+                sizeBytes: 31,
+                reason: "generated",
+                detail: "generated output directory is omitted",
+              },
+            ],
+          },
+          manifestWorkflowSignals: {
+            packageManifests: [],
+            dependencySignals: [],
+            scriptSignals: [],
+            workflowSignals: [],
+            unsupportedManifests: [],
+            omissions: [],
+          },
+          projectArchetypeSignals: {
+            primaryArchetype: "web-app",
+            candidates: [],
+          },
+          languageCodeShapeMetrics: {
+            summary: {
+              analyzedFileCount: 0,
+              sourceFileCount: 0,
+              testFileCount: 0,
+              documentationFileCount: 0,
+              largeFileCount: 0,
+              skippedFileCount: 0,
+              unsupportedFileCount: 0,
+              totalTextLineCount: 0,
+              totalCodeLineCount: 0,
+              totalDeferredWorkMarkerCount: 0,
+              totalBranchLikeTokenCount: 0,
+            },
+            languageMix: [],
+            files: [],
+            deferredWorkMarkers: [],
+            branchLikeTokens: [],
+            largeFiles: [],
+            omissions: [],
+            caveats: [],
+          },
+          securityHygieneSignals: {
+            lockfileSignals: [],
+            dependencyCountSignals: [],
+            envExampleSignals: [],
+            secretRiskSignals: [],
+            limitations: [],
+          },
+          evidenceReferences: [],
+        },
+        rawArtifacts: [
+          {
+            id: "artifact:bad",
+            kind: "repository-snapshot",
+            label: "Broken snapshot",
+            storageKey: "",
+            provenance: {
+              repository,
+              sourceKind: "local-fixture",
+              sourceId: "evidence-bundle-fixture",
+            },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});
+
+function textFile(path: RepositoryPath, text: string): FakeRepositoryFile {
+  return {
+    path,
+    text,
+    sizeBytes: Buffer.byteLength(text),
+  };
+}
+
+type FakeRepositoryFile = {
+  readonly path: RepositoryPath;
+  readonly text: string;
+  readonly sizeBytes: number;
+};
+
+class FakeRepositorySource implements RepositorySource {
+  private readonly files: readonly FakeRepositoryFile[];
+
+  constructor(files: readonly FakeRepositoryFile[]) {
+    this.files = files;
+  }
+
+  async listFiles(): Promise<readonly RepositoryFileEntry[]> {
+    return this.files.map((file) => ({
+      path: file.path,
+      sizeBytes: file.sizeBytes,
+      provenance: {
+        repository,
+        sourceKind: "local-fixture",
+        sourceId: "evidence-bundle-fixture",
+        path: file.path,
+      },
+    }));
+  }
+
+  async readFile(
+    _repository: RepositoryReference,
+    filePath: RepositoryPath,
+  ): Promise<RepositoryFileContent> {
+    const file = this.files.find((candidate) => candidate.path === filePath);
+
+    if (file === undefined) {
+      throw new Error(`Missing fake file: ${filePath}`);
+    }
+
+    return {
+      path: file.path,
+      text: file.text,
+      sizeBytes: file.sizeBytes,
+      provenance: {
+        repository,
+        sourceKind: "local-fixture",
+        sourceId: "evidence-bundle-fixture",
+        path: file.path,
+      },
+    };
+  }
+}

--- a/src/application/analyze-repository/evidence-bundle-record.ts
+++ b/src/application/analyze-repository/evidence-bundle-record.ts
@@ -1,0 +1,392 @@
+import { z } from "zod";
+
+import { ConfidenceSchema } from "../../domain/shared/confidence";
+import { EvidenceReferenceSchema } from "../../domain/shared/evidence-reference";
+import {
+  RepositoryIdentitySchema,
+  type RepositoryIdentity,
+  ProjectArchetypeSchema,
+} from "../../domain/report/report-card";
+import type { RepositoryEvidenceBundle } from "./analyze-repository";
+
+export const EvidenceBundleRecordSchemaVersion = "evidence-bundle-record.v1";
+
+const fileClassificationSignalSchema = z.enum([
+  "configuration",
+  "documentation",
+  "lockfile",
+  "manifest",
+  "source",
+  "test",
+]);
+
+const fileOmissionReasonSchema = z.enum([
+  "binary",
+  "generated",
+  "ignored",
+  "oversized",
+  "vendor",
+]);
+
+const evidenceArtifactKindSchema = z.enum([
+  "collector-output",
+  "file-blob",
+  "repository-snapshot",
+]);
+
+const evidenceArtifactProvenanceSchema = z
+  .object({
+    repository: RepositoryIdentitySchema,
+    sourceKind: z.string().min(1),
+    sourceId: z.string().min(1),
+    path: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const EvidenceArtifactRecordSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: evidenceArtifactKindSchema,
+    label: z.string().min(1),
+    storageKey: z.string().min(1),
+    byteSize: z.number().int().nonnegative().optional(),
+    sha256: z.string().min(1).optional(),
+    provenance: evidenceArtifactProvenanceSchema,
+  })
+  .strict();
+
+export type EvidenceArtifactRecord = z.infer<
+  typeof EvidenceArtifactRecordSchema
+>;
+
+const fileInventoryFileSchema = z
+  .object({
+    path: z.string().min(1),
+    sizeBytes: z.number().int().nonnegative(),
+    extension: z.string(),
+    signals: z.array(fileClassificationSignalSchema),
+  })
+  .strict();
+
+const fileInventoryOmissionSchema = z
+  .object({
+    path: z.string().min(1),
+    sizeBytes: z.number().int().nonnegative(),
+    reason: fileOmissionReasonSchema,
+    detail: z.string().min(1),
+  })
+  .strict();
+
+const fileInventorySchema = z
+  .object({
+    files: z.array(fileInventoryFileSchema),
+    omissions: z.array(fileInventoryOmissionSchema),
+  })
+  .strict();
+
+const projectArchetypeCandidateSchema = z
+  .object({
+    archetype: ProjectArchetypeSchema,
+    confidence: ConfidenceSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+    matchedSignals: z.array(z.string().min(1)),
+  })
+  .strict();
+
+const projectArchetypeSignalResultSchema = z
+  .object({
+    primaryArchetype: ProjectArchetypeSchema,
+    candidates: z.array(projectArchetypeCandidateSchema),
+  })
+  .strict();
+
+const manifestPackageSignalSchema = z
+  .object({
+    kind: z.literal("package-json"),
+    path: z.string().min(1),
+    name: z.string().min(1).optional(),
+    private: z.boolean().optional(),
+    packageManager: z.string().min(1).optional(),
+    main: z.string().min(1).optional(),
+    module: z.string().min(1).optional(),
+    types: z.string().min(1).optional(),
+    exports: z.boolean().optional(),
+    bin: z.boolean().optional(),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const manifestWorkflowOmissionSchema = z
+  .object({
+    path: z.string().min(1),
+    reason: z.enum(["invalid-shape", "parse-error"]),
+    detail: z.string().min(1),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const manifestWorkflowSignalResultSchema = z
+  .object({
+    packageManifests: z.array(manifestPackageSignalSchema),
+    dependencySignals: z.array(z.object({}).passthrough()),
+    scriptSignals: z.array(z.object({}).passthrough()),
+    workflowSignals: z.array(z.object({}).passthrough()),
+    unsupportedManifests: z.array(z.object({}).passthrough()),
+    omissions: z.array(manifestWorkflowOmissionSchema),
+  })
+  .strict();
+
+const languageCodeShapeSummarySchema = z
+  .object({
+    analyzedFileCount: z.number().int().nonnegative(),
+    sourceFileCount: z.number().int().nonnegative(),
+    testFileCount: z.number().int().nonnegative(),
+    documentationFileCount: z.number().int().nonnegative(),
+    largeFileCount: z.number().int().nonnegative(),
+    skippedFileCount: z.number().int().nonnegative(),
+    unsupportedFileCount: z.number().int().nonnegative(),
+    totalTextLineCount: z.number().int().nonnegative(),
+    totalCodeLineCount: z.number().int().nonnegative(),
+    totalDeferredWorkMarkerCount: z.number().int().nonnegative(),
+    totalBranchLikeTokenCount: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const languageCodeShapeLanguageMetricSchema = z
+  .object({
+    language: z.string().min(1),
+    extensions: z.array(z.string().min(1)),
+    fileCount: z.number().int().nonnegative(),
+    sourceFileCount: z.number().int().nonnegative(),
+    textLineCount: z.number().int().nonnegative(),
+    codeLineCount: z.number().int().nonnegative(),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const languageCodeShapeFileMetricSchema = z
+  .object({
+    path: z.string().min(1),
+    extension: z.string().min(1),
+    language: z.string().min(1),
+    sizeBytes: z.number().int().nonnegative(),
+    isSource: z.boolean(),
+    isTest: z.boolean(),
+    isDocumentation: z.boolean(),
+    isLarge: z.boolean(),
+    textLineCount: z.number().int().nonnegative(),
+    nonEmptyLineCount: z.number().int().nonnegative(),
+    codeLineCount: z.number().int().nonnegative(),
+    branchLikeTokenCount: z.number().int().nonnegative(),
+    deferredWorkMarkerCount: z.number().int().nonnegative(),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const languageCodeShapeDeferredWorkMarkerSchema = z
+  .object({
+    path: z.string().min(1),
+    marker: z.enum(["TODO", "FIXME", "HACK", "XXX"]),
+    line: z.number().int().positive(),
+    excerpt: z.string().min(1),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const languageCodeShapeBranchLikeTokenSchema = z
+  .object({
+    path: z.string().min(1),
+    token: z.string().min(1),
+    count: z.number().int().nonnegative(),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const languageCodeShapeLargeFileSchema = z
+  .object({
+    path: z.string().min(1),
+    sizeBytes: z.number().int().nonnegative(),
+    thresholdBytes: z.number().int().nonnegative(),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const languageCodeShapeOmissionSchema = z
+  .object({
+    path: z.string().min(1),
+    sizeBytes: z.number().int().nonnegative(),
+    reason: z.enum([
+      "binary",
+      "generated",
+      "ignored",
+      "oversized",
+      "unsupported-extension",
+      "vendor",
+    ]),
+    detail: z.string().min(1),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const languageCodeShapeCaveatSchema = z
+  .object({
+    kind: z.enum([
+      "large-files",
+      "metric-limitation",
+      "skipped-files",
+      "unsupported-files",
+    ]),
+    detail: z.string().min(1),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const languageCodeShapeMetricResultSchema = z
+  .object({
+    summary: languageCodeShapeSummarySchema,
+    languageMix: z.array(languageCodeShapeLanguageMetricSchema),
+    files: z.array(languageCodeShapeFileMetricSchema),
+    deferredWorkMarkers: z.array(languageCodeShapeDeferredWorkMarkerSchema),
+    branchLikeTokens: z.array(languageCodeShapeBranchLikeTokenSchema),
+    largeFiles: z.array(languageCodeShapeLargeFileSchema),
+    omissions: z.array(languageCodeShapeOmissionSchema),
+    caveats: z.array(languageCodeShapeCaveatSchema),
+  })
+  .strict();
+
+const securityHygieneLockfileSignalSchema = z
+  .object({
+    kind: z.literal("lockfile"),
+    category: z.literal("hygiene"),
+    path: z.string().min(1),
+    ecosystem: z.string().min(1),
+    packageManager: z.string().min(1),
+    confidence: ConfidenceSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+    reviewDisposition: z.object({ required: z.literal(true) }).passthrough(),
+  })
+  .strict();
+
+const securityHygieneDependencyCountSignalSchema = z
+  .object({
+    kind: z.literal("package-dependency-count"),
+    category: z.literal("hygiene"),
+    path: z.string().min(1),
+    totalDependencies: z.number().int().nonnegative(),
+    byRelationship: z.record(z.string(), z.number().int().nonnegative()),
+    confidence: ConfidenceSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+    reviewDisposition: z.object({ required: z.literal(true) }).passthrough(),
+  })
+  .strict();
+
+const securityHygieneEnvExampleSignalSchema = z
+  .object({
+    kind: z.literal("env-example"),
+    category: z.literal("hygiene"),
+    path: z.string().min(1),
+    confidence: ConfidenceSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+    reviewDisposition: z.object({ required: z.literal(true) }).passthrough(),
+  })
+  .strict();
+
+const securityHygieneSecretRiskSignalSchema = z
+  .object({
+    kind: z.enum(["secret-risk-path", "secret-risk-content"]),
+    category: z.literal("risk"),
+    path: z.string().min(1),
+    reason: z.string().min(1),
+    matchedPattern: z.string().min(1).optional(),
+    lineStart: z.number().int().positive().optional(),
+    lineEnd: z.number().int().positive().optional(),
+    confidence: ConfidenceSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+    reviewDisposition: z.object({ required: z.literal(true) }).passthrough(),
+  })
+  .strict();
+
+const securityHygieneLimitationSchema = z
+  .object({
+    kind: z.enum([
+      "bounded-content-scan",
+      "content-unavailable",
+      "human-review-required",
+      "manifest-data-unavailable",
+    ]),
+    detail: z.string().min(1),
+    path: z.string().min(1).optional(),
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+const securityHygieneSignalResultSchema = z
+  .object({
+    lockfileSignals: z.array(securityHygieneLockfileSignalSchema),
+    dependencyCountSignals: z.array(securityHygieneDependencyCountSignalSchema),
+    envExampleSignals: z.array(securityHygieneEnvExampleSignalSchema),
+    secretRiskSignals: z.array(securityHygieneSecretRiskSignalSchema),
+    limitations: z.array(securityHygieneLimitationSchema),
+  })
+  .strict();
+
+export const EvidenceBundleMetadataSchema = z
+  .object({
+    evidenceSummary: z.string().min(1),
+    fileInventory: fileInventorySchema,
+    manifestWorkflowSignals: manifestWorkflowSignalResultSchema,
+    projectArchetypeSignals: projectArchetypeSignalResultSchema,
+    languageCodeShapeMetrics: languageCodeShapeMetricResultSchema,
+    securityHygieneSignals: securityHygieneSignalResultSchema,
+    evidenceReferences: z.array(EvidenceReferenceSchema),
+  })
+  .strict();
+
+export type EvidenceBundleMetadata = z.infer<
+  typeof EvidenceBundleMetadataSchema
+>;
+
+export const EvidenceBundleRecordSchema = z
+  .object({
+    schemaVersion: z.literal(EvidenceBundleRecordSchemaVersion),
+    repository: RepositoryIdentitySchema,
+    collectedAt: z.iso.datetime({ offset: true }),
+    metadata: EvidenceBundleMetadataSchema,
+    rawArtifacts: z.array(EvidenceArtifactRecordSchema).default([]),
+  })
+  .strict();
+
+export type EvidenceBundleRecord = z.infer<typeof EvidenceBundleRecordSchema>;
+
+export type EvidenceBundleRecordInput = {
+  readonly repository: RepositoryIdentity;
+  readonly collectedAt: string;
+  readonly evidenceBundle: RepositoryEvidenceBundle;
+  readonly rawArtifacts?: readonly EvidenceArtifactRecord[];
+};
+
+export function toEvidenceBundleRecord(
+  input: EvidenceBundleRecordInput,
+): EvidenceBundleRecord {
+  return EvidenceBundleRecordSchema.parse({
+    schemaVersion: EvidenceBundleRecordSchemaVersion,
+    repository: input.repository,
+    collectedAt: input.collectedAt,
+    metadata: {
+      evidenceSummary: input.evidenceBundle.evidenceSummary,
+      fileInventory: input.evidenceBundle.fileInventory,
+      manifestWorkflowSignals: input.evidenceBundle.manifestWorkflowSignals,
+      projectArchetypeSignals: input.evidenceBundle.projectArchetypeSignals,
+      languageCodeShapeMetrics: input.evidenceBundle.languageCodeShapeMetrics,
+      securityHygieneSignals: input.evidenceBundle.securityHygieneSignals,
+      evidenceReferences: input.evidenceBundle.evidenceReferences,
+    },
+    rawArtifacts: input.rawArtifacts ?? [],
+  });
+}
+
+export function parseEvidenceBundleRecord(
+  input: unknown,
+): EvidenceBundleRecord {
+  return EvidenceBundleRecordSchema.parse(input);
+}


### PR DESCRIPTION
## Summary\n- add a versioned evidence-bundle record schema at the application boundary\n- keep compact metadata separate from raw artifact pointers\n- validate evidence references and omission reasons through JSON round-trip parsing\n\n## Validation\n- pnpm exec vitest run src/application/analyze-repository/evidence-bundle-record.test.ts\n- pnpm exec vitest run src/application/analyze-repository/analyze-repository.test.ts\n- pnpm check\n\nIssue: #24