### PR TITLE
feat(report): add dashboard view model

### DIFF
--- a/src/application/report-dashboard/report-dashboard-view-model.test.ts
+++ b/src/application/report-dashboard/report-dashboard-view-model.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from "vitest";
+
+import type { AnalyzeRepositoryResponse } from "../analyze-repository/analyze-repository-response";
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportDimensionKey,
+} from "../../domain/report/report-card";
+import { buildReportDashboardViewModel } from "./report-dashboard-view-model";
+
+const generatedAt = "2026-04-26T07:00:00-07:00";
+const reviewedAt = "2026-04-26T06:59:00-07:00";
+
+describe("buildReportDashboardViewModel", () => {
+  it("adapts a complete report into red-compatible overview, big numbers, languages, notes, and sections", () => {
+    const viewModel = buildReportDashboardViewModel(completeAnalysis());
+
+    expect(viewModel.overview).toMatchObject({
+      repositoryLabel: "github:lightstrikelabs/repo-analyzer-green @ abc123",
+      analyzedAt: generatedAt,
+      reviewerNote: "Fixture reviewer reviewed this report",
+      overallScore: 80,
+      grade: "B",
+      summary:
+        "Files analyzed: 24. Source files: 10. Test files: 4. Documentation files: 2.",
+    });
+    expect(viewModel.bigNumbers).toEqual([
+      {
+        id: "overall-score",
+        label: "Overall Score",
+        value: "80",
+        detail: "Average of 5 scored dashboard sections",
+        provenance: { source: "report-card", referenceIds: [] },
+      },
+      {
+        id: "source-files",
+        label: "Source Files",
+        value: "10",
+        detail: "Files classified as source evidence",
+        provenance: { source: "code-shape-summary", referenceIds: [] },
+      },
+      {
+        id: "code-lines",
+        label: "Code Lines",
+        value: "1,000",
+        detail: "Evidence-backed code line count",
+        provenance: { source: "code-shape-summary", referenceIds: [] },
+      },
+      {
+        id: "test-ratio",
+        label: "Test Ratio",
+        value: "40%",
+        detail: "4 test files for 10 source files",
+        provenance: { source: "code-shape-summary", referenceIds: [] },
+      },
+    ]);
+    expect(viewModel.languageSlices).toEqual([
+      {
+        language: "TypeScript",
+        percentOfCode: 80,
+        codeLineCount: 800,
+        fileCount: 10,
+        color: "#047857",
+        provenance: {
+          source: "language-mix",
+          referenceIds: ["language-code-shape:file:src/app.ts"],
+        },
+      },
+      {
+        language: "Markdown",
+        percentOfCode: 20,
+        codeLineCount: 200,
+        fileCount: 2,
+        color: "#2563eb",
+        provenance: {
+          source: "language-mix",
+          referenceIds: ["language-code-shape:file:README.md"],
+        },
+      },
+    ]);
+    expect(viewModel.reviewerNotes.map((note) => note.text)).toEqual([
+      "Bounded modules keep the API surface easy to review.",
+      "Focused tests cover the main workflow.",
+      "Add dependency audit evidence before relying on the security rating.",
+      "Document deployment assumptions.",
+    ]);
+    expect(viewModel.reviewerNotes[0]?.provenance.referenceIds).toEqual([
+      "evidence:architecture",
+    ]);
+
+    expect(viewModel.sections.map((section) => section.id)).toEqual([
+      "maintainability",
+      "testing",
+      "security",
+      "architecture",
+      "documentation",
+    ]);
+    expect(viewModel.sections[1]).toMatchObject({
+      id: "testing",
+      title: "Testing",
+      sourceDimension: "verifiability",
+      status: "assessed",
+      score: 86,
+      rating: "good",
+      confidenceLabel: "high confidence",
+      summary: "Tests exercise the main repository-analysis workflow.",
+      metrics: [
+        { label: "Score", value: "86", detail: "Dimension score" },
+        { label: "Findings", value: "1", detail: "Reviewer signals" },
+        { label: "Evidence", value: "1", detail: "Structured references" },
+      ],
+      highlights: ["Focused tests cover the main workflow."],
+      risks: [],
+      nextChecks: [],
+      chartPoints: [
+        { label: "Score", value: 86 },
+        { label: "Confidence", value: 92 },
+        { label: "Evidence", value: 25 },
+        { label: "Risk", value: 0 },
+      ],
+    });
+  });
+
+  it("keeps required dashboard sections visible when dimensions are missing", () => {
+    const analysis = completeAnalysis({
+      dimensionAssessments: [dimension("maintainability", 74)],
+    });
+
+    const viewModel = buildReportDashboardViewModel(analysis);
+    const security = viewModel.sections.find(
+      (section) => section.id === "security",
+    );
+
+    expect(viewModel.sections).toHaveLength(5);
+    expect(security).toMatchObject({
+      id: "security",
+      title: "Security",
+      sourceDimension: "security",
+      status: "missing",
+      score: undefined,
+      rating: "not-assessed",
+      confidenceLabel: "not assessed",
+      summary: "Security evidence was not available in this report.",
+      caveats: ["Security evidence was not available in this report."],
+      metrics: [
+        { label: "Score", value: "Not assessed", detail: "Missing dimension" },
+        { label: "Findings", value: "0", detail: "Reviewer signals" },
+        { label: "Evidence", value: "0", detail: "Structured references" },
+      ],
+    });
+  });
+
+  it("surfaces low-confidence dimensions as explicit caveats", () => {
+    const analysis = completeAnalysis({
+      dimensionAssessments: [
+        dimension("security", undefined, {
+          confidenceLevel: "low",
+          confidenceScore: 0.28,
+          rating: "not-assessed",
+          summary: "Security posture needs more evidence.",
+        }),
+      ],
+      caveats: [
+        {
+          id: "caveat:security:low-confidence",
+          title: "Low-confidence security assessment",
+          summary:
+            "Reviewer confidence is low, so this should guide follow-up rather than quality judgment.",
+          affectedDimensions: ["security"],
+          missingEvidence: ["Dependency audit output"],
+        },
+      ],
+    });
+
+    const viewModel = buildReportDashboardViewModel(analysis);
+    const security = viewModel.sections.find(
+      (section) => section.id === "security",
+    );
+
+    expect(security).toMatchObject({
+      status: "low-confidence",
+      confidenceLabel: "low confidence",
+      caveats: [
+        "Reviewer confidence is low, so this should guide follow-up rather than quality judgment.",
+        "Missing evidence: Dependency audit output",
+      ],
+      chartPoints: [
+        { label: "Score", value: 0 },
+        { label: "Confidence", value: 28 },
+        { label: "Evidence", value: 25 },
+        { label: "Risk", value: 0 },
+      ],
+    });
+  });
+
+  it("promotes caveats into reviewer notes and section next checks without using raw ids as display copy", () => {
+    const viewModel = buildReportDashboardViewModel(
+      completeAnalysis({
+        caveats: [
+          {
+            id: "caveat:documentation:missing-evidence",
+            title: "Missing documentation evidence",
+            summary: "No onboarding guide was found.",
+            affectedDimensions: ["documentation"],
+            missingEvidence: ["Architecture decision records"],
+          },
+        ],
+      }),
+    );
+
+    const documentation = viewModel.sections.find(
+      (section) => section.id === "documentation",
+    );
+
+    expect(viewModel.reviewerNotes.map((note) => note.text)).toContain(
+      "No onboarding guide was found.",
+    );
+    expect(documentation?.nextChecks).toEqual([
+      "Architecture decision records",
+    ]);
+    expect(
+      viewModel.reviewerNotes.map((note) => note.text).join(" "),
+    ).not.toContain("caveat:documentation:missing-evidence");
+  });
+
+  it("returns an explicit empty language state when language data is absent", () => {
+    const viewModel = buildReportDashboardViewModel(
+      completeAnalysis({
+        languageMix: [],
+      }),
+    );
+
+    expect(viewModel.languageSlices).toEqual([]);
+    expect(viewModel.emptyLanguageMessage).toBe(
+      "No language mix was available in the collected evidence.",
+    );
+  });
+});
+
+function completeAnalysis(
+  overrides: {
+    readonly dimensionAssessments?: DimensionAssessment[];
+    readonly caveats?: ReportCard["caveats"];
+    readonly languageMix?: AnalyzeRepositoryResponse["dashboardInsights"]["languageMix"];
+  } = {},
+): AnalyzeRepositoryResponse {
+  const reportCard: ReportCard = {
+    id: "report:repo-analyzer-green",
+    schemaVersion: "report-card.v1",
+    generatedAt,
+    scoringPolicy: {
+      name: "repo-analyzer-green scoring policy",
+      version: "0.1.0",
+    },
+    repository: {
+      provider: "github",
+      owner: "lightstrikelabs",
+      name: "repo-analyzer-green",
+      revision: "abc123",
+    },
+    assessedArchetype: "web-app",
+    reviewerMetadata: {
+      kind: "fake",
+      name: "Fixture reviewer",
+      reviewedAt,
+    },
+    evidenceReferences: [
+      evidence("evidence:maintainability", "Maintainability evidence"),
+      evidence("evidence:testing", "Testing evidence"),
+      evidence("evidence:security", "Security evidence"),
+      evidence("evidence:architecture", "Architecture evidence"),
+      evidence("evidence:documentation", "Documentation evidence"),
+    ],
+    dimensionAssessments: overrides.dimensionAssessments ?? [
+      dimension("maintainability", 78, {
+        summary: "Module shape is readable with a few growth hotspots.",
+      }),
+      dimension("verifiability", 86, {
+        summary: "Tests exercise the main repository-analysis workflow.",
+        findingSummary: "Focused tests cover the main workflow.",
+        evidenceId: "evidence:testing",
+      }),
+      dimension("security", 70, {
+        summary:
+          "Security hygiene has basic evidence but audit output is absent.",
+        findingSeverity: "medium",
+        findingSummary:
+          "Add dependency audit evidence before relying on the security rating.",
+        evidenceId: "evidence:security",
+      }),
+      dimension("architecture-boundaries", 88, {
+        summary: "Boundaries keep domain logic independent from adapters.",
+        findingSummary: "Bounded modules keep the API surface easy to review.",
+        evidenceId: "evidence:architecture",
+      }),
+      dimension("documentation", 76, {
+        summary: "Documentation explains the main development constraints.",
+        findingSeverity: "low",
+        findingSummary: "Document deployment assumptions.",
+        evidenceId: "evidence:documentation",
+      }),
+    ],
+    caveats: overrides.caveats ?? [],
+    recommendedNextQuestions: [],
+  };
+
+  return {
+    reportCard,
+    dashboardInsights: {
+      evidenceSummary:
+        "Files analyzed: 24. Source files: 10. Test files: 4. Documentation files: 2.",
+      languageMix: overrides.languageMix ?? [
+        {
+          language: "TypeScript",
+          fileCount: 10,
+          sourceFileCount: 8,
+          textLineCount: 1_100,
+          codeLineCount: 800,
+          percentOfCode: 80,
+          evidenceReferenceIds: ["language-code-shape:file:src/app.ts"],
+        },
+        {
+          language: "Markdown",
+          fileCount: 2,
+          sourceFileCount: 0,
+          textLineCount: 220,
+          codeLineCount: 200,
+          percentOfCode: 20,
+          evidenceReferenceIds: ["language-code-shape:file:README.md"],
+        },
+      ],
+      codeShapeSummary: {
+        analyzedFileCount: 24,
+        sourceFileCount: 10,
+        testFileCount: 4,
+        documentationFileCount: 2,
+        largeFileCount: 1,
+        skippedFileCount: 0,
+        unsupportedFileCount: 0,
+        totalTextLineCount: 1_320,
+        totalCodeLineCount: 1_000,
+        totalDeferredWorkMarkerCount: 2,
+        totalBranchLikeTokenCount: 30,
+      },
+    },
+  };
+}
+
+function dimension(
+  dimensionKey: ReportDimensionKey,
+  score: number | undefined,
+  options: {
+    readonly confidenceLevel?: DimensionAssessment["confidence"]["level"];
+    readonly confidenceScore?: number;
+    readonly evidenceId?: string;
+    readonly findingSeverity?: DimensionAssessment["findings"][number]["severity"];
+    readonly findingSummary?: string;
+    readonly rating?: DimensionAssessment["rating"];
+    readonly summary?: string;
+  } = {},
+): DimensionAssessment {
+  const evidenceId = options.evidenceId ?? `evidence:${dimensionKey}`;
+  const title = titleForDimension(dimensionKey);
+
+  return {
+    dimension: dimensionKey,
+    title,
+    summary: options.summary ?? `${title} has enough evidence for review.`,
+    rating: options.rating ?? "good",
+    score,
+    confidence: {
+      level: options.confidenceLevel ?? "high",
+      score: options.confidenceScore ?? 0.92,
+      rationale: `${title} evidence is fixture-backed.`,
+    },
+    evidenceReferences: [evidence(evidenceId, `${title} evidence`)],
+    findings:
+      options.findingSummary === undefined
+        ? []
+        : [
+            {
+              id: `finding:${dimensionKey}:0`,
+              dimension: dimensionKey,
+              severity: options.findingSeverity ?? "info",
+              title: `${title} signal`,
+              summary: options.findingSummary,
+              confidence: {
+                level: options.confidenceLevel ?? "high",
+                score: options.confidenceScore ?? 0.92,
+                rationale: `${title} finding is fixture-backed.`,
+              },
+              evidenceReferences: [evidence(evidenceId, `${title} evidence`)],
+            },
+          ],
+    caveatIds: [],
+  };
+}
+
+function evidence(id: string, label: string) {
+  return {
+    id,
+    kind: "derived" as const,
+    label,
+  };
+}
+
+function titleForDimension(dimensionKey: ReportDimensionKey): string {
+  switch (dimensionKey) {
+    case "architecture-boundaries":
+      return "Architecture";
+    case "documentation":
+      return "Documentation";
+    case "maintainability":
+      return "Maintainability";
+    case "operability":
+      return "Operability";
+    case "security":
+      return "Security";
+    case "verifiability":
+      return "Testing";
+  }
+}

