### PR TITLE
chore(tooling): add lefthook red-green commit gate (#104)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,4 @@ If a task conflicts with those documents, call out the conflict before editing. 
 - Use fake adapters for tests before wiring real infrastructure.
 - Preserve provenance, confidence, caveats, and missing evidence in report behavior.
 - Do not treat raw test LOC, raw coverage, or single static scores as direct proof of repository quality.
+- Red-green enforcement is shared tooling, not a judgment call: `.claude/settings.json` guards in-session source edits, `lefthook.yml` guards staged commits, and both rely on `scripts/red-green-gate.ts`. Update the script and the two hook surfaces together when changing the workflow.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -350,6 +350,7 @@ Pre-commit should stay fast:
 - Format or format-check staged files
 - Run Oxlint on staged JavaScript/TypeScript files
 - Block obvious forbidden type escapes such as `as any`, `: any`, `<any>`, and double assertions through `unknown`
+- Enforce the shared red-green commit gate against staged source edits that skip a colocated test change
 
 Pre-push should run the stronger local gate:
 - `pnpm check`

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -794,7 +794,7 @@ Acceptance criteria:
 - CI command runs lint, format check, typecheck, unit tests, build, and foundational E2E
 - GitHub Actions workflow is planned for the CI command
 - Local hook runner is selected, with Lefthook preferred
-- Pre-commit hook plan covers staged formatting/linting and forbidden type-escape checks
+- Pre-commit hook plan covers staged formatting/linting, forbidden type-escape checks, and the shared red-green commit gate
 - Pre-push hook plan covers the local `check` command
 - Commit-msg hook plan enforces Conventional Commit subjects
 - PR title or squash-merge title check enforces Conventional Commit format in CI

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,8 @@
+# red-green:exempt — commit hook configuration is tooling-only and validated through the shared gate tests
 pre-commit:
   commands:
+    red-green-gate:
+      run: node scripts/red-green-gate.ts --staged
     type-escape-check:
       run: pnpm run type-escape:check
     barrel-files-check:

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scripts/red-green-gate.ts
+++ b/scripts/red-green-gate.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { dirname, join, relative } from "node:path";
 import { pathToFileURL } from "node:url";
 import process from "node:process";
@@ -128,8 +129,9 @@ const DEFAULT_ALLOWLIST: readonly string[] = [
 ];
 
 const RECENCY_WINDOW_MS = 30 * 60 * 1000;
-const EXEMPT_MARKER_REGEX = /\/\/\s*red-green:exempt\b/i;
+const EXEMPT_MARKER_REGEX = /(?:\/\/|#)\s*red-green:exempt\b/i;
 const HANDLED_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+const STAGED_MODE_FLAG = "--staged";
 
 export function loadLedger(ledgerPath: string): Ledger {
   if (!existsSync(ledgerPath)) {
@@ -213,6 +215,11 @@ function extractNewContent(toolName: string, toolInput: unknown): string {
 }
 
 async function main(): Promise<void> {
+  if (process.argv.includes(STAGED_MODE_FLAG)) {
+    await mainForStagedCommit();
+    return;
+  }
+
   const stdin = await readStdin();
   if (stdin.trim() === "") {
     process.exit(0);
@@ -282,6 +289,87 @@ async function main(): Promise<void> {
   process.stderr.write(`${decision.reason}\n`);
   process.stderr.write(`Blocked: ${decision.blockedFiles.join(", ")}\n`);
   process.exit(2);
+}
+
+async function mainForStagedCommit(): Promise<void> {
+  const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+  const stagedFiles = readStagedFiles(projectDir);
+  const stagedPaths = stagedFiles.map((file) => file.path);
+  const stagedTestFiles = stagedFiles
+    .filter((file) => isTestFile(file.path))
+    .map((file) => file.path);
+
+  const overrideMarkers = new Map<string, string>();
+  for (const file of stagedFiles) {
+    if (EXEMPT_MARKER_REGEX.test(file.content)) {
+      overrideMarkers.set(file.path, "inline marker");
+    }
+  }
+
+  const decision = decide({
+    filesTouched: stagedPaths,
+    recentTestEdits: stagedTestFiles,
+    allowlist: DEFAULT_ALLOWLIST,
+    overrideMarkers,
+  });
+
+  if (decision.allowed) {
+    process.exit(0);
+  }
+
+  process.stderr.write(`${decision.reason}\n`);
+  process.stderr.write(`Blocked: ${decision.blockedFiles.join(", ")}\n`);
+  process.exit(2);
+}
+
+function readStagedFiles(
+  projectDir: string,
+): readonly { path: string; content: string }[] {
+  const stagedNames = spawnSync(
+    "git",
+    ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMR"],
+    {
+      cwd: projectDir,
+      encoding: "utf8",
+    },
+  );
+
+  if (stagedNames.error !== undefined || stagedNames.status !== 0) {
+    const message =
+      stagedNames.error?.message ??
+      stagedNames.stderr?.toString() ??
+      "unable to read staged files";
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  }
+
+  const filePaths = stagedNames.stdout
+    .split("\0")
+    .map((filePath) => filePath.trim())
+    .filter((filePath) => filePath !== "");
+
+  const stagedFiles: { path: string; content: string }[] = [];
+  for (const filePath of filePaths) {
+    const stagedContent = spawnSync("git", ["show", `:${filePath}`], {
+      cwd: projectDir,
+      encoding: "utf8",
+    });
+    if (stagedContent.error !== undefined || stagedContent.status !== 0) {
+      const message =
+        stagedContent.error?.message ??
+        stagedContent.stderr?.toString() ??
+        `unable to read staged content for ${filePath}`;
+      process.stderr.write(`${message}\n`);
+      process.exit(1);
+    }
+
+    stagedFiles.push({
+      path: filePath,
+      content: stagedContent.stdout,
+    });
+  }
+
+  return stagedFiles;
 }
 
 if (

--- a/test/tooling/red-green-gate.test.ts
+++ b/test/tooling/red-green-gate.test.ts
@@ -40,10 +40,32 @@ function runHook(
   });
 }
 
+function runCommitGate(options: {
+  readonly projectDir: string;
+}): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, [scriptPath, "--staged"], {
+    cwd: options.projectDir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: options.projectDir,
+    },
+  });
+}
+
 function makeProjectDir(): string {
   const dir = mkdtempSync(path.join(tmpdir(), "green-rg-"));
   mkdirSync(path.join(dir, "src"), { recursive: true });
   mkdirSync(path.join(dir, "docs"), { recursive: true });
+  spawnSync("git", ["init"], { cwd: dir, encoding: "utf8" });
+  spawnSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  spawnSync("git", ["config", "user.name", "Test User"], {
+    cwd: dir,
+    encoding: "utf8",
+  });
   return dir;
 }
 
@@ -348,6 +370,110 @@ describe("red-green-gate CLI", () => {
         },
         { projectDir },
       );
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("red-green-gate staged commit gate", () => {
+  it("blocks a staged source file when the colocated test file is not staged", () => {
+    const projectDir = makeProjectDir();
+    try {
+      writeFileSync(
+        path.join(projectDir, "src/foo.tsx"),
+        "export const a = 1;\n",
+      );
+      spawnSync("git", ["add", "src/foo.tsx"], {
+        cwd: projectDir,
+        encoding: "utf8",
+      });
+
+      const result = runCommitGate({ projectDir });
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toMatch(/colocated test/i);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows a staged source file when the colocated test file is staged too", () => {
+    const projectDir = makeProjectDir();
+    try {
+      writeFileSync(
+        path.join(projectDir, "src/foo.tsx"),
+        "export const a = 1;\n",
+      );
+      writeFileSync(
+        path.join(projectDir, "src/foo.test.tsx"),
+        "import { it } from 'vitest';\nit('a', () => {});\n",
+      );
+      spawnSync("git", ["add", "src/foo.tsx", "src/foo.test.tsx"], {
+        cwd: projectDir,
+        encoding: "utf8",
+      });
+
+      const result = runCommitGate({ projectDir });
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows allowlisted staged files without a paired test", () => {
+    const projectDir = makeProjectDir();
+    try {
+      writeFileSync(path.join(projectDir, "docs/note.md"), "# note\n");
+      spawnSync("git", ["add", "docs/note.md"], {
+        cwd: projectDir,
+        encoding: "utf8",
+      });
+
+      const result = runCommitGate({ projectDir });
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows a staged source file when the inline exemption marker is present", () => {
+    const projectDir = makeProjectDir();
+    try {
+      writeFileSync(
+        path.join(projectDir, "src/foo.tsx"),
+        "// red-green:exempt — config-only change\nexport const a = 1;\n",
+      );
+      spawnSync("git", ["add", "src/foo.tsx"], {
+        cwd: projectDir,
+        encoding: "utf8",
+      });
+
+      const result = runCommitGate({ projectDir });
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(projectDir, { force: true, recursive: true });
+    }
+  });
+
+  it("allows a staged YAML hook config file when the inline exemption marker is present", () => {
+    const projectDir = makeProjectDir();
+    try {
+      writeFileSync(
+        path.join(projectDir, "lefthook.yml"),
+        "# red-green:exempt — hook wiring is tooling-only\npre-commit:\n  commands: {}\n",
+      );
+      spawnSync("git", ["add", "lefthook.yml"], {
+        cwd: projectDir,
+        encoding: "utf8",
+      });
+
+      const result = runCommitGate({ projectDir });
 
       expect(result.status).toBe(0);
     } finally {


### PR DESCRIPTION
## Scope

Implements PR2 of #104: a Lefthook pre-commit gate that reuses the shared red-green enforcement script against the staged diff.

## What changed

- Added a Lefthook pre-commit command that runs node scripts/red-green-gate.ts --staged
- Extended the shared gate script to inspect staged files via git diff --cached
- Reused the same allowlist and inline exemption marker path from the Claude hook
- Recognized YAML # red-green:exempt markers so hook configuration can be maintained without a bypass
- Added deterministic tests for negative and positive staged-commit cases, including the hook config exemption path
- Updated AGENTS.md, docs/architecture.md, and docs/development-plan.md to point at the shared enforcement model

## Validation

- pnpm exec vitest run test/tooling/red-green-gate.test.ts
- pnpm check
- pnpm build
- pnpm test:e2e -- e2e/app-shell.spec.ts

Issue: #104