### PR TITLE
feat(ui): add red-style analysis shell

### DIFF
--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -1,13 +1,19 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+import { analyzeRepositoryResponseFixture } from "../test/support/analyze-repository-response-fixture";
 
 test("runs the repository analysis workflow", async ({ page }) => {
+  await mockAnalyzeRoute(page);
   await page.goto("/");
 
   await expect(
-    page.getByRole("heading", { name: "Repository analysis" }),
+    page.getByRole("heading", { name: "Report Card" }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: "Analyze repository" }).click();
+  await page
+    .getByLabel("GitHub repository URL")
+    .fill("https://github.com/lightstrikelabs/repo-analyzer-green");
+  await page.getByRole("button", { name: "Analyze" }).click();
 
   await expect(
     page.getByRole("heading", { name: "Evidence-backed report" }),
@@ -32,11 +38,14 @@ test("runs the repository analysis workflow", async ({ page }) => {
 });
 
 test("starts a follow-up thread from the report view", async ({ page }) => {
+  await mockAnalyzeRoute(page);
   await page.goto("/");
   await page
-    .getByLabel("Reviewer model preference")
-    .fill("fixture-parity-model");
-  await page.getByRole("button", { name: "Analyze repository" }).click();
+    .getByLabel("GitHub repository URL")
+    .fill("https://github.com/lightstrikelabs/repo-analyzer-green");
+  await page.getByText("Advanced", { exact: true }).click();
+  await page.getByLabel("OpenRouter Model").fill("fixture-parity-model");
+  await page.getByRole("button", { name: "Analyze" }).click();
 
   await expect(page.getByText("Follow-up").first()).toBeVisible();
 
@@ -61,7 +70,8 @@ test("starts a follow-up thread from the report view", async ({ page }) => {
 
   await page.reload();
 
-  await expect(page.getByLabel("Reviewer model preference")).toHaveValue(
+  await page.getByText("Advanced", { exact: true }).click();
+  await expect(page.getByLabel("OpenRouter Model")).toHaveValue(
     "fixture-parity-model",
   );
   await expect(
@@ -70,3 +80,13 @@ test("starts a follow-up thread from the report view", async ({ page }) => {
   await expect(page.getByText("Evidence summary")).toBeVisible();
   await expect(page.getByText("Evidence-backed answer")).toBeVisible();
 });
+
+async function mockAnalyzeRoute(page: Page) {
+  await page.route("**/api/analyze", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(analyzeRepositoryResponseFixture),
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -39,9 +39,12 @@
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "jsdom": "^29.0.2",
     "lefthook": "^2.1.6",
     "oxlint": "^1.30.0",
     "prettier": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.2.4
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
@@ -45,6 +51,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
@@ -62,13 +71,80 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.0
-        version: 4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+        version: 4.1.5(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -78,6 +154,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -647,8 +732,36 @@ packages:
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -699,6 +812,17 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -707,6 +831,9 @@ packages:
     resolution: {integrity: sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   caniuse-lite@1.0.30001790:
     resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
@@ -725,16 +852,38 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -768,9 +917,28 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   lefthook-darwin-arm64@2.1.6:
     resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
@@ -900,8 +1068,19 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -950,6 +1129,9 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -983,6 +1165,14 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -994,14 +1184,25 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1041,6 +1242,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
@@ -1067,6 +1271,21 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1077,6 +1296,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -1162,10 +1385,33 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -1177,6 +1423,64 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1193,6 +1497,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.74.0(react@19.2.5))':
     dependencies:
@@ -1543,10 +1849,37 @@ snapshots:
       postcss: 8.5.10
       tailwindcss: 4.2.4
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1610,9 +1943,21 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   assertion-error@2.0.1: {}
 
   baseline-browser-mapping@2.10.22: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   caniuse-lite@1.0.30001790: {}
 
@@ -1624,14 +1969,34 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  decimal.js@10.6.0: {}
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   enhanced-resolve@5.21.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -1653,7 +2018,43 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  is-potential-custom-element-name@1.0.1: {}
+
   jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   lefthook-darwin-arm64@2.1.6:
     optional: true
@@ -1747,9 +2148,15 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lru-cache@11.3.5: {}
+
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
 
   minipass@7.1.3: {}
 
@@ -1808,6 +2215,10 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.61.0
       '@oxlint/binding-win32-x64-msvc': 1.61.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -1836,6 +2247,14 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -1845,7 +2264,11 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  react-is@17.0.2: {}
+
   react@19.2.5: {}
+
+  require-from-string@2.0.2: {}
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -1867,6 +2290,10 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -1918,6 +2345,8 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.5
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
@@ -1941,11 +2370,27 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.25.0: {}
 
   vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1):
     dependencies:
@@ -1959,7 +2404,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)):
+  vitest@4.1.5(@types/node@24.12.2)(jsdom@29.0.2)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
@@ -1983,13 +2428,34 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@5.0.0: {}
 

--- a/src/components/report/analyze-repository-panel.test.tsx
+++ b/src/components/report/analyze-repository-panel.test.tsx
@@ -1,13 +1,185 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenRouterDefaultModelId } from "../../infrastructure/llm/openrouter-config";
+import { BrowserLocalSessionStorageKey } from "../../infrastructure/persistence/browser-local-session-storage";
+import { analyzeRepositoryResponseFixture } from "../../../test/support/analyze-repository-response-fixture";
 
 import { AnalyzeRepositoryPanel } from "./analyze-repository-panel";
 
 describe("AnalyzeRepositoryPanel", () => {
-  it("hides the analysis sidebar in printed output", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    window.localStorage.clear();
+  });
+
+  it("renders the red-style first screen and keeps the analysis shell out of print", () => {
     const html = renderToStaticMarkup(<AnalyzeRepositoryPanel />);
 
-    expect(html).toContain("Browser session");
-    expect(html).toMatch(/<aside[^>]*class="[^"]*print:hidden[^"]*"/);
+    expect(html).toContain("Repository Quality");
+    expect(html).toContain("Report Card");
+    expect(html).toContain("GitHub repository URL");
+    expect(html).toContain("OpenRouter API key");
+    expect(html).toContain("Advanced");
+    expect(html).toMatch(/<section[^>]*class="[^"]*print:hidden[^"]*"/);
+  });
+
+  it("submits the red-style request and persists the URL and model without the API key", async () => {
+    const fetchMock = mockSuccessfulAnalyzeFetch();
+    const user = userEvent.setup();
+
+    render(<AnalyzeRepositoryPanel />);
+
+    await user.type(
+      screen.getByLabelText("GitHub repository URL"),
+      "https://github.com/lightstrikelabs/repo-analyzer-green",
+    );
+    await user.type(screen.getByLabelText("OpenRouter API key"), "sk-test");
+    await user.click(screen.getByText("Advanced"));
+    await user.clear(screen.getByLabelText("OpenRouter Model"));
+    await user.type(
+      screen.getByLabelText("OpenRouter Model"),
+      "openai/gpt-4.1-mini",
+    );
+    await user.click(screen.getByRole("button", { name: "Analyze" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Evidence-backed report" }),
+      ).toBeTruthy();
+    });
+
+    expect(postedBody(fetchMock)).toEqual({
+      repoUrl: "https://github.com/lightstrikelabs/repo-analyzer-green",
+      apiKey: "sk-test",
+      model: "openai/gpt-4.1-mini",
+    });
+
+    const rawSession = storedSessionText();
+    expect(rawSession).toContain(
+      "https://github.com/lightstrikelabs/repo-analyzer-green",
+    );
+    expect(rawSession).toContain("openai/gpt-4.1-mini");
+    expect(rawSession).not.toContain("sk-test");
+  });
+
+  it("resets the advanced model field to the free router default", async () => {
+    const user = userEvent.setup();
+
+    render(<AnalyzeRepositoryPanel />);
+
+    await user.click(screen.getByText("Advanced"));
+    await user.clear(screen.getByLabelText("OpenRouter Model"));
+    await user.type(screen.getByLabelText("OpenRouter Model"), "custom/model");
+    await user.click(screen.getByRole("button", { name: "Use Free Router" }));
+
+    expect(modelInputValue()).toBe(OpenRouterDefaultModelId);
+  });
+
+  it("advances through red-style loading phases while analysis is pending", () => {
+    vi.useFakeTimers();
+    const fetchPromise = new Promise<Response>(() => {});
+    const fetchMock = vi.fn(() => fetchPromise);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AnalyzeRepositoryPanel />);
+
+    fireEvent.change(screen.getByLabelText("GitHub repository URL"), {
+      target: {
+        value: "https://github.com/lightstrikelabs/repo-analyzer-green",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze" }));
+
+    expect(screen.getByText("Cloning repository")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1_200);
+    });
+    expect(screen.getByText("Mapping files")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1_200);
+    });
+    expect(screen.getByText("Scoring quality")).toBeTruthy();
+  });
+
+  it("shows product-focused validation copy for invalid repository URLs", async () => {
+    const fetchMock = mockSuccessfulAnalyzeFetch();
+    const user = userEvent.setup();
+
+    render(<AnalyzeRepositoryPanel />);
+
+    await user.type(screen.getByLabelText("GitHub repository URL"), "not-url");
+    await user.click(screen.getByRole("button", { name: "Analyze" }));
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Enter a valid GitHub repository URL.",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+function mockSuccessfulAnalyzeFetch() {
+  const fetchMock = vi.fn<typeof fetch>(async (_input, _init) =>
+    Response.json(analyzeRepositoryResponseFixture),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function postedBody(fetchMock: ReturnType<typeof mockSuccessfulAnalyzeFetch>) {
+  const firstCall = fetchMock.mock.calls[0];
+  if (firstCall === undefined) {
+    throw new Error("Expected analyze fetch to be called.");
+  }
+
+  const init = firstCall[1];
+  if (
+    init === undefined ||
+    typeof init !== "object" ||
+    !("body" in init) ||
+    typeof init.body !== "string"
+  ) {
+    throw new Error("Expected analyze fetch to include a JSON string body.");
+  }
+
+  const body: unknown = JSON.parse(init.body);
+  return body;
+}
+
+function storedSessionText() {
+  const rawSession = window.localStorage.getItem(BrowserLocalSessionStorageKey);
+  if (rawSession === null) {
+    throw new Error("Expected browser session to be saved.");
+  }
+  return rawSession;
+}
+
+function modelInputValue() {
+  const modelInput = screen.getByLabelText("OpenRouter Model");
+  if (!(modelInput instanceof HTMLInputElement)) {
+    throw new Error("Expected model field to be an input.");
+  }
+  return modelInput.value;
+}

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -1,11 +1,22 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 
 import {
   AnalyzeRepositoryResponseSchema,
   type AnalyzeRepositoryResponse,
 } from "../../application/analyze-repository/analyze-repository-response";
+import { GitHubRepositoryUrlSchema } from "../../infrastructure/github/github-repository-url";
+import {
+  OpenRouterDefaultModelId,
+  OpenRouterModelIdSchema,
+} from "../../infrastructure/llm/openrouter-config";
 import {
   clearBrowserLocalSession,
   defaultBrowserRepositoryForm,
@@ -35,24 +46,35 @@ type LoadingPhase = {
 
 const loadingPhases: readonly [LoadingPhase, ...LoadingPhase[]] = [
   {
-    title: "Collecting repository evidence",
-    detail: "Inventorying files, manifests, workflows, and omissions.",
-    progress: 28,
+    title: "Cloning repository",
+    detail: "Fetching the GitHub snapshot and preparing it for analysis.",
+    progress: 16,
   },
   {
-    title: "Measuring code shape",
-    detail: "Summarizing language mix, code lines, tests, and caveats.",
-    progress: 52,
+    title: "Mapping files",
+    detail: "Classifying source, tests, docs, generated files, and omissions.",
+    progress: 32,
   },
   {
-    title: "Reviewing dimensions",
-    detail: "Combining deterministic evidence with reviewer assessment.",
-    progress: 76,
+    title: "Scoring quality",
+    detail: "Combining deterministic evidence with the domain scoring policy.",
+    progress: 50,
   },
   {
-    title: "Preparing report card",
-    detail: "Linking findings, confidence, caveats, and evidence references.",
-    progress: 92,
+    title: "Checking tests and release gates",
+    detail: "Looking for verification, CI, scripts, and release readiness.",
+    progress: 66,
+  },
+  {
+    title: "Scanning security and docs",
+    detail:
+      "Reviewing dependency hygiene, secrets risk, and onboarding signals.",
+    progress: 82,
+  },
+  {
+    title: "Writing reviewer notes",
+    detail: "Preparing evidence-backed findings, confidence, and caveats.",
+    progress: 94,
   },
 ];
 
@@ -62,6 +84,7 @@ export function AnalyzeRepositoryPanel() {
   const [repositoryForm, setRepositoryForm] = useState<BrowserRepositoryForm>(
     () => defaultBrowserRepositoryForm(),
   );
+  const [apiKey, setApiKey] = useState("");
   const [latestReport, setLatestReport] =
     useState<AnalyzeRepositoryResponse | null>(null);
   const [hydrated, setHydrated] = useState(false);
@@ -119,7 +142,41 @@ export function AnalyzeRepositoryPanel() {
     return { kind: "idle" as const };
   }, [latestReport, loadingPhaseIndex, status.kind]);
 
-  async function analyzeRepository() {
+  async function analyzeRepository(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const repositoryUrlResult = GitHubRepositoryUrlSchema.safeParse(
+      repositoryForm.repoUrl,
+    );
+    if (!repositoryUrlResult.success) {
+      setStatus({
+        kind: "error",
+        message: "Enter a valid GitHub repository URL.",
+      });
+      return;
+    }
+
+    const normalizedRepositoryUrl = repositoryUrlResult.data.url;
+    if (normalizedRepositoryUrl === undefined) {
+      setStatus({
+        kind: "error",
+        message: "Enter a valid GitHub repository URL.",
+      });
+      return;
+    }
+
+    const modelResult = OpenRouterModelIdSchema.safeParse(
+      repositoryForm.selectedModel,
+    );
+    if (!modelResult.success) {
+      setStatus({
+        kind: "error",
+        message: "Enter a valid OpenRouter model id.",
+      });
+      return;
+    }
+
+    const trimmedApiKey = apiKey.trim();
     setStatus({ kind: "loading" });
 
     const response = await fetch("/api/analyze", {
@@ -128,19 +185,9 @@ export function AnalyzeRepositoryPanel() {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        repository: {
-          provider: repositoryForm.provider,
-          name: repositoryForm.name,
-          ...(repositoryForm.owner === undefined
-            ? {}
-            : { owner: repositoryForm.owner }),
-          ...(repositoryForm.url === undefined
-            ? {}
-            : { url: repositoryForm.url }),
-          ...(repositoryForm.revision === undefined
-            ? {}
-            : { revision: repositoryForm.revision }),
-        },
+        repoUrl: normalizedRepositoryUrl,
+        ...(trimmedApiKey.length === 0 ? {} : { apiKey: trimmedApiKey }),
+        model: modelResult.data,
       }),
     });
     const body: unknown = await response.json();
@@ -149,8 +196,7 @@ export function AnalyzeRepositoryPanel() {
     if (!response.ok || !parseResult.success) {
       setStatus({
         kind: "error",
-        message:
-          "Analysis failed. Check the repository evidence and try again.",
+        message: "Analysis failed. Check the repository URL and try again.",
       });
       return;
     }
@@ -162,10 +208,7 @@ export function AnalyzeRepositoryPanel() {
   function updateRepositoryForm(
     updater: (current: BrowserRepositoryForm) => BrowserRepositoryForm,
   ) {
-    setRepositoryForm((current) => {
-      const next = updater(current);
-      return next;
-    });
+    setRepositoryForm((current) => updater(current));
     setLatestReport(null);
     if (status.kind === "error") {
       setStatus({ kind: "idle" });
@@ -175,175 +218,119 @@ export function AnalyzeRepositoryPanel() {
   function resetSavedSession() {
     clearBrowserLocalSession(window.localStorage);
     setRepositoryForm(defaultBrowserRepositoryForm());
+    setApiKey("");
     setLatestReport(null);
     setStatus({ kind: "idle" });
   }
 
   return (
-    <div className="grid min-h-screen gap-6 px-6 py-6 lg:grid-cols-[360px_1fr]">
-      <aside className="rounded-md border border-slate-200 bg-white p-5 print:hidden">
-        <p className="text-sm font-medium uppercase text-emerald-700">
-          Repo Analyzer Green
-        </p>
-        <h1 className="mt-3 text-2xl font-semibold text-slate-950">
-          Repository analysis
-        </h1>
-        <p className="mt-3 text-sm leading-6 text-slate-700">
-          Run the repository analysis workflow to produce a report card with
-          dimensions, evidence, confidence, caveats, and follow-up questions.
-        </p>
-
-        <section className="mt-5 space-y-4 rounded-md border border-slate-200 bg-slate-50 p-4">
-          <div className="flex items-start justify-between gap-3">
+    <div className="min-h-screen bg-stone-50 text-slate-950">
+      <section className="border-b border-slate-200 bg-white px-4 py-5 print:hidden sm:px-6">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <p className="text-sm font-medium uppercase text-emerald-700">
-                Browser session
+              <p className="text-sm font-semibold text-emerald-700">
+                Repository Quality
               </p>
-              <p className="mt-1 text-sm leading-6 text-slate-700">
-                Repository settings and the latest report are restored from this
-                browser only.
-              </p>
+              <h1 className="mt-1 text-3xl font-semibold text-slate-950">
+                Report Card
+              </h1>
             </div>
             <button
               type="button"
               onClick={resetSavedSession}
-              className="rounded-md border border-slate-200 px-3 py-2 text-xs font-medium text-slate-700 transition hover:bg-white"
+              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
             >
               Reset
             </button>
           </div>
 
-          <div className="grid gap-3">
-            <Field label="Provider">
-              <select
-                value={repositoryForm.provider}
-                onChange={(event) =>
-                  updateRepositoryForm((current) => ({
-                    ...current,
-                    provider: event.target
-                      .value as BrowserRepositoryForm["provider"],
-                  }))
-                }
-                className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-400"
-                disabled={status.kind === "loading"}
-              >
-                <option value="local-fixture">local-fixture</option>
-                <option value="github">github</option>
-              </select>
-            </Field>
-
-            <Field label="Repository name">
+          <form
+            noValidate
+            onSubmit={analyzeRepository}
+            className="mt-5 grid gap-3 lg:grid-cols-[minmax(240px,1fr)_minmax(220px,320px)_auto]"
+          >
+            <Field label="GitHub repository URL">
               <input
-                value={repositoryForm.name}
+                type="url"
+                inputMode="url"
+                autoComplete="url"
+                value={repositoryForm.repoUrl}
                 onChange={(event) =>
                   updateRepositoryForm((current) => ({
                     ...current,
-                    name: event.target.value,
+                    repoUrl: event.target.value,
                   }))
                 }
-                className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-400"
+                placeholder="https://github.com/owner/repo"
+                className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
                 disabled={status.kind === "loading"}
               />
             </Field>
 
-            <Field label="Revision">
+            <Field label="OpenRouter API key">
               <input
-                value={repositoryForm.revision ?? ""}
-                onChange={(event) =>
-                  updateRepositoryForm((current) => ({
-                    ...current,
-                    revision:
-                      event.target.value.length === 0
-                        ? undefined
-                        : event.target.value,
-                  }))
-                }
-                className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-400"
+                type="password"
+                autoComplete="off"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
                 disabled={status.kind === "loading"}
               />
             </Field>
 
-            <details className="rounded-md border border-slate-200 bg-white p-3">
-              <summary className="cursor-pointer text-sm font-medium text-slate-800">
-                Advanced repository details
+            <button
+              type="submit"
+              disabled={status.kind === "loading"}
+              className="h-11 rounded-md bg-slate-950 px-5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {status.kind === "loading" ? "Analyzing" : "Analyze"}
+            </button>
+
+            <details className="lg:col-span-3">
+              <summary className="cursor-pointer text-sm font-semibold text-slate-800">
+                Advanced
               </summary>
-              <div className="mt-3 grid gap-3">
-                <Field label="Owner">
+              <div className="mt-3 grid gap-3 rounded-md border border-slate-200 bg-slate-50 p-3 sm:grid-cols-[minmax(220px,420px)_auto]">
+                <Field label="OpenRouter Model">
                   <input
-                    value={repositoryForm.owner ?? ""}
+                    value={repositoryForm.selectedModel}
                     onChange={(event) =>
                       updateRepositoryForm((current) => ({
                         ...current,
-                        owner:
-                          event.target.value.length === 0
-                            ? undefined
-                            : event.target.value,
+                        selectedModel: event.target.value,
                       }))
                     }
-                    className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-400"
+                    className="h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
                     disabled={status.kind === "loading"}
                   />
                 </Field>
-
-                <Field label="Repository URL">
-                  <input
-                    value={repositoryForm.url ?? ""}
-                    onChange={(event) =>
-                      updateRepositoryForm((current) => ({
-                        ...current,
-                        url:
-                          event.target.value.length === 0
-                            ? undefined
-                            : event.target.value,
-                      }))
-                    }
-                    className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-400"
-                    disabled={status.kind === "loading"}
-                  />
-                </Field>
+                <button
+                  type="button"
+                  onClick={() =>
+                    updateRepositoryForm((current) => ({
+                      ...current,
+                      selectedModel: OpenRouterDefaultModelId,
+                    }))
+                  }
+                  disabled={status.kind === "loading"}
+                  className="h-10 self-end rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                >
+                  Use Free Router
+                </button>
               </div>
             </details>
-
-            <Field label="Reviewer model preference">
-              <input
-                value={repositoryForm.selectedModel}
-                onChange={(event) =>
-                  updateRepositoryForm((current) => ({
-                    ...current,
-                    selectedModel: event.target.value,
-                  }))
-                }
-                className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-emerald-400"
-                disabled={status.kind === "loading"}
-              />
-            </Field>
-          </div>
-
-          <p className="text-xs leading-5 text-slate-600">
-            This browser stores the repository form, selected model preference,
-            and the latest successful report. API keys are not persisted here.
-          </p>
-
-          <button
-            type="button"
-            onClick={analyzeRepository}
-            disabled={status.kind === "loading"}
-            className="w-full rounded-md bg-slate-950 px-4 py-2.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-400"
-          >
-            {status.kind === "loading"
-              ? "Analyzing repository..."
-              : "Analyze repository"}
-          </button>
+          </form>
 
           {status.kind === "error" ? (
-            <p role="alert" className="text-sm text-red-700">
+            <p role="alert" className="mt-3 text-sm font-medium text-red-700">
               {status.message}
             </p>
           ) : null}
-        </section>
-      </aside>
+        </div>
+      </section>
 
-      <main className="min-w-0 rounded-md border border-slate-200 bg-slate-50 p-5">
+      <main className="mx-auto min-w-0 max-w-7xl px-4 py-6 sm:px-6">
         {reportContent.kind === "loaded" ? (
           <ReportCardView analysis={reportContent.analysis} />
         ) : reportContent.kind === "loading" ? (
@@ -352,11 +339,10 @@ export function AnalyzeRepositoryPanel() {
           <section className="flex min-h-[520px] items-center justify-center rounded-md border border-dashed border-slate-300 bg-white p-6 text-center">
             <div>
               <h2 className="text-lg font-semibold text-slate-950">
-                No report generated yet
+                No report loaded
               </h2>
               <p className="mt-2 max-w-md text-sm leading-6 text-slate-700">
-                Start an analysis to generate dimensions, findings, confidence,
-                caveats, and evidence references.
+                Enter a repository URL to begin.
               </p>
             </div>
           </section>
@@ -375,7 +361,7 @@ function Field({
 }) {
   return (
     <label className="block">
-      <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+      <span className="mb-1 block text-sm font-medium text-slate-700">
         {label}
       </span>
       {children}

--- a/src/infrastructure/persistence/browser-analysis-session-storage.ts
+++ b/src/infrastructure/persistence/browser-analysis-session-storage.ts
@@ -2,16 +2,19 @@ import { z } from "zod";
 
 import { AnalyzeRepositoryResponseSchema } from "../../application/analyze-repository/analyze-repository-response";
 import {
-  RepositoryIdentitySchema,
-  type RepositoryIdentity,
-} from "../../domain/report/report-card";
+  OpenRouterDefaultModelId,
+  OpenRouterModelIdSchema,
+} from "../llm/openrouter-config";
 
 export const BrowserAnalysisSessionSchemaVersion =
   "browser-analysis-session.v1";
 
-export const BrowserRepositoryFormSchema = RepositoryIdentitySchema.extend({
-  selectedModel: z.string().min(1),
-}).strict();
+export const BrowserRepositoryFormSchema = z
+  .object({
+    repoUrl: z.string(),
+    selectedModel: OpenRouterModelIdSchema,
+  })
+  .strict();
 
 export type BrowserRepositoryForm = z.infer<typeof BrowserRepositoryFormSchema>;
 
@@ -64,41 +67,7 @@ export function clearBrowserAnalysisSession(storage: BrowserStorageLike): void {
 
 export function defaultBrowserRepositoryForm(): BrowserRepositoryForm {
   return {
-    provider: "local-fixture",
-    name: "minimal-node-library",
-    revision: "fixture",
-    selectedModel: "fixture-default",
-  };
-}
-
-export function browserRepositoryIdentityFromForm(
-  form: BrowserRepositoryForm,
-): RepositoryIdentity {
-  return {
-    provider: form.provider,
-    name: form.name,
-    ...(form.owner === undefined ? {} : { owner: form.owner }),
-    ...(form.url === undefined ? {} : { url: form.url }),
-    ...(form.revision === undefined ? {} : { revision: form.revision }),
-    ...(form.defaultBranch === undefined
-      ? {}
-      : { defaultBranch: form.defaultBranch }),
-  };
-}
-
-export function browserRepositoryFormFromIdentity(
-  identity: RepositoryIdentity,
-  selectedModel = "fixture-default",
-): BrowserRepositoryForm {
-  return {
-    provider: identity.provider,
-    name: identity.name,
-    ...(identity.owner === undefined ? {} : { owner: identity.owner }),
-    ...(identity.url === undefined ? {} : { url: identity.url }),
-    ...(identity.revision === undefined ? {} : { revision: identity.revision }),
-    ...(identity.defaultBranch === undefined
-      ? {}
-      : { defaultBranch: identity.defaultBranch }),
-    selectedModel,
+    repoUrl: "",
+    selectedModel: OpenRouterDefaultModelId,
   };
 }

--- a/src/infrastructure/persistence/browser-local-session-storage.ts
+++ b/src/infrastructure/persistence/browser-local-session-storage.ts
@@ -7,15 +7,18 @@ import {
   ConversationTargetSchema,
 } from "../../domain/chat/conversation";
 import {
-  RepositoryIdentitySchema,
-  type RepositoryIdentity,
-} from "../../domain/report/report-card";
+  OpenRouterDefaultModelId,
+  OpenRouterModelIdSchema,
+} from "../llm/openrouter-config";
 
 export const BrowserLocalSessionSchemaVersion = "browser-local-session.v1";
 
-export const BrowserRepositoryFormSchema = RepositoryIdentitySchema.extend({
-  selectedModel: z.string().min(1),
-}).strict();
+export const BrowserRepositoryFormSchema = z
+  .object({
+    repoUrl: z.string(),
+    selectedModel: OpenRouterModelIdSchema,
+  })
+  .strict();
 
 export type BrowserRepositoryForm = z.infer<typeof BrowserRepositoryFormSchema>;
 
@@ -152,42 +155,8 @@ export function clearBrowserLocalSession(storage: BrowserStorageLike): void {
 
 export function defaultBrowserRepositoryForm(): BrowserRepositoryForm {
   return {
-    provider: "local-fixture",
-    name: "minimal-node-library",
-    revision: "fixture",
-    selectedModel: "fixture-default",
-  };
-}
-
-export function browserRepositoryIdentityFromForm(
-  form: BrowserRepositoryForm,
-): RepositoryIdentity {
-  return {
-    provider: form.provider,
-    name: form.name,
-    ...(form.owner === undefined ? {} : { owner: form.owner }),
-    ...(form.url === undefined ? {} : { url: form.url }),
-    ...(form.revision === undefined ? {} : { revision: form.revision }),
-    ...(form.defaultBranch === undefined
-      ? {}
-      : { defaultBranch: form.defaultBranch }),
-  };
-}
-
-export function browserRepositoryFormFromIdentity(
-  identity: RepositoryIdentity,
-  selectedModel = "fixture-default",
-): BrowserRepositoryForm {
-  return {
-    provider: identity.provider,
-    name: identity.name,
-    ...(identity.owner === undefined ? {} : { owner: identity.owner }),
-    ...(identity.url === undefined ? {} : { url: identity.url }),
-    ...(identity.revision === undefined ? {} : { revision: identity.revision }),
-    ...(identity.defaultBranch === undefined
-      ? {}
-      : { defaultBranch: identity.defaultBranch }),
-    selectedModel,
+    repoUrl: "",
+    selectedModel: OpenRouterDefaultModelId,
   };
 }
 

--- a/test/infrastructure/persistence/browser-analysis-session-storage.test.ts
+++ b/test/infrastructure/persistence/browser-analysis-session-storage.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { AnalyzeRepositoryResponse } from "../../../src/application/analyze-repository/analyze-repository-response";
+import { OpenRouterDefaultModelId } from "../../../src/infrastructure/llm/openrouter-config";
 import type {
   BrowserFollowUpState,
   BrowserLocalSession,
 } from "../../../src/infrastructure/persistence/browser-local-session-storage";
 import {
-  browserRepositoryFormFromIdentity,
   clearBrowserLocalSession,
   defaultBrowserRepositoryForm,
   loadBrowserAnalysisSession,
@@ -24,10 +24,8 @@ describe("browser-analysis-session-storage", () => {
       schemaVersion: "browser-local-session.v1",
       analysis: {
         form: {
-          provider: "local-fixture",
-          name: "minimal-node-library",
-          revision: "fixture",
-          selectedModel: "fixture-default",
+          repoUrl: "https://github.com/lightstrikelabs/repo-analyzer-green",
+          selectedModel: OpenRouterDefaultModelId,
         },
         latestReport: analysis,
       },
@@ -100,21 +98,26 @@ describe("browser-analysis-session-storage", () => {
     expect(loadBrowserLocalSession(storage)).toBeNull();
   });
 
-  it("can reconstruct a repository form from a repository identity", () => {
-    expect(
-      browserRepositoryFormFromIdentity({
-        provider: "github",
-        owner: "lightstrikelabs",
-        name: "repo-analyzer-green",
-        revision: "main",
-      }),
-    ).toEqual({
-      provider: "github",
-      owner: "lightstrikelabs",
-      name: "repo-analyzer-green",
-      revision: "main",
-      selectedModel: "fixture-default",
+  it("defaults to an empty repo URL and the free router model", () => {
+    expect(defaultBrowserRepositoryForm()).toEqual({
+      repoUrl: "",
+      selectedModel: OpenRouterDefaultModelId,
     });
+  });
+
+  it("does not include a credential field in the persisted form", () => {
+    const storage = new FakeStorage();
+
+    saveBrowserAnalysisSession(storage, {
+      form: {
+        repoUrl: "https://github.com/lightstrikelabs/repo-analyzer-green",
+        selectedModel: "openai/gpt-4.1-mini",
+      },
+    });
+
+    expect(storage.raw).toContain("repoUrl");
+    expect(storage.raw).toContain("selectedModel");
+    expect(storage.raw).not.toContain("apiKey");
   });
 });
 

--- a/test/support/analyze-repository-response-fixture.ts
+++ b/test/support/analyze-repository-response-fixture.ts
@@ -1,0 +1,141 @@
+import type { AnalyzeRepositoryResponse } from "../../src/application/analyze-repository/analyze-repository-response";
+
+export const analyzeRepositoryResponseFixture: AnalyzeRepositoryResponse = {
+  reportCard: {
+    id: "report:minimal-node-library",
+    schemaVersion: "report-card.v1",
+    generatedAt: "2026-04-26T07:00:00-07:00",
+    scoringPolicy: {
+      name: "repo-analyzer-green scoring policy",
+      version: "0.1.0",
+    },
+    repository: {
+      provider: "local-fixture",
+      name: "minimal-node-library",
+      revision: "fixture",
+    },
+    assessedArchetype: "library",
+    reviewerMetadata: {
+      kind: "fake",
+      name: "Fixture reviewer",
+      reviewedAt: "2026-04-26T07:00:00-07:00",
+    },
+    evidenceReferences: [
+      {
+        id: "evidence:package-json",
+        kind: "file",
+        label: "Package manifest",
+        path: "package.json",
+      },
+      {
+        id: "evidence:ci-workflow",
+        kind: "file",
+        label: "CI workflow",
+        path: ".github/workflows/ci.yml",
+      },
+    ],
+    dimensionAssessments: [
+      {
+        dimension: "maintainability",
+        title: "Maintainability",
+        summary: "Minimal fixture.",
+        rating: "good",
+        score: 88,
+        confidence: {
+          level: "high",
+          score: 0.9,
+          rationale: "Fixture is minimal.",
+        },
+        evidenceReferences: [
+          {
+            id: "evidence:source-file",
+            kind: "file",
+            label: "Source file",
+            path: "src/add.ts",
+          },
+        ],
+        findings: [
+          {
+            id: "finding:test-surface",
+            dimension: "verifiability",
+            severity: "info",
+            title: "Focused test surface",
+            summary: "A unit test exercises the exported behavior.",
+            confidence: {
+              level: "high",
+              score: 0.9,
+              rationale: "The fixture includes a deterministic unit test.",
+            },
+            evidenceReferences: [
+              {
+                id: "evidence:test-file",
+                kind: "file",
+                label: "Unit test file",
+                path: "test/add.spec.ts",
+              },
+            ],
+          },
+        ],
+        caveatIds: [],
+      },
+      {
+        dimension: "verifiability",
+        title: "Verifiability",
+        summary: "A focused unit test exercises exported behavior.",
+        rating: "good",
+        score: 90,
+        confidence: {
+          level: "high",
+          score: 0.9,
+          rationale: "The fixture includes a deterministic unit test.",
+        },
+        evidenceReferences: [
+          {
+            id: "evidence:test-file",
+            kind: "file",
+            label: "Unit test file",
+            path: "test/add.spec.ts",
+          },
+        ],
+        findings: [],
+        caveatIds: [],
+      },
+    ],
+    caveats: [],
+    recommendedNextQuestions: [
+      {
+        id: "question:test-depth",
+        question: "What behavior remains untested?",
+        targetDimension: "verifiability",
+        rationale: "The deterministic fixture is intentionally narrow.",
+      },
+    ],
+  },
+  dashboardInsights: {
+    evidenceSummary: "Fixture evidence.",
+    languageMix: [
+      {
+        language: "TypeScript",
+        fileCount: 2,
+        sourceFileCount: 1,
+        textLineCount: 12,
+        codeLineCount: 10,
+        percentOfCode: 100,
+        evidenceReferenceIds: ["language-code-shape:file:src/add.ts"],
+      },
+    ],
+    codeShapeSummary: {
+      analyzedFileCount: 2,
+      sourceFileCount: 1,
+      testFileCount: 1,
+      documentationFileCount: 0,
+      largeFileCount: 0,
+      skippedFileCount: 0,
+      unsupportedFileCount: 0,
+      totalTextLineCount: 12,
+      totalCodeLineCount: 10,
+      totalDeferredWorkMarkerCount: 0,
+      totalBranchLikeTokenCount: 0,
+    },
+  },
+};


### PR DESCRIPTION
## Scope
- Replaces the implementation-facing provider/name/revision sidebar with the red-style Report Card analysis shell.
- Sends the red-style analyze payload with repoUrl, model, and request-scoped API key.
- Updates browser-local persistence to keep repo URL, selected model, latest report, and follow-up threads without storing API keys.
- Adds jsdom component interaction coverage and keeps the foundational Playwright workflow deterministic with a fixture-backed analyze response.

## Non-goals
- Does not render the red report dashboard sections; that remains #118/#119.
- Does not replace the current follow-up panel with the red slideout chat; that remains #120/#121.
- Does not persist user credentials.

## Tests
- pnpm check
- pnpm build
- pnpm test:e2e
- pnpm test:e2e:red-parity (first-screen parity passes; dashboard/chat parity still fail pending #118/#119/#121)

Closes #117