--- a/src/application/report-dashboard/report-dashboard-view-model.ts
+++ b/src/application/report-dashboard/report-dashboard-view-model.ts
@@ -1,0 +1,503 @@
+import type {
+  AnalyzeRepositoryResponse,
+  DashboardLanguageMixItem,
+} from "../analyze-repository/analyze-repository-response";
+import type {
+  DimensionAssessment,
+  FindingSeverity,
+  ReportCaveat,
+  ReportDimensionKey,
+  ReportFinding,
+  ReportRating,
+} from "../../domain/report/report-card";
+
+export type ReportDashboardViewModel = {
+  readonly overview: ReportDashboardOverview;
+  readonly bigNumbers: readonly ReportDashboardBigNumber[];
+  readonly languageSlices: readonly ReportDashboardLanguageSlice[];
+  readonly emptyLanguageMessage: string | undefined;
+  readonly reviewerNotes: readonly ReportDashboardReviewerNote[];
+  readonly sections: readonly ReportDashboardSection[];
+};
+
+export type ReportDashboardOverview = {
+  readonly repositoryLabel: string;
+  readonly analyzedAt: string;
+  readonly reviewerNote: string;
+  readonly overallScore: number | undefined;
+  readonly grade: string;
+  readonly summary: string;
+  readonly provenance: ReportDashboardProvenance;
+};
+
+export type ReportDashboardBigNumber = {
+  readonly id: "overall-score" | "source-files" | "code-lines" | "test-ratio";
+  readonly label: string;
+  readonly value: string;
+  readonly detail: string;
+  readonly provenance: ReportDashboardProvenance;
+};
+
+export type ReportDashboardLanguageSlice = {
+  readonly language: string;
+  readonly percentOfCode: number;
+  readonly codeLineCount: number;
+  readonly fileCount: number;
+  readonly color: string;
+  readonly provenance: ReportDashboardProvenance;
+};
+
+export type ReportDashboardReviewerNote = {
+  readonly text: string;
+  readonly tone: "signal" | "risk" | "caveat";
+  readonly provenance: ReportDashboardProvenance;
+};
+
+export type ReportDashboardSection = {
+  readonly id: ReportDashboardSectionId;
+  readonly title: string;
+  readonly sourceDimension: ReportDimensionKey;
+  readonly status: "assessed" | "low-confidence" | "missing";
+  readonly score: number | undefined;
+  readonly rating: ReportRating;
+  readonly confidenceLabel: string;
+  readonly summary: string;
+  readonly metrics: readonly ReportDashboardMetric[];
+  readonly highlights: readonly string[];
+  readonly risks: readonly string[];
+  readonly nextChecks: readonly string[];
+  readonly caveats: readonly string[];
+  readonly chartPoints: readonly ReportDashboardChartPoint[];
+  readonly provenance: ReportDashboardProvenance;
+};
+
+export type ReportDashboardSectionId =
+  | "maintainability"
+  | "testing"
+  | "security"
+  | "architecture"
+  | "documentation";
+
+export type ReportDashboardMetric = {
+  readonly label: string;
+  readonly value: string;
+  readonly detail: string;
+};
+
+export type ReportDashboardChartPoint = {
+  readonly label: "Score" | "Confidence" | "Evidence" | "Risk";
+  readonly value: number;
+};
+
+export type ReportDashboardProvenance = {
+  readonly source:
+    | "report-card"
+    | "code-shape-summary"
+    | "language-mix"
+    | "dimension-assessment"
+    | "finding"
+    | "caveat";
+  readonly referenceIds: readonly string[];
+};
+
+const dashboardSections = [
+  {
+    id: "maintainability",
+    title: "Maintainability",
+    sourceDimension: "maintainability",
+  },
+  {
+    id: "testing",
+    title: "Testing",
+    sourceDimension: "verifiability",
+  },
+  {
+    id: "security",
+    title: "Security",
+    sourceDimension: "security",
+  },
+  {
+    id: "architecture",
+    title: "Architecture",
+    sourceDimension: "architecture-boundaries",
+  },
+  {
+    id: "documentation",
+    title: "Documentation",
+    sourceDimension: "documentation",
+  },
+] as const satisfies readonly {
+  readonly id: ReportDashboardSectionId;
+  readonly title: string;
+  readonly sourceDimension: ReportDimensionKey;
+}[];
+
+const languageColors = ["#047857", "#2563eb", "#d97706", "#be123c", "#7c3aed"];
+
+export function buildReportDashboardViewModel(
+  analysis: AnalyzeRepositoryResponse,
+): ReportDashboardViewModel {
+  const sections = dashboardSections.map((section) =>
+    buildSection(
+      section,
+      analysis.reportCard.dimensionAssessments,
+      analysis.reportCard.caveats,
+    ),
+  );
+  const overallScore = scoreAverage(
+    sections
+      .map((section) => section.score)
+      .filter((score) => score !== undefined),
+  );
+  const languageSlices =
+    analysis.dashboardInsights.languageMix.map(languageSlice);
+
+  return {
+    overview: {
+      repositoryLabel: repositoryLabel(analysis),
+      analyzedAt: analysis.reportCard.generatedAt,
+      reviewerNote: reviewerNote(analysis),
+      overallScore,
+      grade: gradeForScore(overallScore),
+      summary: analysis.dashboardInsights.evidenceSummary,
+      provenance: {
+        source: "report-card",
+        referenceIds: analysis.reportCard.evidenceReferences.map(
+          (reference) => reference.id,
+        ),
+      },
+    },
+    bigNumbers: bigNumbers(analysis, overallScore, sections),
+    languageSlices,
+    emptyLanguageMessage:
+      languageSlices.length === 0
+        ? "No language mix was available in the collected evidence."
+        : undefined,
+    reviewerNotes: reviewerNotes(sections, analysis.reportCard.caveats),
+    sections,
+  };
+}
+
+function buildSection(
+  section: (typeof dashboardSections)[number],
+  assessments: readonly DimensionAssessment[],
+  caveats: readonly ReportCaveat[],
+): ReportDashboardSection {
+  const assessment = assessments.find(
+    (candidate) => candidate.dimension === section.sourceDimension,
+  );
+
+  if (assessment === undefined) {
+    const summary = `${section.title} evidence was not available in this report.`;
+    return {
+      id: section.id,
+      title: section.title,
+      sourceDimension: section.sourceDimension,
+      status: "missing",
+      score: undefined,
+      rating: "not-assessed",
+      confidenceLabel: "not assessed",
+      summary,
+      metrics: [
+        { label: "Score", value: "Not assessed", detail: "Missing dimension" },
+        { label: "Findings", value: "0", detail: "Reviewer signals" },
+        { label: "Evidence", value: "0", detail: "Structured references" },
+      ],
+      highlights: [],
+      risks: [],
+      nextChecks: [],
+      caveats: [summary],
+      chartPoints: [
+        { label: "Score", value: 0 },
+        { label: "Confidence", value: 0 },
+        { label: "Evidence", value: 0 },
+        { label: "Risk", value: 0 },
+      ],
+      provenance: {
+        source: "report-card",
+        referenceIds: [],
+      },
+    };
+  }
+
+  const relevantCaveats = caveats.filter((caveat) =>
+    caveat.affectedDimensions.includes(assessment.dimension),
+  );
+  const confidencePercent = Math.round(assessment.confidence.score * 100);
+  const highlights = assessment.findings
+    .filter(
+      (finding) => severityRank(finding.severity) === severityRank("info"),
+    )
+    .map((finding) => finding.summary);
+  const risks = assessment.findings
+    .filter((finding) => severityRank(finding.severity) > severityRank("info"))
+    .map((finding) => finding.summary);
+  const nextChecks = relevantCaveats.flatMap(
+    (caveat) => caveat.missingEvidence,
+  );
+
+  return {
+    id: section.id,
+    title: section.title,
+    sourceDimension: section.sourceDimension,
+    status:
+      assessment.confidence.level === "low" ? "low-confidence" : "assessed",
+    score: assessment.score,
+    rating: assessment.rating,
+    confidenceLabel: `${assessment.confidence.level} confidence`,
+    summary: assessment.summary,
+    metrics: [
+      {
+        label: "Score",
+        value:
+          assessment.score === undefined
+            ? "Not assessed"
+            : String(assessment.score),
+        detail: "Dimension score",
+      },
+      {
+        label: "Findings",
+        value: String(assessment.findings.length),
+        detail: "Reviewer signals",
+      },
+      {
+        label: "Evidence",
+        value: String(assessment.evidenceReferences.length),
+        detail: "Structured references",
+      },
+    ],
+    highlights,
+    risks,
+    nextChecks,
+    caveats: caveatDisplayText(relevantCaveats),
+    chartPoints: [
+      { label: "Score", value: assessment.score ?? 0 },
+      { label: "Confidence", value: confidencePercent },
+      {
+        label: "Evidence",
+        value: Math.min(100, assessment.evidenceReferences.length * 25),
+      },
+      { label: "Risk", value: riskValue(assessment.findings) },
+    ],
+    provenance: {
+      source: "dimension-assessment",
+      referenceIds: assessment.evidenceReferences.map(
+        (reference) => reference.id,
+      ),
+    },
+  };
+}
+
+function bigNumbers(
+  analysis: AnalyzeRepositoryResponse,
+  overallScore: number | undefined,
+  sections: readonly ReportDashboardSection[],
+): readonly ReportDashboardBigNumber[] {
+  const summary = analysis.dashboardInsights.codeShapeSummary;
+  const scoredSectionCount = sections.filter(
+    (section) => section.score !== undefined,
+  ).length;
+
+  return [
+    {
+      id: "overall-score",
+      label: "Overall Score",
+      value: overallScore === undefined ? "Not assessed" : String(overallScore),
+      detail:
+        overallScore === undefined
+          ? "No scored dashboard sections"
+          : `Average of ${scoredSectionCount} scored dashboard sections`,
+      provenance: { source: "report-card", referenceIds: [] },
+    },
+    {
+      id: "source-files",
+      label: "Source Files",
+      value: formatNumber(summary.sourceFileCount),
+      detail: "Files classified as source evidence",
+      provenance: { source: "code-shape-summary", referenceIds: [] },
+    },
+    {
+      id: "code-lines",
+      label: "Code Lines",
+      value: formatNumber(summary.totalCodeLineCount),
+      detail: "Evidence-backed code line count",
+      provenance: { source: "code-shape-summary", referenceIds: [] },
+    },
+    {
+      id: "test-ratio",
+      label: "Test Ratio",
+      value: testRatioValue(summary.testFileCount, summary.sourceFileCount),
+      detail: `${formatNumber(summary.testFileCount)} test files for ${formatNumber(
+        summary.sourceFileCount,
+      )} source files`,
+      provenance: { source: "code-shape-summary", referenceIds: [] },
+    },
+  ];
+}
+
+function languageSlice(
+  item: DashboardLanguageMixItem,
+  index: number,
+): ReportDashboardLanguageSlice {
+  return {
+    language: item.language,
+    percentOfCode: item.percentOfCode,
+    codeLineCount: item.codeLineCount,
+    fileCount: item.fileCount,
+    color: languageColors[index % languageColors.length] ?? "#047857",
+    provenance: {
+      source: "language-mix",
+      referenceIds: item.evidenceReferenceIds,
+    },
+  };
+}
+
+function reviewerNotes(
+  sections: readonly ReportDashboardSection[],
+  caveats: readonly ReportCaveat[],
+): readonly ReportDashboardReviewerNote[] {
+  const signals = sections
+    .toSorted((left, right) => (right.score ?? 0) - (left.score ?? 0))
+    .flatMap((section) => signalNotesForSection(section));
+  const risks = sections
+    .toSorted(
+      (left, right) =>
+        riskChartValue(right.chartPoints) - riskChartValue(left.chartPoints),
+    )
+    .flatMap((section) => riskNotesForSection(section));
+  const caveatNotes = caveats.map((caveat) => ({
+    text: caveat.summary,
+    tone: "caveat" as const,
+    provenance: {
+      source: "caveat" as const,
+      referenceIds: [caveat.id],
+    },
+  }));
+
+  return [...signals, ...risks, ...caveatNotes];
+}
+
+function signalNotesForSection(
+  section: ReportDashboardSection,
+): readonly ReportDashboardReviewerNote[] {
+  return section.highlights.map((text) => ({
+    text,
+    tone: "signal",
+    provenance: section.provenance,
+  }));
+}
+
+function riskNotesForSection(
+  section: ReportDashboardSection,
+): readonly ReportDashboardReviewerNote[] {
+  return section.risks.map((text) => ({
+    text,
+    tone: "risk",
+    provenance: section.provenance,
+  }));
+}
+
+function riskChartValue(points: readonly ReportDashboardChartPoint[]): number {
+  return points.find((point) => point.label === "Risk")?.value ?? 0;
+}
+
+function caveatDisplayText(
+  caveats: readonly ReportCaveat[],
+): readonly string[] {
+  return caveats.flatMap((caveat) => {
+    const missingEvidence =
+      caveat.missingEvidence.length === 0
+        ? []
+        : [`Missing evidence: ${caveat.missingEvidence.join(", ")}`];
+    return [caveat.summary, ...missingEvidence];
+  });
+}
+
+function repositoryLabel(analysis: AnalyzeRepositoryResponse): string {
+  const repository = analysis.reportCard.repository;
+  const owner = repository.owner === undefined ? "" : `${repository.owner}/`;
+  const revision =
+    repository.revision === undefined ? "" : ` @ ${repository.revision}`;
+  return `${repository.provider}:${owner}${repository.name}${revision}`;
+}
+
+function reviewerNote(analysis: AnalyzeRepositoryResponse): string {
+  const metadata = analysis.reportCard.reviewerMetadata;
+  const model =
+    metadata.modelProvider === undefined || metadata.modelName === undefined
+      ? ""
+      : ` using ${metadata.modelProvider}/${metadata.modelName}`;
+  return `${metadata.name} reviewed this report${model}`;
+}
+
+function scoreAverage(scores: readonly number[]): number | undefined {
+  if (scores.length === 0) {
+    return undefined;
+  }
+
+  return Math.round(
+    scores.reduce((total, score) => total + score, 0) / scores.length,
+  );
+}
+
+function gradeForScore(score: number | undefined): string {
+  if (score === undefined) {
+    return "Not assessed";
+  }
+
+  if (score >= 90) {
+    return "A";
+  }
+
+  if (score >= 80) {
+    return "B";
+  }
+
+  if (score >= 70) {
+    return "C";
+  }
+
+  if (score >= 60) {
+    return "D";
+  }
+
+  return "F";
+}
+
+function testRatioValue(
+  testFileCount: number,
+  sourceFileCount: number,
+): string {
+  if (sourceFileCount === 0) {
+    return testFileCount === 0 ? "No source files" : "No source baseline";
+  }
+
+  return `${Math.round((testFileCount / sourceFileCount) * 100)}%`;
+}
+
+function riskValue(findings: readonly ReportFinding[]): number {
+  const highestSeverity = findings.reduce(
+    (highest, finding) => Math.max(highest, severityRank(finding.severity)),
+    0,
+  );
+  return highestSeverity * 25;
+}
+
+function severityRank(severity: FindingSeverity): number {
+  switch (severity) {
+    case "info":
+      return 0;
+    case "low":
+      return 1;
+    case "medium":
+      return 2;
+    case "high":
+      return 3;
+    case "critical":
+      return 4;
+  }
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}


### PR DESCRIPTION
## Scope
- Adds a red-compatible report dashboard view model adapter for Green report responses.
- Maps overview, big numbers, language slices, reviewer notes, and fixed sections for Maintainability, Testing, Security, Architecture, and Documentation.
- Preserves structured provenance while keeping raw evidence ids out of primary display copy.
- Covers complete, missing-dimension, low-confidence, caveat, and empty-language cases.

## Non-goals
- Does not render the dashboard in React; that remains #119.
- Does not change the analysis form; that is #117/#130.
- Does not alter scoring policy or domain report structures.

## Tests
- pnpm vitest run src/application/report-dashboard/report-dashboard-view-model.test.ts
- pnpm check
- pnpm build
- pnpm test:e2e

Closes #118