### PR TITLE
feat(api): accept red-style analyze requests (#116)

### DIFF
--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import type {
   AnalyzeRepositoryReportCardResult,
+  AnalyzeRepositoryInput,
   AnalyzeRepositoryResult,
 } from "../../../application/analyze-repository/analyze-repository";
 import { buildAnalyzeRepositoryResponse } from "../../../application/analyze-repository/analyze-repository-response";
 import { RepositorySourceError } from "../../../domain/repository/repository-source";
-import { handleAnalyzeRequest } from "./route";
+import { OpenRouterDefaultBaseUrl } from "../../../infrastructure/llm/openrouter-config";
+import { handleAnalyzeRequest, type AnalyzeRouteOptions } from "./route";
 
 const validRequestBody = {
   repository: {
@@ -173,6 +175,86 @@ const reportResult: AnalyzeRepositoryReportCardResult = {
 };
 
 describe("POST /api/analyze", () => {
+  it("accepts red-style GitHub repository URL requests with reviewer config", async () => {
+    let received:
+      | {
+          readonly input: AnalyzeRepositoryInput;
+          readonly options: AnalyzeRouteOptions;
+        }
+      | undefined;
+
+    const response = await handleAnalyzeRequest(
+      jsonRequest({
+        repoUrl: "https://github.com/lightstrikelabs/repo-analyzer-green",
+        apiKey: " sk-or-v1-test ",
+        model: "openai/gpt-4.1-mini",
+      }),
+      {
+        analyze: async (input, options) => {
+          received = { input, options };
+          return reportResult;
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(received).toEqual({
+      input: {
+        repository: {
+          provider: "github",
+          owner: "lightstrikelabs",
+          name: "repo-analyzer-green",
+          url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+        },
+      },
+      options: {
+        openRouterConfig: {
+          provider: "openrouter",
+          apiKey: "sk-or-v1-test",
+          model: "openai/gpt-4.1-mini",
+          baseUrl: OpenRouterDefaultBaseUrl,
+        },
+      },
+    });
+  });
+
+  it("accepts red-style GitHub repository URL requests without persisting reviewer credentials", async () => {
+    let receivedOptions: AnalyzeRouteOptions | undefined;
+
+    const response = await handleAnalyzeRequest(
+      jsonRequest({
+        repoUrl: "https://github.com/lightstrikelabs/repo-analyzer-green",
+      }),
+      {
+        analyze: async (_input, options) => {
+          receivedOptions = options;
+          return reportResult;
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(receivedOptions).toEqual({});
+  });
+
+  it("rejects red-style requests that are not GitHub repository URLs", async () => {
+    const response = await handleAnalyzeRequest(
+      jsonRequest({
+        repoUrl: "https://gitlab.com/lightstrikelabs/repo-analyzer-green",
+      }),
+      {
+        analyze: async () => reportResult,
+      },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("invalid-request");
+    expect(body.error.issues[0]).toMatchObject({
+      path: ["repoUrl"],
+    });
+  });
+
   it("validates the request and returns the report card from the analyzer", async () => {
     const response = await handleAnalyzeRequest(jsonRequest(validRequestBody), {
       analyze: async () => reportResult,

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -9,19 +9,36 @@ import {
 } from "../../../application/analyze-repository/analyze-repository";
 import { buildAnalyzeRepositoryResponse } from "../../../application/analyze-repository/analyze-repository-response";
 import { LocalFixtureRepositorySource } from "../../../infrastructure/filesystem/local-fixture-repository-source";
+import { GitHubArchiveRepositorySource } from "../../../infrastructure/github/github-archive-repository-source";
+import { GitHubRepositoryUrlSchema } from "../../../infrastructure/github/github-repository-url";
+import {
+  OpenRouterDefaultBaseUrl,
+  OpenRouterDefaultModelId,
+  OpenRouterModelIdSchema,
+  type OpenRouterProviderConfig,
+} from "../../../infrastructure/llm/openrouter-config";
 import { FakeReviewer } from "../../../infrastructure/reviewer/fake-reviewer";
+import { OpenRouterReviewer } from "../../../infrastructure/reviewer/openrouter-reviewer";
+import { StaticEvidenceReviewer } from "../../../infrastructure/reviewer/static-evidence-reviewer";
 import {
   RepositorySourceError,
   type RepositoryReference,
+  type RepositorySource,
 } from "../../../domain/repository/repository-source";
+import type { Reviewer } from "../../../domain/reviewer/reviewer";
 import {
   ReviewerAssessmentSchemaVersion,
   type ReviewerAssessment,
 } from "../../../domain/reviewer/reviewer-assessment";
 
+export type AnalyzeRouteOptions = {
+  readonly openRouterConfig?: OpenRouterProviderConfig;
+};
+
 type AnalyzeRouteDependencies = {
   readonly analyze: (
     input: AnalyzeRepositoryInput,
+    options: AnalyzeRouteOptions,
   ) => Promise<AnalyzeRepositoryResult>;
 };
 
@@ -30,7 +47,7 @@ type ApiValidationIssue = {
   readonly message: string;
 };
 
-const AnalyzeRepositoryRequestSchema = z
+const StructuredAnalyzeRepositoryRequestSchema = z
   .object({
     repository: z
       .object({
@@ -44,7 +61,46 @@ const AnalyzeRepositoryRequestSchema = z
   })
   .strict();
 
-type AnalyzeRepositoryRequest = z.infer<typeof AnalyzeRepositoryRequestSchema>;
+const RedStyleAnalyzeRepositoryRequestSchema = z
+  .object({
+    repoUrl: GitHubRepositoryUrlSchema,
+    apiKey: z.preprocess(normalizeOptionalText, z.string().min(1).optional()),
+    model: OpenRouterModelIdSchema.optional(),
+  })
+  .strict();
+
+type StructuredAnalyzeRepositoryRequest = z.infer<
+  typeof StructuredAnalyzeRepositoryRequestSchema
+>;
+
+type RedStyleAnalyzeRepositoryRequest = z.infer<
+  typeof RedStyleAnalyzeRepositoryRequestSchema
+>;
+
+type ParsedAnalyzeRepositoryRequest =
+  | {
+      readonly kind: "structured";
+      readonly data: StructuredAnalyzeRepositoryRequest;
+    }
+  | {
+      readonly kind: "red-style";
+      readonly data: RedStyleAnalyzeRepositoryRequest;
+    };
+
+type AnalyzeRequestParseResult =
+  | {
+      readonly success: true;
+      readonly request: ParsedAnalyzeRepositoryRequest;
+    }
+  | {
+      readonly success: false;
+      readonly issues: readonly z.core.$ZodIssue[];
+    };
+
+type NormalizedAnalyzeRequest = {
+  readonly repository: RepositoryReference;
+  readonly options: AnalyzeRouteOptions;
+};
 
 export async function POST(request: Request): Promise<Response> {
   return handleAnalyzeRequest(request, {
@@ -65,20 +121,24 @@ export async function handleAnalyzeRequest(
     });
   }
 
-  const parseResult = AnalyzeRepositoryRequestSchema.safeParse(bodyResult.body);
+  const parseResult = parseAnalyzeRepositoryRequest(bodyResult.body);
 
   if (!parseResult.success) {
     return jsonError(400, {
       code: "invalid-request",
       message: "Request body did not match the analyze contract.",
-      issues: parseResult.error.issues.map(toApiValidationIssue),
+      issues: parseResult.issues.map(toApiValidationIssue),
     });
   }
+  const normalizedRequest = normalizeAnalyzeRequest(parseResult.request);
 
   try {
-    const result = await dependencies.analyze({
-      repository: toRepositoryReference(parseResult.data.repository),
-    });
+    const result = await dependencies.analyze(
+      {
+        repository: normalizedRequest.repository,
+      },
+      normalizedRequest.options,
+    );
 
     if (result.kind === "reviewer-malformed-response") {
       return jsonError(502, {
@@ -102,7 +162,7 @@ export async function handleAnalyzeRequest(
 }
 
 function toRepositoryReference(
-  repository: AnalyzeRepositoryRequest["repository"],
+  repository: StructuredAnalyzeRepositoryRequest["repository"],
 ): RepositoryReference {
   return {
     provider: repository.provider,
@@ -115,28 +175,89 @@ function toRepositoryReference(
   };
 }
 
+function parseAnalyzeRepositoryRequest(
+  body: unknown,
+): AnalyzeRequestParseResult {
+  if (typeof body === "object" && body !== null && "repoUrl" in body) {
+    const result = RedStyleAnalyzeRepositoryRequestSchema.safeParse(body);
+    return result.success
+      ? {
+          success: true,
+          request: {
+            kind: "red-style",
+            data: result.data,
+          },
+        }
+      : {
+          success: false,
+          issues: result.error.issues,
+        };
+  }
+
+  const result = StructuredAnalyzeRepositoryRequestSchema.safeParse(body);
+  return result.success
+    ? {
+        success: true,
+        request: {
+          kind: "structured",
+          data: result.data,
+        },
+      }
+    : {
+        success: false,
+        issues: result.error.issues,
+      };
+}
+
+function normalizeAnalyzeRequest(
+  request: ParsedAnalyzeRepositoryRequest,
+): NormalizedAnalyzeRequest {
+  if (request.kind === "structured") {
+    return {
+      repository: toRepositoryReference(request.data.repository),
+      options: {},
+    };
+  }
+
+  return {
+    repository: request.data.repoUrl,
+    options: openRouterRouteOptions(request.data),
+  };
+}
+
+function openRouterRouteOptions(
+  request: RedStyleAnalyzeRepositoryRequest,
+): AnalyzeRouteOptions {
+  if (request.apiKey === undefined) {
+    return {};
+  }
+
+  return {
+    openRouterConfig: {
+      provider: "openrouter",
+      apiKey: request.apiKey,
+      model: request.model ?? OpenRouterDefaultModelId,
+      baseUrl: OpenRouterDefaultBaseUrl,
+    },
+  };
+}
+
 async function analyzeWithDefaultDependencies(
   input: AnalyzeRepositoryInput,
+  options: AnalyzeRouteOptions,
 ): Promise<AnalyzeRepositoryResult> {
-  return analyzeRepository(input, {
-    repositorySource: new LocalFixtureRepositorySource({
-      fixtures: {
-        "minimal-node-library": {
-          id: "minimal-node-library",
-          rootPath: path.join(
-            process.cwd(),
-            "test/fixtures/repositories/minimal-node-library",
-          ),
-        },
-      },
-    }),
-    reviewer: new FakeReviewer({
-      result: {
-        kind: "assessment",
-        assessment: defaultReviewerAssessment,
-      },
-    }),
-  });
+  const repositorySource = repositorySourceFor(input.repository);
+
+  try {
+    return await analyzeRepository(input, {
+      repositorySource,
+      reviewer: reviewerFor(input.repository, options),
+    });
+  } finally {
+    if (repositorySource instanceof GitHubArchiveRepositorySource) {
+      await repositorySource.dispose();
+    }
+  }
 }
 
 function repositorySourceErrorResponse(error: RepositorySourceError): Response {
@@ -214,6 +335,57 @@ function jsonError(
       status,
     },
   );
+}
+
+function repositorySourceFor(
+  repository: RepositoryReference,
+): RepositorySource {
+  if (repository.provider === "github") {
+    return new GitHubArchiveRepositorySource();
+  }
+
+  return new LocalFixtureRepositorySource({
+    fixtures: {
+      "minimal-node-library": {
+        id: "minimal-node-library",
+        rootPath: path.join(
+          process.cwd(),
+          "test/fixtures/repositories/minimal-node-library",
+        ),
+      },
+    },
+  });
+}
+
+function reviewerFor(
+  repository: RepositoryReference,
+  options: AnalyzeRouteOptions,
+): Reviewer {
+  if (options.openRouterConfig !== undefined) {
+    return new OpenRouterReviewer({
+      config: options.openRouterConfig,
+    });
+  }
+
+  if (repository.provider === "github") {
+    return new StaticEvidenceReviewer();
+  }
+
+  return new FakeReviewer({
+    result: {
+      kind: "assessment",
+      assessment: defaultReviewerAssessment,
+    },
+  });
+}
+
+function normalizeOptionalText(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
 }
 
 const defaultReviewerAssessment: ReviewerAssessment = {

--- a/src/infrastructure/reviewer/static-evidence-reviewer.test.ts
+++ b/src/infrastructure/reviewer/static-evidence-reviewer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { StaticEvidenceReviewer } from "./static-evidence-reviewer";
+
+describe("StaticEvidenceReviewer", () => {
+  it("returns deterministic reviewer assessment for the red no-key path", async () => {
+    const reviewer = new StaticEvidenceReviewer({
+      now: () => new Date("2026-04-26T14:15:00-07:00"),
+    });
+
+    const result = await reviewer.assess({
+      repository: {
+        provider: "github",
+        owner: "lightstrikelabs",
+        name: "repo-analyzer-green",
+        url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+      },
+      evidenceSummary:
+        "Files analyzed: 109 Source files: 109 Test files: 49 Documentation files: 27",
+      evidenceReferences: [
+        {
+          id: "evidence:file-inventory",
+          kind: "collector",
+          label: "File inventory",
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      kind: "assessment",
+      assessment: {
+        schemaVersion: "reviewer-assessment.v1",
+        reviewer: {
+          kind: "automated",
+          name: "Static evidence reviewer",
+          reviewedAt: "2026-04-26T21:15:00.000Z",
+        },
+        assessedArchetype: {
+          value: "unknown",
+        },
+      },
+    });
+
+    if (result.kind !== "assessment") {
+      throw new Error("Expected deterministic assessment");
+    }
+
+    expect(
+      result.assessment.dimensions.map((dimension) => dimension.dimension),
+    ).toEqual([
+      "maintainability",
+      "verifiability",
+      "security",
+      "architecture-boundaries",
+      "documentation",
+    ]);
+    expect(
+      result.assessment.dimensions.every(
+        (dimension) => dimension.evidenceReferences.length > 0,
+      ),
+    ).toBe(true);
+    expect(result.assessment.followUpQuestions[0]).toMatchObject({
+      targetDimension: "maintainability",
+    });
+  });
+});

--- a/src/infrastructure/reviewer/static-evidence-reviewer.ts
+++ b/src/infrastructure/reviewer/static-evidence-reviewer.ts
@@ -1,0 +1,197 @@
+import type { ReportDimensionKey } from "../../domain/report/report-card";
+import type {
+  Reviewer,
+  ReviewerRequest,
+  ReviewerResult,
+} from "../../domain/reviewer/reviewer";
+import { ReviewerAssessmentSchemaVersion } from "../../domain/reviewer/reviewer-assessment";
+import type { EvidenceReference } from "../../domain/shared/evidence-reference";
+
+export type StaticEvidenceReviewerOptions = {
+  readonly now?: () => Date;
+};
+
+export class StaticEvidenceReviewer implements Reviewer {
+  private readonly now: () => Date;
+
+  constructor(options: StaticEvidenceReviewerOptions = {}) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async assess(request: ReviewerRequest): Promise<ReviewerResult> {
+    const evidenceReferences = evidenceReferencesFor(request);
+
+    return {
+      kind: "assessment",
+      assessment: {
+        schemaVersion: ReviewerAssessmentSchemaVersion,
+        reviewer: {
+          kind: "automated",
+          name: "Static evidence reviewer",
+          reviewerVersion: "static-evidence-reviewer.v1",
+          reviewedAt: this.now().toISOString(),
+        },
+        assessedArchetype: {
+          value: "unknown",
+          confidence: {
+            level: "medium",
+            score: 0.55,
+            rationale:
+              "The static reviewer does not infer a project archetype beyond collected evidence.",
+          },
+          evidenceReferences: [...evidenceReferences],
+          rationale:
+            "No LLM reviewer key was supplied, so the report uses deterministic evidence-only interpretation.",
+        },
+        dimensions: dimensionsFor(request, evidenceReferences),
+        caveats: [
+          {
+            id: "caveat:static-reviewer",
+            summary:
+              "No OpenRouter key was supplied, so semantic reviewer interpretation is limited to deterministic evidence.",
+            affectedDimensions: [
+              "maintainability",
+              "verifiability",
+              "security",
+              "architecture-boundaries",
+              "documentation",
+            ],
+            missingEvidence: [
+              "Structured LLM or human reviewer assessment",
+              "Repository-specific semantic interpretation",
+            ],
+            confidence: {
+              level: "medium",
+              score: 0.6,
+              rationale:
+                "Static evidence can identify surface signals but cannot fully evaluate intent or design quality.",
+            },
+            evidenceReferences: [...evidenceReferences],
+          },
+        ],
+        followUpQuestions: [
+          {
+            id: "question:static-reviewer:first-fix",
+            question: "What should we inspect first?",
+            targetDimension: "maintainability",
+            rationale:
+              "The deterministic report should be followed by targeted review of the riskiest maintainability signals.",
+          },
+          {
+            id: "question:static-reviewer:test-risk",
+            question: "Which user-facing workflow is least protected by tests?",
+            targetDimension: "verifiability",
+            rationale:
+              "Static test counts need follow-up to determine whether critical behavior is actually covered.",
+          },
+        ],
+      },
+    };
+  }
+}
+
+function dimensionsFor(
+  request: ReviewerRequest,
+  evidenceReferences: readonly EvidenceReference[],
+) {
+  return [
+    dimension({
+      key: "maintainability",
+      summary:
+        "Static evidence was collected for file inventory, code shape, and deferred-work signals.",
+      strength:
+        "Repository structure and code-shape evidence are available for maintainability review.",
+      risk: "Static metrics cannot determine whether module boundaries match product responsibilities.",
+      request,
+      evidenceReferences,
+    }),
+    dimension({
+      key: "verifiability",
+      summary:
+        "Static evidence was collected for test files, scripts, and workflow signals.",
+      strength:
+        "Test and workflow evidence can identify whether a verification path exists.",
+      risk: "Test presence does not prove meaningful behavioral coverage.",
+      request,
+      evidenceReferences,
+    }),
+    dimension({
+      key: "security",
+      summary:
+        "Static evidence was collected for dependency, lockfile, environment, and secret-risk signals.",
+      strength:
+        "Security hygiene evidence can flag obvious repository-level risks.",
+      risk: "Static scanning cannot replace manual review of auth, data access, and secret handling.",
+      request,
+      evidenceReferences,
+    }),
+    dimension({
+      key: "architecture-boundaries",
+      summary:
+        "Static evidence was collected for project shape, directories, manifests, and source distribution.",
+      strength:
+        "Project structure evidence can show whether boundaries are visible.",
+      risk: "Architecture quality still requires semantic review of ownership and data flow.",
+      request,
+      evidenceReferences,
+    }),
+    dimension({
+      key: "documentation",
+      summary:
+        "Static evidence was collected for README, documentation files, and setup-related metadata.",
+      strength:
+        "Documentation inventory evidence can identify onboarding materials.",
+      risk: "Documentation presence does not prove that setup or operations guidance is accurate.",
+      request,
+      evidenceReferences,
+    }),
+  ];
+}
+
+function dimension(options: {
+  readonly key: ReportDimensionKey;
+  readonly summary: string;
+  readonly strength: string;
+  readonly risk: string;
+  readonly request: ReviewerRequest;
+  readonly evidenceReferences: readonly EvidenceReference[];
+}) {
+  return {
+    dimension: options.key,
+    summary: `${options.summary} ${summarySentence(options.request)}`,
+    confidence: {
+      level: "medium" as const,
+      score: 0.72,
+      rationale:
+        "The assessment is based on deterministic repository evidence without semantic reviewer enrichment.",
+    },
+    evidenceReferences: [...options.evidenceReferences],
+    strengths: [options.strength],
+    risks: [options.risk],
+    missingEvidence: ["Structured reviewer assessment"],
+  };
+}
+
+function evidenceReferencesFor(
+  request: ReviewerRequest,
+): readonly EvidenceReference[] {
+  if (request.evidenceReferences.length > 0) {
+    return request.evidenceReferences;
+  }
+
+  return [
+    {
+      id: "reviewer:static-evidence",
+      kind: "reviewer",
+      label: "Static evidence reviewer",
+      notes:
+        "No deterministic evidence references were supplied to the static reviewer.",
+    },
+  ];
+}
+
+function summarySentence(request: ReviewerRequest): string {
+  return request.evidenceSummary === undefined
+    ? "No evidence summary was available."
+    : request.evidenceSummary;
+}


### PR DESCRIPTION
## Scope

Implements #116: the analyze API now accepts red-style `{ repoUrl, apiKey, model }` requests while preserving the existing structured fixture request contract.

## What changed

- Added red-style request parsing for GitHub repository URLs
- Normalized GitHub URLs into `RepositoryReference` values through the existing parser
- Passed optional OpenRouter config through route options without persistence
- Kept no-key requests as deterministic analysis by adding `StaticEvidenceReviewer`
- Wired default route dependencies to select GitHub archive source for GitHub references and local fixture source for fixture references
- Kept local fixture/fake reviewer behavior intact for deterministic development and existing E2E

## Red/Green Evidence

Initial red:

- `pnpm exec vitest run src/app/api/analyze/route.test.ts` failed because `{ repoUrl }` requests returned 400 and validation pointed at the old `repository` object contract.

Green validation:

- `pnpm exec vitest run src/app/api/analyze/route.test.ts src/infrastructure/reviewer/static-evidence-reviewer.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm test:e2e`

## Security note

API keys are normalized into request-scoped OpenRouter config only. This PR does not add browser persistence or server persistence for user-supplied model credentials.

Issue: #116