### PR TITLE
feat(persistence): unify browser-local session restore (#74)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -572,6 +572,9 @@ Required seams:
 - Domain objects do not import database clients, ORM types, or auth provider types
 - User-supplied credentials are request-scoped unless encrypted persistence is explicitly designed
 - Browser-local session adapters may store repository form state, selected model preference, latest report cards, and follow-up chat threads for anonymous use, but they must validate schema versions and discard invalid saved data cleanly
+- Browser-local state should live behind a single versioned envelope so form state, latest report, and per-report follow-up threads restore together instead of through ad hoc keys
+- Local snapshot failures should fall back to defaults rather than partially resurrecting stale or incompatible state
+- The same application services should be able to move this state into repository ports later without changing domain models or UI contracts
 
 Likely future persistence:
 - Relational database for users, workspaces, reports, conversations, and metadata

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -298,6 +298,9 @@ Design constraints:
 - Large evidence artifacts may need object storage or compressed blobs rather than normal relational rows
 - Conversation messages should store citations and model metadata separately from rendered Markdown
 - Repository analysis should be reproducible from saved evidence and reviewer assessment versions when possible
+- Browser-local MVP state should be stored in a single versioned session envelope that can restore repository form state, latest report output, and per-report follow-up threads together
+- Invalid or version-mismatched browser-local snapshots should be discarded and rebuilt from defaults rather than partially trusted
+- User credentials and API keys should remain request-scoped unless encrypted persistence is explicitly designed
 
 ### Presentation
 

--- a/docs/red-parity.md
+++ b/docs/red-parity.md
@@ -37,7 +37,7 @@ Parity does not mean copying red's architecture or scoring formulas. Green shoul
 | Snippet retrieval for follow-up | #35 | Evidence-aware retrieval with citations and missing-context states. |
 | Chat answer contract/provider behavior | #37, #28 | Structured answer contract plus provider adapter; no free-form provider output in domain. |
 | Follow-up UI slideout/conversation threads | #38 | Modular chat components over conversation application services. |
-| Browser local persistence | #39, #74 | Adapter boundary for anonymous/local state with future database migration path. |
+| Browser local persistence | #39, #74 | Single browser-local session envelope for repository form state, latest report, and per-report chat threads, with future database migration path. |
 | Auth/database readiness | #18, #43 | Actor/context, owner/workspace metadata, repository ports, and future access policy. |
 | Preview/live-provider E2E setup | #45, #66, #78 | Vercel preview E2E plus documented OpenRouter secret/test-repo setup. |
 

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -33,6 +33,9 @@ test("runs the repository analysis workflow", async ({ page }) => {
 
 test("starts a follow-up thread from the report view", async ({ page }) => {
   await page.goto("/");
+  await page
+    .getByLabel("Reviewer model preference")
+    .fill("fixture-parity-model");
   await page.getByRole("button", { name: "Analyze repository" }).click();
 
   await expect(page.getByText("Follow-up").first()).toBeVisible();
@@ -46,16 +49,21 @@ test("starts a follow-up thread from the report view", async ({ page }) => {
   await expect(page.getByText("Evidence-backed answer")).toBeVisible();
   await expect(page.getByText("Relevant evidence from").first()).toBeVisible();
 
-  await page.waitForFunction(() =>
-    window.localStorage
-      .getItem(
-        "repo-analyzer-green.follow-up:report:local-fixture:unknown:minimal-node-library:fixture",
-      )
-      ?.includes("Report: What should we inspect first?"),
+  await page.waitForFunction(
+    () =>
+      window.localStorage
+        .getItem("repo-analyzer-green.browser-local-session")
+        ?.includes("fixture-parity-model") &&
+      window.localStorage
+        .getItem("repo-analyzer-green.browser-local-session")
+        ?.includes("Report: What should we inspect first?"),
   );
 
   await page.reload();
 
+  await expect(page.getByLabel("Reviewer model preference")).toHaveValue(
+    "fixture-parity-model",
+  );
   await expect(
     page.getByText("Report: What should we inspect first?").first(),
   ).toBeVisible();

--- a/src/components/chat/follow-up-panel.tsx
+++ b/src/components/chat/follow-up-panel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { z } from "zod";
 
 import type { AnalyzeRepositoryResponse } from "../../application/analyze-repository/analyze-repository-response";
 import {
@@ -14,49 +13,22 @@ import type {
   ChatAnswer,
   ChatAnswerContract,
 } from "../../domain/chat/chat-answer";
-import { ChatAnswerContractSchema } from "../../domain/chat/chat-answer";
-import {
-  ConversationSchema,
-  ConversationTargetSchema,
-  type Conversation,
-  type ConversationTarget,
+import type {
+  Conversation,
+  ConversationTarget,
 } from "../../domain/chat/conversation";
 import type { ConversationTargetSelector } from "../../domain/chat/conversation-target-resolver";
 import type { EvidenceContentResult } from "../../domain/chat/evidence-retrieval";
 import type { EvidenceReference } from "../../domain/shared/evidence-reference";
+import {
+  loadBrowserFollowUpState,
+  saveBrowserFollowUpState,
+  type BrowserFollowUpSession,
+  type BrowserFollowUpState,
+} from "../../infrastructure/persistence/browser-local-session-storage";
 import { InMemoryConversationRepository } from "../../infrastructure/persistence/in-memory-conversation-repository";
 
-type FollowUpSession = {
-  readonly conversation: Conversation;
-  readonly target: ConversationTarget;
-  readonly answer: ChatAnswerContract;
-  readonly evidenceSummary: string;
-  readonly title: string;
-};
-
-type StoredFollowUpState = {
-  readonly sessions: FollowUpSession[];
-  readonly activeConversationId: string | null;
-};
-
-const StoredFollowUpSessionSchema = z
-  .object({
-    conversation: ConversationSchema,
-    target: ConversationTargetSchema,
-    answer: ChatAnswerContractSchema,
-    evidenceSummary: z.string(),
-    title: z.string(),
-  })
-  .strict();
-
-const StoredFollowUpStateSchema = z
-  .object({
-    sessions: z.array(StoredFollowUpSessionSchema),
-    activeConversationId: z.string().nullable(),
-  })
-  .strict();
-
-const storagePrefix = "repo-analyzer-green.follow-up";
+type FollowUpSession = BrowserFollowUpSession;
 
 export function FollowUpPanel({
   analysis,
@@ -79,15 +51,19 @@ export function FollowUpPanel({
   const contentSource = useMemo(() => createContentSource(), []);
 
   useEffect(() => {
-    const stored = readStoredState(reportCard.id);
-    setSessions(stored.sessions);
+    const stored = loadBrowserFollowUpState(window.localStorage, reportCard.id);
+    const nextState: BrowserFollowUpState = stored ?? {
+      sessions: [],
+      activeConversationId: null,
+    };
+    setSessions(nextState.sessions);
     setActiveConversationId(
-      stored.activeConversationId ??
-        stored.sessions[0]?.conversation.id ??
+      nextState.activeConversationId ??
+        nextState.sessions[0]?.conversation.id ??
         null,
     );
     conversationRepository.replaceAll(
-      stored.sessions.map((session) => session.conversation),
+      nextState.sessions.map((session) => session.conversation),
     );
     setHydrated(true);
   }, [conversationRepository, reportCard.id]);
@@ -97,7 +73,10 @@ export function FollowUpPanel({
       return;
     }
 
-    persistState(reportCard.id, { sessions, activeConversationId });
+    saveBrowserFollowUpState(window.localStorage, reportCard.id, {
+      sessions,
+      activeConversationId,
+    });
   }, [activeConversationId, hydrated, reportCard.id, sessions]);
 
   const dependencies = useMemo<FollowUpChatDependencies>(
@@ -676,35 +655,6 @@ function targetErrorMessage(result: { readonly kind: string }): string {
   return result.kind === "conversation-not-found"
     ? "Conversation not found."
     : "Selected target could not be resolved.";
-}
-
-function persistState(reportId: string, state: StoredFollowUpState) {
-  window.localStorage.setItem(storageKey(reportId), JSON.stringify(state));
-}
-
-function readStoredState(reportId: string): StoredFollowUpState {
-  const raw = window.localStorage.getItem(storageKey(reportId));
-  if (raw === null) {
-    return {
-      sessions: [],
-      activeConversationId: null,
-    };
-  }
-
-  try {
-    return StoredFollowUpStateSchema.parse(JSON.parse(raw));
-  } catch {
-    // Ignore malformed local state.
-  }
-
-  return {
-    sessions: [],
-    activeConversationId: null,
-  };
-}
-
-function storageKey(reportId: string): string {
-  return `${storagePrefix}:${reportId}`;
 }
 
 function createDemoChatReviewer(): ChatReviewer {

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -7,12 +7,12 @@ import {
   type AnalyzeRepositoryResponse,
 } from "../../application/analyze-repository/analyze-repository-response";
 import {
-  clearBrowserAnalysisSession,
+  clearBrowserLocalSession,
   defaultBrowserRepositoryForm,
   loadBrowserAnalysisSession,
   saveBrowserAnalysisSession,
   type BrowserRepositoryForm,
-} from "../../infrastructure/persistence/browser-analysis-session-storage";
+} from "../../infrastructure/persistence/browser-local-session-storage";
 import { ReportCardView } from "./report-card-view";
 
 type AnalyzeStatus =
@@ -81,10 +81,8 @@ export function AnalyzeRepositoryPanel() {
     }
 
     saveBrowserAnalysisSession(window.localStorage, {
-      schemaVersion: "browser-analysis-session.v1",
       form: repositoryForm,
       ...(latestReport === null ? {} : { latestReport }),
-      updatedAt: new Date().toISOString(),
     });
   }, [hydrated, latestReport, repositoryForm]);
 
@@ -175,7 +173,7 @@ export function AnalyzeRepositoryPanel() {
   }
 
   function resetSavedSession() {
-    clearBrowserAnalysisSession(window.localStorage);
+    clearBrowserLocalSession(window.localStorage);
     setRepositoryForm(defaultBrowserRepositoryForm());
     setLatestReport(null);
     setStatus({ kind: "idle" });

--- a/src/infrastructure/persistence/browser-local-session-storage.ts
+++ b/src/infrastructure/persistence/browser-local-session-storage.ts
@@ -1,0 +1,203 @@
+import { z } from "zod";
+
+import { AnalyzeRepositoryResponseSchema } from "../../application/analyze-repository/analyze-repository-response";
+import { ChatAnswerContractSchema } from "../../domain/chat/chat-answer";
+import {
+  ConversationSchema,
+  ConversationTargetSchema,
+} from "../../domain/chat/conversation";
+import {
+  RepositoryIdentitySchema,
+  type RepositoryIdentity,
+} from "../../domain/report/report-card";
+
+export const BrowserLocalSessionSchemaVersion = "browser-local-session.v1";
+
+export const BrowserRepositoryFormSchema = RepositoryIdentitySchema.extend({
+  selectedModel: z.string().min(1),
+}).strict();
+
+export type BrowserRepositoryForm = z.infer<typeof BrowserRepositoryFormSchema>;
+
+export const BrowserAnalysisSessionSchema = z
+  .object({
+    form: BrowserRepositoryFormSchema,
+    latestReport: AnalyzeRepositoryResponseSchema.optional(),
+  })
+  .strict();
+
+export type BrowserAnalysisSession = z.infer<
+  typeof BrowserAnalysisSessionSchema
+>;
+
+export const BrowserFollowUpSessionSchema = z
+  .object({
+    conversation: ConversationSchema,
+    target: ConversationTargetSchema,
+    answer: ChatAnswerContractSchema,
+    evidenceSummary: z.string(),
+    title: z.string(),
+  })
+  .strict();
+
+export type BrowserFollowUpSession = z.infer<
+  typeof BrowserFollowUpSessionSchema
+>;
+
+export const BrowserFollowUpStateSchema = z
+  .object({
+    sessions: z.array(BrowserFollowUpSessionSchema),
+    activeConversationId: z.string().nullable(),
+  })
+  .strict();
+
+export type BrowserFollowUpState = z.infer<typeof BrowserFollowUpStateSchema>;
+
+export const BrowserLocalSessionSchema = z
+  .object({
+    schemaVersion: z.literal(BrowserLocalSessionSchemaVersion),
+    analysis: BrowserAnalysisSessionSchema,
+    followUpThreads: z.record(z.string(), BrowserFollowUpStateSchema),
+    updatedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+
+export type BrowserLocalSession = z.infer<typeof BrowserLocalSessionSchema>;
+
+export interface BrowserStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export const BrowserLocalSessionStorageKey =
+  "repo-analyzer-green.browser-local-session";
+
+export function loadBrowserLocalSession(
+  storage: BrowserStorageLike,
+): BrowserLocalSession | null {
+  const raw = storage.getItem(BrowserLocalSessionStorageKey);
+  if (raw === null) {
+    return null;
+  }
+
+  try {
+    return BrowserLocalSessionSchema.parse(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function saveBrowserLocalSession(
+  storage: BrowserStorageLike,
+  session: BrowserLocalSession,
+): void {
+  storage.setItem(BrowserLocalSessionStorageKey, JSON.stringify(session));
+}
+
+export function loadBrowserAnalysisSession(
+  storage: BrowserStorageLike,
+): BrowserAnalysisSession | null {
+  return loadBrowserLocalSession(storage)?.analysis ?? null;
+}
+
+export function saveBrowserAnalysisSession(
+  storage: BrowserStorageLike,
+  analysis: BrowserAnalysisSession,
+): void {
+  const current =
+    loadBrowserLocalSession(storage) ?? defaultBrowserLocalSession();
+  saveBrowserLocalSession(
+    storage,
+    BrowserLocalSessionSchema.parse({
+      ...current,
+      analysis,
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+}
+
+export function loadBrowserFollowUpState(
+  storage: BrowserStorageLike,
+  reportCardId: string,
+): BrowserFollowUpState | null {
+  return (
+    loadBrowserLocalSession(storage)?.followUpThreads[reportCardId] ?? null
+  );
+}
+
+export function saveBrowserFollowUpState(
+  storage: BrowserStorageLike,
+  reportCardId: string,
+  state: BrowserFollowUpState,
+): void {
+  const current =
+    loadBrowserLocalSession(storage) ?? defaultBrowserLocalSession();
+  saveBrowserLocalSession(
+    storage,
+    BrowserLocalSessionSchema.parse({
+      ...current,
+      followUpThreads: {
+        ...current.followUpThreads,
+        [reportCardId]: state,
+      },
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+}
+
+export function clearBrowserLocalSession(storage: BrowserStorageLike): void {
+  storage.removeItem(BrowserLocalSessionStorageKey);
+}
+
+export function defaultBrowserRepositoryForm(): BrowserRepositoryForm {
+  return {
+    provider: "local-fixture",
+    name: "minimal-node-library",
+    revision: "fixture",
+    selectedModel: "fixture-default",
+  };
+}
+
+export function browserRepositoryIdentityFromForm(
+  form: BrowserRepositoryForm,
+): RepositoryIdentity {
+  return {
+    provider: form.provider,
+    name: form.name,
+    ...(form.owner === undefined ? {} : { owner: form.owner }),
+    ...(form.url === undefined ? {} : { url: form.url }),
+    ...(form.revision === undefined ? {} : { revision: form.revision }),
+    ...(form.defaultBranch === undefined
+      ? {}
+      : { defaultBranch: form.defaultBranch }),
+  };
+}
+
+export function browserRepositoryFormFromIdentity(
+  identity: RepositoryIdentity,
+  selectedModel = "fixture-default",
+): BrowserRepositoryForm {
+  return {
+    provider: identity.provider,
+    name: identity.name,
+    ...(identity.owner === undefined ? {} : { owner: identity.owner }),
+    ...(identity.url === undefined ? {} : { url: identity.url }),
+    ...(identity.revision === undefined ? {} : { revision: identity.revision }),
+    ...(identity.defaultBranch === undefined
+      ? {}
+      : { defaultBranch: identity.defaultBranch }),
+    selectedModel,
+  };
+}
+
+function defaultBrowserLocalSession(): BrowserLocalSession {
+  return {
+    schemaVersion: BrowserLocalSessionSchemaVersion,
+    analysis: {
+      form: defaultBrowserRepositoryForm(),
+    },
+    followUpThreads: {},
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/test/infrastructure/persistence/browser-analysis-session-storage.test.ts
+++ b/test/infrastructure/persistence/browser-analysis-session-storage.test.ts
@@ -1,57 +1,103 @@
 import { describe, expect, it } from "vitest";
 
 import type { AnalyzeRepositoryResponse } from "../../../src/application/analyze-repository/analyze-repository-response";
-import type { BrowserAnalysisSession } from "../../../src/infrastructure/persistence/browser-analysis-session-storage";
+import type {
+  BrowserFollowUpState,
+  BrowserLocalSession,
+} from "../../../src/infrastructure/persistence/browser-local-session-storage";
 import {
   browserRepositoryFormFromIdentity,
-  clearBrowserAnalysisSession,
+  clearBrowserLocalSession,
   defaultBrowserRepositoryForm,
   loadBrowserAnalysisSession,
+  loadBrowserFollowUpState,
+  loadBrowserLocalSession,
   saveBrowserAnalysisSession,
-} from "../../../src/infrastructure/persistence/browser-analysis-session-storage";
+  saveBrowserFollowUpState,
+  saveBrowserLocalSession,
+} from "../../../src/infrastructure/persistence/browser-local-session-storage";
 
 describe("browser-analysis-session-storage", () => {
-  it("round-trips the browser analysis session with the latest report", () => {
+  it("round-trips the browser local session with analysis and chat state", () => {
     const storage = new FakeStorage();
-    const session: BrowserAnalysisSession = {
-      schemaVersion: "browser-analysis-session.v1",
-      form: {
-        provider: "local-fixture",
-        name: "minimal-node-library",
-        revision: "fixture",
-        selectedModel: "fixture-default",
+    const session: BrowserLocalSession = {
+      schemaVersion: "browser-local-session.v1",
+      analysis: {
+        form: {
+          provider: "local-fixture",
+          name: "minimal-node-library",
+          revision: "fixture",
+          selectedModel: "fixture-default",
+        },
+        latestReport: analysis,
       },
-      latestReport: analysis,
+      followUpThreads: {
+        "report:minimal-node-library": followUpState,
+      },
       updatedAt: "2026-04-26T10:00:00-07:00",
     };
 
-    saveBrowserAnalysisSession(storage, session);
+    saveBrowserLocalSession(storage, session);
 
-    expect(loadBrowserAnalysisSession(storage)).toEqual(session);
+    expect(loadBrowserLocalSession(storage)).toEqual(session);
+    expect(loadBrowserAnalysisSession(storage)).toEqual(session.analysis);
+    expect(
+      loadBrowserFollowUpState(storage, "report:minimal-node-library"),
+    ).toEqual(followUpState);
+  });
+
+  it("keeps follow-up threads when analysis is saved and keeps analysis when chat is saved", () => {
+    const storage = new FakeStorage();
+
+    saveBrowserAnalysisSession(storage, {
+      form: defaultBrowserRepositoryForm(),
+      latestReport: analysis,
+    });
+    saveBrowserFollowUpState(
+      storage,
+      "report:minimal-node-library",
+      followUpState,
+    );
+
+    expect(loadBrowserAnalysisSession(storage)).toEqual({
+      form: defaultBrowserRepositoryForm(),
+      latestReport: analysis,
+    });
+    expect(
+      loadBrowserFollowUpState(storage, "report:minimal-node-library"),
+    ).toEqual(followUpState);
   });
 
   it("discards invalid JSON and schema mismatches", () => {
     const storage = new FakeStorage({
-      raw: JSON.stringify({ schemaVersion: "browser-analysis-session.v0" }),
+      raw: JSON.stringify({ schemaVersion: "browser-local-session.v0" }),
     });
 
+    expect(loadBrowserLocalSession(storage)).toBeNull();
     expect(loadBrowserAnalysisSession(storage)).toBeNull();
+    expect(
+      loadBrowserFollowUpState(storage, "report:minimal-node-library"),
+    ).toBeNull();
 
     storage.raw = "{ not json";
-    expect(loadBrowserAnalysisSession(storage)).toBeNull();
+    expect(loadBrowserLocalSession(storage)).toBeNull();
   });
 
   it("can clear the stored browser session", () => {
     const storage = new FakeStorage();
     saveBrowserAnalysisSession(storage, {
-      schemaVersion: "browser-analysis-session.v1",
       form: defaultBrowserRepositoryForm(),
-      updatedAt: "2026-04-26T10:00:00-07:00",
+      latestReport: analysis,
     });
+    saveBrowserFollowUpState(
+      storage,
+      "report:minimal-node-library",
+      followUpState,
+    );
 
-    clearBrowserAnalysisSession(storage);
+    clearBrowserLocalSession(storage);
 
-    expect(loadBrowserAnalysisSession(storage)).toBeNull();
+    expect(loadBrowserLocalSession(storage)).toBeNull();
   });
 
   it("can reconstruct a repository form from a repository identity", () => {
@@ -156,4 +202,80 @@ const analysis: AnalyzeRepositoryResponse = {
       totalBranchLikeTokenCount: 0,
     },
   },
+};
+
+const followUpState: BrowserFollowUpState = {
+  sessions: [
+    {
+      conversation: {
+        id: "conversation:report:minimal-node-library:0",
+        schemaVersion: "conversation.v1",
+        reportCardId: "report:minimal-node-library",
+        repository: {
+          provider: "local-fixture",
+          name: "minimal-node-library",
+          revision: "fixture",
+        },
+        target: {
+          kind: "report",
+        },
+        messages: [
+          {
+            id: "message:user:0",
+            role: "user",
+            content: "What should we inspect first?",
+            citations: [],
+            assumptions: [],
+            createdAt: "2026-04-26T09:55:00-07:00",
+          },
+          {
+            id: "message:assistant:0",
+            role: "assistant",
+            content: "Inspect the package manifest and test surface.",
+            citations: [],
+            assumptions: [],
+            createdAt: "2026-04-26T09:56:00-07:00",
+          },
+        ],
+        createdAt: "2026-04-26T09:55:00-07:00",
+        updatedAt: "2026-04-26T09:56:00-07:00",
+      },
+      target: {
+        kind: "report",
+      },
+      answer: {
+        answer: {
+          schemaVersion: "chat-answer.v1",
+          status: "answered",
+          summary: "Inspect the package manifest and test surface.",
+          evidenceBackedClaims: [
+            {
+              claim: "The manifest provides the primary evidence.",
+              citations: [
+                {
+                  evidenceReference: {
+                    id: "evidence:package-json",
+                    kind: "file",
+                    label: "Package manifest",
+                    path: "package.json",
+                  },
+                },
+              ],
+            },
+          ],
+          assumptions: [],
+          caveats: [],
+          suggestedNextQuestions: [],
+        },
+        metadata: {
+          provider: "fixture",
+          modelName: "demo-chat-reviewer",
+          generatedAt: "2026-04-26T09:56:00-07:00",
+        },
+      },
+      evidenceSummary: "Retrieved 1 snippet from Package manifest.",
+      title: "Report: What should we inspect first?",
+    },
+  ],
+  activeConversationId: "conversation:report:minimal-node-library:0",
 };


### PR DESCRIPTION
Summary:\n- Store repository form state, latest report output, and per-report follow-up threads behind one versioned browser-local envelope.\n- Route report and follow-up hydration through the shared adapter boundary.\n- Keep invalid JSON and schema/version mismatches as a clean reset path.\n- Document the local-only persistence behavior and future database migration path.\n\nValidation:\n- pnpm exec vitest run test/infrastructure/persistence/browser-analysis-session-storage.test.ts src/components/chat/follow-up-panel.test.tsx\n- pnpm test:e2e -- e2e/app-shell.spec.ts\n- pnpm check\n\nIssue: #74