### PR TITLE
chore(tooling): untrack next env output (#127 PR2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .claude/state/
 .next/
+next-env.d.ts
 dist/
 build/
 coverage/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,7 +212,7 @@ Recommended script:
 }
 ```
 
-For this Next.js app, run route type generation before `tsc` and keep it aligned with `next build`. Do not force development-mode typegen in the scripted `typecheck` command; it rewrites `next-env.d.ts` to `.next/dev/types/routes.d.ts`, while `next build` rewrites the same generated file to `.next/types/routes.d.ts`.
+For this Next.js app, run route type generation before `tsc` and keep scripted typegen aligned with `next build`. Do not force development-mode typegen in the scripted `typecheck` command. `next-env.d.ts` is a Next-generated local file, ignored by git, because `next dev` rewrites it to `.next/dev/types/routes.d.ts` while `next build` rewrites it to `.next/types/routes.d.ts`.
 
 Recommended TypeScript posture:
 - `strict: true`

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Scope

PR2 for #127. PR #128 aligned scripted typegen with build, but a short `pnpm dev` check showed `next dev` still rewrites tracked `next-env.d.ts` to the development route-type path. This PR removes the generated file from version control entirely.

## What changed

- Added `next-env.d.ts` to `.gitignore`
- Removed tracked `next-env.d.ts` from the repository
- Updated `docs/architecture.md` to document that `next-env.d.ts` is generated local output

## Validation

- Removed local `next-env.d.ts`
- `pnpm check` regenerated it before `tsc` and passed
- `pnpm build` passed
- Started and stopped `pnpm dev`
- Confirmed regenerated `next-env.d.ts` is ignored and no longer appears as tracked churn

Issue: #127