### PR TITLE
feat(ui): add PDF export print flow (#103)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,3 +10,20 @@ body {
   color: #0f172a;
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@media print {
+  @page {
+    margin: 0.5in;
+  }
+
+  article,
+  aside,
+  header,
+  section {
+    break-inside: avoid;
+  }
+
+  body {
+    background: #ffffff;
+  }
+}

--- a/src/components/chat/follow-up-panel.tsx
+++ b/src/components/chat/follow-up-panel.tsx
@@ -194,7 +194,7 @@ export function FollowUpPanel({
   return (
     <section
       aria-labelledby="follow-up-panel-title"
-      className="rounded-md border border-slate-200 bg-white p-5"
+      className="rounded-md border border-slate-200 bg-white p-5 print:hidden"
     >
       <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-4">
         <div>

--- a/src/components/report/analyze-repository-panel.test.tsx
+++ b/src/components/report/analyze-repository-panel.test.tsx
@@ -1,0 +1,13 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { AnalyzeRepositoryPanel } from "./analyze-repository-panel";
+
+describe("AnalyzeRepositoryPanel", () => {
+  it("hides the analysis sidebar in printed output", () => {
+    const html = renderToStaticMarkup(<AnalyzeRepositoryPanel />);
+
+    expect(html).toContain("Browser session");
+    expect(html).toMatch(/<aside[^>]*class="[^"]*print:hidden[^"]*"/);
+  });
+});

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -183,7 +183,7 @@ export function AnalyzeRepositoryPanel() {
 
   return (
     <div className="grid min-h-screen gap-6 px-6 py-6 lg:grid-cols-[360px_1fr]">
-      <aside className="rounded-md border border-slate-200 bg-white p-5">
+      <aside className="rounded-md border border-slate-200 bg-white p-5 print:hidden">
         <p className="text-sm font-medium uppercase text-emerald-700">
           Repo Analyzer Green
         </p>

--- a/src/components/report/print-report-button.tsx
+++ b/src/components/report/print-report-button.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+export function triggerPrint(): void {
+  window.print();
+}
+
+export function PrintReportButton() {
+  return (
+    <button
+      type="button"
+      className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 print:hidden"
+      onClick={triggerPrint}
+    >
+      Download PDF
+    </button>
+  );
+}

--- a/src/components/report/report-card-view.test.tsx
+++ b/src/components/report/report-card-view.test.tsx
@@ -1,9 +1,10 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { AnalyzeRepositoryResponse } from "../../application/analyze-repository/analyze-repository-response";
 import type { ReportCard } from "../../domain/report/report-card";
 import { ReportCardView } from "./report-card-view";
+import { triggerPrint } from "./print-report-button";
 
 const reportCard: ReportCard = {
   id: "report:minimal-node-library",
@@ -158,6 +159,38 @@ describe("ReportCardView", () => {
     expect(html).toContain("Release workflow history");
     expect(html).toContain("evidence:test-file");
     expect(html).toContain("How is this package released and verified?");
+  });
+
+  it("renders a Download PDF button so users can export the report", () => {
+    const html = renderToStaticMarkup(<ReportCardView analysis={analysis} />);
+
+    expect(html).toContain("Download PDF");
+  });
+
+  it("hides the Download PDF button itself from the printed output", () => {
+    const html = renderToStaticMarkup(<ReportCardView analysis={analysis} />);
+
+    expect(html).toMatch(
+      /<button[^>]*class="[^"]*print:hidden[^"]*"[^>]*>Download PDF<\/button>/,
+    );
+  });
+
+  it("invokes the native print flow when requested", () => {
+    const print = vi.fn();
+    vi.stubGlobal("window", { print });
+
+    triggerPrint();
+
+    expect(print).toHaveBeenCalledOnce();
+    vi.unstubAllGlobals();
+  });
+
+  it("excludes the follow-up chat from the printed output", () => {
+    const html = renderToStaticMarkup(<ReportCardView analysis={analysis} />);
+
+    expect(html).toMatch(
+      /<section[^>]*aria-labelledby="follow-up-panel-title"[^>]*class="[^"]*print:hidden[^"]*"/,
+    );
   });
 
   it("does not collapse the report into a single overall score", () => {

--- a/src/components/report/report-card-view.tsx
+++ b/src/components/report/report-card-view.tsx
@@ -11,6 +11,7 @@ import type {
   DashboardLanguageMixItem,
 } from "../../application/analyze-repository/analyze-repository-response";
 import { FollowUpPanel } from "../chat/follow-up-panel";
+import { PrintReportButton } from "./print-report-button";
 
 export function ReportCardView({
   analysis,
@@ -72,6 +73,7 @@ export function ReportCardView({
             Reviewer: {reportCard.reviewerMetadata.name}
           </p>
         </div>
+        <PrintReportButton />
       </header>
 
       <section


### PR DESCRIPTION
Adds a browser-native print export flow for the report card with print-hidden controls for the export trigger, follow-up chat, and analysis sidebar.

Validation:
- pnpm check
- pnpm exec vitest run src/components/report/analyze-repository-panel.test.tsx src/components/report/report-card-view.test.tsx src/components/chat/follow-up-panel.test.tsx

Issue: #103