### PR TITLE
chore(tooling): stabilize next route typegen (#127)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,6 +212,8 @@ Recommended script:
 }
 ```
 
+For this Next.js app, run route type generation before `tsc` and keep it aligned with `next build`. Do not force development-mode typegen in the scripted `typecheck` command; it rewrites `next-env.d.ts` to `.next/dev/types/routes.d.ts`, while `next build` rewrites the same generated file to `.next/types/routes.d.ts`.
+
 Recommended TypeScript posture:
 - `strict: true`
 - `allowJs: false`

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "commit-message:check": "node scripts/check-commit-message.ts",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "typecheck": "rm -rf .next/types .next/dev/types && NODE_ENV=development next typegen && tsc --noEmit",
+    "typecheck": "rm -rf .next/types .next/dev/types && next typegen && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Scope

Closes #127 by eliminating the `next-env.d.ts` flip between `pnpm check` and `pnpm build`.

## What changed

- Removed `NODE_ENV=development` from the `typecheck` script
- Committed `next-env.d.ts` in the route typegen state that matches `next build`
- Documented the reason in `docs/architecture.md`

## Why

Next rewrites `next-env.d.ts` to reference `.next/dev/types/routes.d.ts` when route typegen runs in development mode, but `next build` rewrites it to `.next/types/routes.d.ts`. Because the file is tracked, that made normal check/build cycles dirty unrelated feature branches.

## Validation

- `rm -rf .next/types .next/dev/types && pnpm exec next typegen && pnpm exec tsc --noEmit`
- `pnpm check`
- `pnpm build`
- confirmed build left no additional generated-file churn beyond the intended `next-env.d.ts` state

Issue: #127