### PR TITLE
test(ui): add red parity harness (#115)

### DIFF
--- a/docs/red-parity.md
+++ b/docs/red-parity.md
@@ -72,6 +72,14 @@ Product-surface parity means a user can exercise those capabilities through the 
 
 Future parity PRs should cite which checklist items they satisfy.
 
+The executable parity harness lives in `e2e/red-ui-parity.spec.ts`. It is opt-in until the milestone 7 implementation issues satisfy the red product surface:
+
+```bash
+pnpm test:e2e:red-parity
+```
+
+The normal CI E2E command keeps running the stable foundational workflow. UI parity PRs should run the red-parity harness locally and call out whether the remaining failures are expected for later milestone issues.
+
 ## UI/UX Parity Checklist
 
 ### Analysis Shell
@@ -133,7 +141,7 @@ Milestone `7. Red UI/UX Parity` tracks the follow-up work:
 
 | Issue | Scope |
 | --- | --- |
-| #115 | Add a red UI/UX parity workflow harness. |
+| #115 | Add the opt-in red UI/UX parity workflow harness. |
 | #116 | Support red-style GitHub URL analysis with reviewer config. |
 | #117 | Replace provider form with red-style analysis shell. |
 | #118 | Build red-compatible report dashboard view model. |

--- a/e2e/red-ui-parity.spec.ts
+++ b/e2e/red-ui-parity.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+
+const parityEnabled = process.env.RED_UI_PARITY === "1";
+
+test.skip(
+  !parityEnabled,
+  "Red UI parity harness is opt-in until milestone 7 UI slices satisfy it.",
+);
+
+test.describe("red UI/UX parity", () => {
+  test.setTimeout(45_000);
+
+  test("matches the red first-screen analysis workflow", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(
+      page.getByText("Repository Quality", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Report Card" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("GitHub repository URL")).toBeVisible();
+    await expect(page.getByLabel("OpenRouter API key")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Analyze" })).toBeVisible();
+
+    await page.getByText("Advanced", { exact: true }).click();
+    await expect(page.getByLabel("OpenRouter Model")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Use Free Router" }),
+    ).toBeVisible();
+
+    await expect(page.getByText("No report loaded")).toBeVisible();
+    await expect(
+      page.getByText("Enter a repository URL to begin."),
+    ).toBeVisible();
+  });
+
+  test("matches the red report dashboard workflow", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByLabel("GitHub repository URL")).toBeVisible();
+    await page
+      .getByLabel("GitHub repository URL")
+      .fill("https://github.com/lightstrikelabs/repo-analyzer-green");
+    await page.getByRole("button", { name: "Analyze" }).click();
+
+    await expect(page.getByText("Reviewer Notes")).toBeVisible();
+    await expect(page.getByText("Overall Score")).toBeVisible();
+    await expect(page.getByText("Source Files")).toBeVisible();
+    await expect(page.getByText("Code Lines")).toBeVisible();
+    await expect(page.getByText("Test Ratio")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Language Mix" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Download PDF" }),
+    ).toBeVisible();
+
+    await expect(page.getByText("Provider", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("Repository name")).toHaveCount(0);
+    await expect(page.getByText("Revision", { exact: true })).toHaveCount(0);
+
+    for (const section of [
+      "Maintainability",
+      "Testing",
+      "Security",
+      "Architecture",
+      "Documentation",
+    ]) {
+      const panel = page.locator("article").filter({ hasText: section });
+      await expect(panel.getByRole("heading", { name: section })).toBeVisible();
+      await expect(panel.getByText("Signals")).toBeVisible();
+      await expect(panel.getByText("Next Checks")).toBeVisible();
+      await expect(panel.getByLabel(`Ask About ${section}`)).toBeVisible();
+      await expect(
+        panel.getByRole("button", { name: "Open Chat" }),
+      ).toBeVisible();
+    }
+  });
+
+  test("matches the red section chat workflow", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByLabel("GitHub repository URL")).toBeVisible();
+    await page
+      .getByLabel("GitHub repository URL")
+      .fill("https://github.com/lightstrikelabs/repo-analyzer-green");
+    await page.getByRole("button", { name: "Analyze" }).click();
+
+    const maintainability = page.locator("article").filter({
+      has: page.getByRole("heading", { name: "Maintainability" }),
+    });
+    await maintainability
+      .getByLabel("Ask About Maintainability")
+      .fill("What should we fix first?");
+    await maintainability.getByRole("button", { name: "Open Chat" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "What should we fix first?" }),
+    ).toBeVisible();
+    await expect(page.getByText("Conversations")).toBeVisible();
+    await expect(page.getByText("Searches matching repo files")).toBeVisible();
+
+    await page.getByRole("button", { name: "Close chat" }).click();
+
+    await expect(page.getByText("Chats")).toBeVisible();
+    await expect(page.getByText("Recent Threads")).toBeVisible();
+    await expect(page.getByText("What should we fix first?")).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:e2e:red-parity": "RED_UI_PARITY=1 playwright test e2e/red-ui-parity.spec.ts",
     "check": "pnpm run type-escape:check && pnpm run barrel-files:check && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test",
     "ci": "pnpm check && pnpm build && pnpm test:e2e"
   },


### PR DESCRIPTION
## Scope

Closes #115 by adding an opt-in Playwright harness for the red UI/UX product surface.

## What changed

- Added `e2e/red-ui-parity.spec.ts` with red-baseline assertions for:
  - first-screen analysis workflow
  - report dashboard workflow
  - section-scoped chat workflow
- Added `pnpm test:e2e:red-parity` to run the harness with `RED_UI_PARITY=1`
- Documented the opt-in command in `docs/red-parity.md`

## Red/Green Evidence

Expected red command:

```text
pnpm test:e2e:red-parity
```

Current expected failures:

- `Repository Quality` is not present in the first-screen shell
- `GitHub repository URL` is not present in the current provider/fixture form
- report/chat parity assertions fail at the same missing first-screen input

CI-safe green commands:

```text
pnpm check
pnpm build
pnpm test:e2e
```

Default E2E skips the parity harness until milestone 7 UI slices satisfy it, while keeping the foundational workflow green.

Issue: #115