### PR TITLE
fix(reviewer): fall back when OpenRouter analysis fails

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../infrastructure/llm/openrouter-config";
 import { FakeReviewer } from "../../../infrastructure/reviewer/fake-reviewer";
 import { OpenRouterReviewer } from "../../../infrastructure/reviewer/openrouter-reviewer";
+import { OpenRouterReviewerFallback } from "../../../infrastructure/reviewer/openrouter-reviewer-fallback";
 import { StaticEvidenceReviewer } from "../../../infrastructure/reviewer/static-evidence-reviewer";
 import {
   RepositorySourceError,
@@ -362,8 +363,11 @@ function reviewerFor(
   options: AnalyzeRouteOptions,
 ): Reviewer {
   if (options.openRouterConfig !== undefined) {
-    return new OpenRouterReviewer({
-      config: options.openRouterConfig,
+    return new OpenRouterReviewerFallback({
+      primary: new OpenRouterReviewer({
+        config: options.openRouterConfig,
+      }),
+      fallback: new StaticEvidenceReviewer(),
     });
   }
 

--- a/src/infrastructure/reviewer/openrouter-reviewer-fallback.ts
+++ b/src/infrastructure/reviewer/openrouter-reviewer-fallback.ts
@@ -1,0 +1,126 @@
+import type { ReportDimensionKey } from "../../domain/report/report-card";
+import type {
+  MalformedReviewerResponse,
+  Reviewer,
+  ReviewerRequest,
+  ReviewerResult,
+} from "../../domain/reviewer/reviewer";
+import type {
+  ReviewerAssessment,
+  ReviewerCaveat,
+} from "../../domain/reviewer/reviewer-assessment";
+
+export type OpenRouterReviewerFallbackOptions = {
+  readonly primary: Reviewer;
+  readonly fallback: Reviewer;
+};
+
+const staticReviewerCaveatId = "caveat:static-reviewer";
+const fallbackCaveatId = "caveat:openrouter-reviewer-fallback";
+const affectedDimensions = [
+  "maintainability",
+  "verifiability",
+  "security",
+  "architecture-boundaries",
+  "documentation",
+] satisfies readonly ReportDimensionKey[];
+
+export class OpenRouterReviewerFallback implements Reviewer {
+  private readonly primary: Reviewer;
+  private readonly fallback: Reviewer;
+
+  constructor(options: OpenRouterReviewerFallbackOptions) {
+    this.primary = options.primary;
+    this.fallback = options.fallback;
+  }
+
+  async assess(request: ReviewerRequest): Promise<ReviewerResult> {
+    const primaryResult = await this.primary.assess(request);
+
+    if (primaryResult.kind === "assessment") {
+      return primaryResult;
+    }
+
+    const fallbackResult = await this.fallback.assess(request);
+
+    if (fallbackResult.kind === "malformed-response") {
+      return primaryResult;
+    }
+
+    return {
+      kind: "assessment",
+      assessment: withOpenRouterFallbackCaveat(
+        fallbackResult.assessment,
+        fallbackCaveat(request, primaryResult),
+      ),
+    };
+  }
+}
+
+function withOpenRouterFallbackCaveat(
+  assessment: ReviewerAssessment,
+  caveat: ReviewerCaveat,
+): ReviewerAssessment {
+  return {
+    ...assessment,
+    caveats: [
+      ...assessment.caveats.filter(
+        (existingCaveat) => existingCaveat.id !== staticReviewerCaveatId,
+      ),
+      caveat,
+    ],
+  };
+}
+
+function fallbackCaveat(
+  request: ReviewerRequest,
+  malformedResponse: MalformedReviewerResponse,
+): ReviewerCaveat {
+  const providerFailure = malformedResponse.rawResponse.trim() === "";
+
+  return {
+    id: fallbackCaveatId,
+    summary: providerFailure
+      ? "OpenRouter reviewer enrichment failed for the selected model, so the report falls back to deterministic static analysis. Try openai/gpt-4.1-mini or another structured-output-capable model."
+      : "OpenRouter reviewer output could not be parsed or validated, so the report falls back to deterministic static analysis while preserving validation details.",
+    affectedDimensions: [...affectedDimensions],
+    missingEvidence: providerFailure
+      ? [
+          "Structured OpenRouter reviewer assessment",
+          "Successful reviewer response from the selected OpenRouter model",
+          ...validationIssueMessages(malformedResponse),
+        ]
+      : [
+          "Structured OpenRouter reviewer assessment",
+          ...validationIssueMessages(malformedResponse),
+        ],
+    confidence: {
+      level: "medium",
+      score: 0.62,
+      rationale:
+        "Repository evidence was collected, but semantic reviewer enrichment was unavailable for this run.",
+    },
+    evidenceReferences:
+      request.evidenceReferences.length === 0
+        ? [
+            {
+              id: "reviewer:openrouter-fallback",
+              kind: "reviewer",
+              label: "OpenRouter reviewer fallback",
+              notes:
+                "No deterministic evidence references were supplied to the fallback caveat.",
+            },
+          ]
+        : [...request.evidenceReferences],
+  };
+}
+
+function validationIssueMessages(
+  malformedResponse: MalformedReviewerResponse,
+): readonly string[] {
+  return [
+    ...new Set(
+      malformedResponse.validationIssues.map((issue) => issue.message),
+    ),
+  ];
+}

--- a/src/infrastructure/reviewer/openrouter-reviewer.ts
+++ b/src/infrastructure/reviewer/openrouter-reviewer.ts
@@ -158,16 +158,103 @@ function promptInput(
 }
 
 function parseJson(content: string): JsonParseResult {
-  try {
-    return {
-      success: true,
-      value: JSON.parse(content),
-    };
-  } catch {
-    return {
-      success: false,
-    };
+  for (const candidate of jsonCandidates(content)) {
+    try {
+      return {
+        success: true,
+        value: JSON.parse(candidate),
+      };
+    } catch {
+      continue;
+    }
   }
+
+  return {
+    success: false,
+  };
+}
+
+function jsonCandidates(content: string): readonly string[] {
+  const trimmed = content.trim();
+  const candidates = [trimmed];
+  const fencedContent = extractFencedContent(trimmed);
+
+  if (fencedContent !== undefined) {
+    candidates.push(fencedContent);
+  }
+
+  const objectContent = extractFirstJsonObject(trimmed);
+
+  if (objectContent !== undefined) {
+    candidates.push(objectContent);
+  }
+
+  return [...new Set(candidates)];
+}
+
+function extractFencedContent(content: string): string | undefined {
+  const match = /^```(?:json)?\s*([\s\S]*?)\s*```$/iu.exec(content);
+  return match?.[1]?.trim();
+}
+
+function extractFirstJsonObject(content: string): string | undefined {
+  let startIndex: number | undefined;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index];
+
+    if (character === undefined) {
+      continue;
+    }
+
+    if (startIndex === undefined) {
+      if (character === "{") {
+        startIndex = index;
+        depth = 1;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+
+      if (character === "\\") {
+        escaped = true;
+        continue;
+      }
+
+      if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (character === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (character === "}") {
+      depth -= 1;
+
+      if (depth === 0) {
+        return content.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function malformedResponse(options: {

--- a/test/infrastructure/reviewer/openrouter-reviewer-fallback.test.ts
+++ b/test/infrastructure/reviewer/openrouter-reviewer-fallback.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReviewerMetadata } from "../../../src/domain/report/report-card";
+import type {
+  MalformedReviewerResponse,
+  Reviewer,
+  ReviewerRequest,
+  ReviewerResult,
+} from "../../../src/domain/reviewer/reviewer";
+import {
+  ReviewerAssessmentSchemaVersion,
+  type ReviewerAssessment,
+} from "../../../src/domain/reviewer/reviewer-assessment";
+import { OpenRouterReviewerFallback } from "../../../src/infrastructure/reviewer/openrouter-reviewer-fallback";
+
+const evidenceReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+} as const;
+
+const request: ReviewerRequest = {
+  repository: {
+    provider: "github",
+    owner: "lightstrikelabs",
+    name: "repo-analyzer-green",
+    url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+  },
+  evidenceReferences: [evidenceReference],
+  evidenceSummary: "Repository evidence was collected successfully.",
+};
+
+const fallbackAssessment = {
+  schemaVersion: ReviewerAssessmentSchemaVersion,
+  reviewer: {
+    kind: "automated",
+    name: "Static evidence reviewer",
+    reviewerVersion: "static-evidence-reviewer.v1",
+    reviewedAt: "2026-04-26T12:00:00-07:00",
+  },
+  assessedArchetype: {
+    value: "unknown",
+    confidence: {
+      level: "medium",
+      score: 0.55,
+      rationale: "Static evidence only.",
+    },
+    evidenceReferences: [evidenceReference],
+    rationale: "Static fallback assessment.",
+  },
+  dimensions: [
+    {
+      dimension: "maintainability",
+      summary: "Static evidence can still support a report.",
+      confidence: {
+        level: "medium",
+        score: 0.7,
+        rationale: "Repository evidence was collected.",
+      },
+      evidenceReferences: [evidenceReference],
+      strengths: ["Static signals are available."],
+      risks: ["Semantic review was unavailable."],
+      missingEvidence: ["Structured reviewer assessment"],
+    },
+  ],
+  caveats: [
+    {
+      id: "caveat:static-reviewer",
+      summary: "No OpenRouter key was supplied.",
+      affectedDimensions: ["maintainability"],
+      missingEvidence: ["Structured LLM or human reviewer assessment"],
+      confidence: {
+        level: "medium",
+        score: 0.6,
+        rationale: "Static evidence has limited semantic coverage.",
+      },
+      evidenceReferences: [evidenceReference],
+    },
+  ],
+  followUpQuestions: [],
+} satisfies ReviewerAssessment;
+
+const openRouterMetadata: ReviewerMetadata = {
+  kind: "llm",
+  name: "OpenRouter reviewer",
+  reviewerVersion: "openrouter-reviewer.v1",
+  modelProvider: "openrouter",
+  modelName: "openrouter/free",
+  reviewedAt: "2026-04-26T12:01:00-07:00",
+};
+
+describe("OpenRouterReviewerFallback", () => {
+  it("returns the primary reviewer assessment when OpenRouter succeeds", async () => {
+    const primary = new StubReviewer({
+      kind: "assessment",
+      assessment: fallbackAssessment,
+    });
+    const fallback = new StubReviewer({
+      kind: "assessment",
+      assessment: fallbackAssessment,
+    });
+    const reviewer = new OpenRouterReviewerFallback({ primary, fallback });
+
+    const result = await reviewer.assess(request);
+
+    expect(result).toEqual({
+      kind: "assessment",
+      assessment: fallbackAssessment,
+    });
+    expect(primary.calls).toBe(1);
+    expect(fallback.calls).toBe(0);
+  });
+
+  it("falls back to static analysis with an alternate-model suggestion when OpenRouter cannot complete", async () => {
+    const primary = new StubReviewer(
+      malformedOpenRouterResult({
+        rawResponse: "",
+        message:
+          "OpenRouter reviewer output is unavailable because the provider request could not be completed.",
+      }),
+    );
+    const fallback = new StubReviewer({
+      kind: "assessment",
+      assessment: fallbackAssessment,
+    });
+    const reviewer = new OpenRouterReviewerFallback({ primary, fallback });
+
+    const result = await reviewer.assess(request);
+
+    expect(result.kind).toBe("assessment");
+    if (result.kind !== "assessment") {
+      throw new Error("Expected fallback reviewer assessment");
+    }
+    expect(fallback.calls).toBe(1);
+    expect(result.assessment.caveats).not.toContainEqual(
+      expect.objectContaining({ id: "caveat:static-reviewer" }),
+    );
+    expect(result.assessment.caveats).toContainEqual(
+      expect.objectContaining({
+        id: "caveat:openrouter-reviewer-fallback",
+        summary: expect.stringContaining("openai/gpt-4.1-mini"),
+        missingEvidence: expect.arrayContaining([
+          "Successful reviewer response from the selected OpenRouter model",
+        ]),
+      }),
+    );
+  });
+
+  it("falls back with parse diagnostics when OpenRouter output cannot be validated", async () => {
+    const primary = new StubReviewer(
+      malformedOpenRouterResult({
+        rawResponse: "not-json",
+        message: "Reviewer response was not valid JSON.",
+      }),
+    );
+    const fallback = new StubReviewer({
+      kind: "assessment",
+      assessment: fallbackAssessment,
+    });
+    const reviewer = new OpenRouterReviewerFallback({ primary, fallback });
+
+    const result = await reviewer.assess(request);
+
+    expect(result.kind).toBe("assessment");
+    if (result.kind !== "assessment") {
+      throw new Error("Expected fallback reviewer assessment");
+    }
+    expect(result.assessment.caveats).toContainEqual(
+      expect.objectContaining({
+        id: "caveat:openrouter-reviewer-fallback",
+        summary: expect.stringContaining("could not be parsed or validated"),
+        missingEvidence: expect.arrayContaining([
+          "Reviewer response was not valid JSON.",
+        ]),
+      }),
+    );
+  });
+});
+
+class StubReviewer implements Reviewer {
+  calls = 0;
+
+  constructor(private readonly result: ReviewerResult) {}
+
+  async assess(): Promise<ReviewerResult> {
+    this.calls += 1;
+    return this.result;
+  }
+}
+
+function malformedOpenRouterResult(options: {
+  readonly rawResponse: string;
+  readonly message: string;
+}): MalformedReviewerResponse {
+  return {
+    kind: "malformed-response",
+    reviewer: openRouterMetadata,
+    rawResponse: options.rawResponse,
+    validationIssues: [
+      {
+        path: [],
+        message: options.message,
+      },
+    ],
+  };
+}

--- a/test/infrastructure/reviewer/openrouter-reviewer.test.ts
+++ b/test/infrastructure/reviewer/openrouter-reviewer.test.ts
@@ -161,6 +161,31 @@ describe("OpenRouterReviewer", () => {
     });
   });
 
+  it("accepts reviewer JSON wrapped in common model formatting", async () => {
+    const reviewer = new OpenRouterReviewer({
+      chatProvider: completionProviderForContent(
+        [
+          "Here is the structured reviewer assessment:",
+          "",
+          "```json",
+          JSON.stringify(assessment),
+          "```",
+        ].join("\n"),
+      ),
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result).toEqual({ kind: "assessment", assessment });
+  });
+
   it("returns malformed-response when model JSON does not match the reviewer assessment schema", async () => {
     const malformedContent = JSON.stringify({
       schemaVersion: ReviewerAssessmentSchemaVersion,


### PR DESCRIPTION
## Summary

- Adds an OpenRouter reviewer fallback wrapper so provider/model failures return a deterministic report with a caveat instead of failing the whole analysis.
- Adds an alternate-model suggestion in the fallback caveat for provider/model failures.
- Accepts common model formatting by extracting valid reviewer JSON from fenced/prose-wrapped responses before schema validation.

Closes #132.

## Diagnostics

Production-style reproduction with a non-secret invalid OpenRouter key and `model: openrouter/free` returned:

```text
HTTP 502
error.code: reviewer-malformed-response
issue: OpenRouter reviewer output is unavailable because the provider request could not be completed.
```

Local route verification after this change, using the same repository/model shape with a non-secret invalid key, returns HTTP 200 with `caveat:openrouter-reviewer-fallback` and suggests `openai/gpt-4.1-mini`.

## Verification

- `pnpm vitest run test/infrastructure/reviewer/openrouter-reviewer.test.ts test/infrastructure/reviewer/openrouter-reviewer-fallback.test.ts`
- `npx -y node@24 $(command -v pnpm) check`
- `npx -y node@24 $(command -v pnpm) build`
- `npx -y node@24 $(command -v pnpm) test:e2e`
- Local `/api/analyze` curl with dummy invalid OpenRouter key returned HTTP 200 plus fallback caveat.

Note: plain local `pnpm check` under the shell's Node 25 fails in existing `analyze-repository-panel` jsdom tests because `window.localStorage.clear` is unavailable. The repo engine is Node 24, so verification above ran the full check under Node 24.
