### PR TITLE
fix(reviewer): harden OpenRouter assessment parsing

### DIFF
--- a/docs/how-tos/openrouter-e2e.md
+++ b/docs/how-tos/openrouter-e2e.md
@@ -65,6 +65,16 @@ OpenRouter configuration is parsed at the provider boundary in `src/infrastructu
 
 The OpenRouter chat provider returns typed provider failures instead of throwing provider details into the domain. Missing keys, network failures, non-2xx responses, invalid response shapes, and empty or reasoning-only responses should become user-facing caveats that say OpenRouter output is unavailable. Do not include raw provider error bodies or secret values in user-facing UI, persisted reports, traces, or PR/issue text.
 
+## Local Live Contract Check
+
+The normal test suite must not depend on live model calls. To verify the OpenRouter request contract locally, run the skipped-by-default live contract test with a request-scoped key:
+
+```bash
+OPENROUTER_API_KEY="<local key>" RUN_OPENROUTER_LIVE=1 pnpm vitest run test/infrastructure/llm/openrouter-live-contract.test.ts
+```
+
+This test uses `openai/gpt-4.1-mini`, requests JSON object output, and asserts that OpenRouter returns parseable JSON content. Do not commit keys, paste keys into issue bodies, or include raw provider responses in logs.
+
 ## Safety Rules
 
 - Keep the deterministic foundational E2E fake-backed.

--- a/src/domain/reviewer/reviewer-prompt.test.ts
+++ b/src/domain/reviewer/reviewer-prompt.test.ts
@@ -45,6 +45,11 @@ describe("renderReviewerPrompt", () => {
     expect(prompt.system).toContain(ReviewerAssessmentSchemaVersion);
     expect(prompt.system).toContain("Do not make unsupported claims");
     expect(prompt.system).toContain("Missing evidence is not a defect");
+    expect(prompt.system).toContain("copy complete EvidenceReference objects");
+    expect(prompt.system).toContain("Do not return string ids");
+    expect(prompt.system).toContain(
+      "Every confidence object must include a rationale string.",
+    );
     expect(prompt.system).toContain("follow-up questions");
     expect(prompt.user).toContain("lightstrikelabs/repo-analyzer-green");
     expect(prompt.user).toContain("Files analyzed: 42");
@@ -54,6 +59,9 @@ describe("renderReviewerPrompt", () => {
     );
     expect(prompt.responseContractJson).toContain(
       '"schemaVersion":"reviewer-assessment.v1"',
+    );
+    expect(prompt.responseContractJson).toContain(
+      '"evidenceReferences":[{"id":"evidence:id"',
     );
     expect(prompt.messages).toEqual([
       {

--- a/src/domain/reviewer/reviewer-prompt.ts
+++ b/src/domain/reviewer/reviewer-prompt.ts
@@ -47,11 +47,13 @@ export function renderReviewerPrompt(
     "Static metrics are evidence, not final judgments.",
     "Security hygiene signals are indicators that require review, not confirmed vulnerabilities.",
     "Every dimension assessment must cite evidenceReferences when evidence exists, or explain missingEvidence when it does not.",
+    "When citing evidenceReferences, copy complete EvidenceReference objects from the input. Do not return string ids.",
     `Assess these dimensions exactly: ${requiredDimensions.join(", ")}.`,
     "Include caveats for low confidence, unavailable evidence, unsupported ecosystems, bounded scans, and provider limitations.",
     "Include follow-up questions tied to uncertainty or risk, not generic advice.",
     "Use confidence.score between 0 and 1 and confidence.level as low, medium, or high.",
-    "Use concise strings. Preserve evidence reference ids exactly as supplied.",
+    "Every confidence object must include a rationale string.",
+    "Use concise strings. Preserve ids inside copied evidence reference objects exactly as supplied.",
     `Response contract JSON example: ${responseContractJson}`,
   ].join("\n");
   const user = [
@@ -101,7 +103,17 @@ function responseContract() {
         score: 0.5,
         rationale: "string",
       },
-      evidenceReferences: ["EvidenceReference objects copied from input"],
+      evidenceReferences: [
+        {
+          id: "evidence:id",
+          kind: "file | collector | reviewer | derived",
+          label: "string",
+          path: "optional/path.ext",
+          lineStart: 1,
+          lineEnd: 1,
+          notes: "optional notes",
+        },
+      ],
       rationale: "string",
     },
     dimensions: requiredDimensions.map((dimension) => ({
@@ -112,7 +124,17 @@ function responseContract() {
         score: 0.5,
         rationale: "string",
       },
-      evidenceReferences: ["EvidenceReference objects copied from input"],
+      evidenceReferences: [
+        {
+          id: "evidence:id",
+          kind: "file | collector | reviewer | derived",
+          label: "string",
+          path: "optional/path.ext",
+          lineStart: 1,
+          lineEnd: 1,
+          notes: "optional notes",
+        },
+      ],
       strengths: ["evidence-backed strength"],
       risks: ["evidence-backed risk"],
       missingEvidence: ["evidence that would change confidence"],
@@ -128,7 +150,17 @@ function responseContract() {
           score: 0.5,
           rationale: "string",
         },
-        evidenceReferences: ["EvidenceReference objects copied from input"],
+        evidenceReferences: [
+          {
+            id: "evidence:id",
+            kind: "file | collector | reviewer | derived",
+            label: "string",
+            path: "optional/path.ext",
+            lineStart: 1,
+            lineEnd: 1,
+            notes: "optional notes",
+          },
+        ],
       },
     ],
     followUpQuestions: [

--- a/src/infrastructure/llm/openrouter-chat-provider.ts
+++ b/src/infrastructure/llm/openrouter-chat-provider.ts
@@ -16,6 +16,7 @@ export type OpenRouterChatMessage = {
 
 export type OpenRouterChatCompletionControls = {
   readonly maxOutputTokens?: number;
+  readonly responseFormat?: "json_object";
   readonly temperature?: number;
 };
 
@@ -78,9 +79,13 @@ const OpenRouterChatProviderResponseSchema = z
 const OpenRouterChatCompletionControlsSchema = z
   .object({
     maxOutputTokens: z.int().positive().optional(),
+    responseFormat: z.literal("json_object").optional(),
     temperature: z.number().min(0).max(2).optional(),
   })
   .strict();
+
+const OpenRouterAppReferer = "https://repo-analyzer-green.vercel.app";
+const OpenRouterAppTitle = "Repo Analyzer Green";
 
 export class OpenRouterChatCompletionProvider {
   private readonly fetcher: OpenRouterChatFetcher;
@@ -115,6 +120,8 @@ export class OpenRouterChatCompletionProvider {
           headers: {
             authorization: `Bearer ${request.config.apiKey}`,
             "content-type": "application/json",
+            "HTTP-Referer": OpenRouterAppReferer,
+            "X-Title": OpenRouterAppTitle,
           },
           body: JSON.stringify({
             model: request.config.model,
@@ -128,8 +135,6 @@ export class OpenRouterChatCompletionProvider {
       return providerFailure({
         model: request.config.model,
         code: "network-error",
-        userFacingCaveat:
-          "OpenRouter reviewer output is unavailable because the provider request could not be completed.",
       });
     }
 
@@ -138,8 +143,6 @@ export class OpenRouterChatCompletionProvider {
         model: request.config.model,
         code: "provider-error",
         status: response.status,
-        userFacingCaveat:
-          "OpenRouter reviewer output is unavailable because the provider request failed.",
       });
     }
 
@@ -198,11 +201,23 @@ export class OpenRouterChatCompletionProvider {
 
 function requestBodyControls(
   controls: OpenRouterChatCompletionControls | undefined,
-): Record<string, number> {
-  const requestControls: Record<string, number> = {};
+): {
+  readonly max_tokens?: number;
+  readonly response_format?: { readonly type: "json_object" };
+  readonly temperature?: number;
+} {
+  const requestControls: {
+    max_tokens?: number;
+    response_format?: { readonly type: "json_object" };
+    temperature?: number;
+  } = {};
 
   if (controls?.maxOutputTokens !== undefined) {
     requestControls.max_tokens = controls.maxOutputTokens;
+  }
+
+  if (controls?.responseFormat !== undefined) {
+    requestControls.response_format = { type: controls.responseFormat };
   }
 
   if (controls?.temperature !== undefined) {
@@ -221,6 +236,9 @@ function parseOpenRouterChatCompletionControls(
     ...(parsedControls.maxOutputTokens === undefined
       ? {}
       : { maxOutputTokens: parsedControls.maxOutputTokens }),
+    ...(parsedControls.responseFormat === undefined
+      ? {}
+      : { responseFormat: parsedControls.responseFormat }),
     ...(parsedControls.temperature === undefined
       ? {}
       : { temperature: parsedControls.temperature }),
@@ -231,14 +249,16 @@ function providerFailure(options: {
   readonly model: OpenRouterModelId;
   readonly code: OpenRouterProviderFailureCode;
   readonly status?: number;
-  readonly userFacingCaveat: string;
+  readonly userFacingCaveat?: string;
 }): OpenRouterProviderFailure {
   const baseFailure = {
     kind: "provider-failure" as const,
     provider: "openrouter" as const,
     model: options.model,
     code: options.code,
-    userFacingCaveat: options.userFacingCaveat,
+    userFacingCaveat:
+      options.userFacingCaveat ??
+      userFacingProviderFailureCaveat(providerFailureCaveatOptions(options)),
   };
 
   if (options.status === undefined) {
@@ -249,4 +269,76 @@ function providerFailure(options: {
     ...baseFailure,
     status: options.status,
   };
+}
+
+function providerFailureCaveatOptions(options: {
+  readonly model: OpenRouterModelId;
+  readonly code: OpenRouterProviderFailureCode;
+  readonly status?: number;
+}):
+  | {
+      readonly code: OpenRouterProviderFailureCode;
+      readonly model: OpenRouterModelId;
+    }
+  | {
+      readonly code: OpenRouterProviderFailureCode;
+      readonly model: OpenRouterModelId;
+      readonly status: number;
+    } {
+  if (options.status === undefined) {
+    return {
+      code: options.code,
+      model: options.model,
+    };
+  }
+
+  return {
+    code: options.code,
+    model: options.model,
+    status: options.status,
+  };
+}
+
+function userFacingProviderFailureCaveat(options: {
+  readonly code: OpenRouterProviderFailureCode;
+  readonly model: OpenRouterModelId;
+  readonly status?: number;
+}): string {
+  switch (options.code) {
+    case "network-error":
+      return `OpenRouter reviewer output is unavailable because the network request to OpenRouter could not be completed for ${options.model}. Retry the request; if it persists, choose another structured-output-capable model or check provider connectivity.`;
+    case "provider-error":
+      return providerStatusCaveat(options.model, options.status);
+    case "invalid-response":
+      return `OpenRouter reviewer output is unavailable because OpenRouter returned an unexpected response shape for ${options.model}. Retry the request or choose another structured-output-capable model.`;
+    case "empty-response":
+      return `OpenRouter reviewer output is unavailable because OpenRouter returned no usable message content for ${options.model}. Retry the request or choose another structured-output-capable model.`;
+    case "missing-api-key":
+      return "OpenRouter reviewer output is unavailable because OPENROUTER_API_KEY is not configured for this request.";
+  }
+}
+
+function providerStatusCaveat(
+  model: OpenRouterModelId,
+  status: number | undefined,
+): string {
+  if (status === 401 || status === 403) {
+    return `OpenRouter reviewer output is unavailable because OpenRouter returned status ${status} for ${model}. Check the API key and account access, then retry.`;
+  }
+
+  if (status === 400 || status === 404) {
+    return `OpenRouter reviewer output is unavailable because OpenRouter returned status ${status} for ${model}. Check that the selected model id is available and supports structured JSON output.`;
+  }
+
+  if (status === 402) {
+    return `OpenRouter reviewer output is unavailable because OpenRouter returned status 402 for ${model}. Check account credits or choose an available free structured-output-capable model.`;
+  }
+
+  if (status === 429) {
+    return `OpenRouter reviewer output is unavailable because OpenRouter returned status 429 for ${model}. The selected model or account may be rate limited; retry later or choose another structured-output-capable model.`;
+  }
+
+  return status === undefined
+    ? `OpenRouter reviewer output is unavailable because the provider request failed for ${model}. Retry the request or choose another structured-output-capable model.`
+    : `OpenRouter reviewer output is unavailable because OpenRouter returned status ${status} for ${model}. Retry the request or choose another structured-output-capable model.`;
 }

--- a/src/infrastructure/reviewer/openrouter-reviewer-fallback.ts
+++ b/src/infrastructure/reviewer/openrouter-reviewer-fallback.ts
@@ -81,7 +81,7 @@ function fallbackCaveat(
   return {
     id: fallbackCaveatId,
     summary: providerFailure
-      ? "OpenRouter reviewer enrichment failed for the selected model, so the report falls back to deterministic static analysis. Try openai/gpt-4.1-mini or another structured-output-capable model."
+      ? `OpenRouter reviewer enrichment failed for ${modelLabel(malformedResponse)}, so the report falls back to deterministic static analysis. Try openai/gpt-4.1-mini or another structured-output-capable model.`
       : "OpenRouter reviewer output could not be parsed or validated, so the report falls back to deterministic static analysis while preserving validation details.",
     affectedDimensions: [...affectedDimensions],
     missingEvidence: providerFailure
@@ -123,4 +123,11 @@ function validationIssueMessages(
       malformedResponse.validationIssues.map((issue) => issue.message),
     ),
   ];
+}
+
+function modelLabel(malformedResponse: MalformedReviewerResponse): string {
+  return malformedResponse.reviewer.kind === "llm" &&
+    malformedResponse.reviewer.modelName !== undefined
+    ? malformedResponse.reviewer.modelName
+    : "the selected model";
 }

--- a/src/infrastructure/reviewer/openrouter-reviewer.ts
+++ b/src/infrastructure/reviewer/openrouter-reviewer.ts
@@ -7,6 +7,7 @@ import type {
   ReviewerResponseValidationIssue,
   ReviewerResult,
 } from "../../domain/reviewer/reviewer";
+import type { EvidenceReference } from "../../domain/shared/evidence-reference";
 import {
   renderReviewerPrompt,
   type ReviewerPromptInput,
@@ -18,6 +19,7 @@ import {
 import type { OpenRouterProviderConfig } from "../llm/openrouter-config";
 
 export const OpenRouterReviewerVersion = "openrouter-reviewer.v1";
+const DefaultReviewerMaxOutputTokens = 6_000;
 
 export type OpenRouterReviewerControls = OpenRouterChatCompletionControls & {
   readonly maxEvidenceSummaryCharacters?: number;
@@ -90,7 +92,10 @@ export class OpenRouterReviewer implements Reviewer {
     }
 
     const parsedAssessment = ReviewerAssessmentSchema.safeParse(
-      parsedJson.value,
+      normalizeReviewerAssessmentInput(
+        parsedJson.value,
+        request.evidenceReferences,
+      ),
     );
 
     if (!parsedAssessment.success) {
@@ -158,20 +163,256 @@ function promptInput(
 }
 
 function parseJson(content: string): JsonParseResult {
-  for (const candidate of jsonCandidates(content)) {
+  const candidates = [...jsonCandidates(content)];
+  const seenCandidates = new Set(candidates);
+  let lastParsedValue: unknown;
+
+  for (let index = 0; index < candidates.length; index += 1) {
+    const candidate = candidates[index];
+
+    if (candidate === undefined) {
+      continue;
+    }
+
     try {
+      const value = normalizeParsedJsonValue(JSON.parse(candidate));
+      lastParsedValue = value;
+
+      if (typeof value === "string") {
+        for (const nestedCandidate of jsonCandidates(value)) {
+          if (!seenCandidates.has(nestedCandidate)) {
+            seenCandidates.add(nestedCandidate);
+            candidates.push(nestedCandidate);
+          }
+        }
+        continue;
+      }
+
       return {
         success: true,
-        value: JSON.parse(candidate),
+        value,
       };
     } catch {
       continue;
     }
   }
 
+  if (lastParsedValue !== undefined) {
+    return {
+      success: true,
+      value: lastParsedValue,
+    };
+  }
+
   return {
     success: false,
   };
+}
+
+function normalizeParsedJsonValue(value: unknown): unknown {
+  return Array.isArray(value) && value.length === 1 ? value[0] : value;
+}
+
+function normalizeReviewerAssessmentInput(
+  value: unknown,
+  evidenceReferences: readonly EvidenceReference[],
+): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return {
+    ...value,
+    assessedArchetype: normalizeAssessedArchetypeRecord(
+      value.assessedArchetype,
+      evidenceReferences,
+    ),
+    dimensions: normalizeEvidenceReferencesRecords(
+      value.dimensions,
+      evidenceReferences,
+    ),
+    caveats: normalizeEvidenceReferencesRecords(
+      value.caveats,
+      evidenceReferences,
+    ),
+  };
+}
+
+function normalizeAssessedArchetypeRecord(
+  value: unknown,
+  evidenceReferences: readonly EvidenceReference[],
+): unknown {
+  const normalizedValue = normalizeEvidenceReferencesRecord(
+    value,
+    evidenceReferences,
+  );
+
+  if (!isRecord(normalizedValue)) {
+    return normalizedValue;
+  }
+
+  return {
+    ...normalizedValue,
+    rationale:
+      typeof normalizedValue.rationale === "string" &&
+      normalizedValue.rationale.trim() !== ""
+        ? normalizedValue.rationale
+        : "Reviewer did not provide an archetype rationale; treat the archetype assessment as lower assurance.",
+  };
+}
+
+function normalizeEvidenceReferencesRecords(
+  value: unknown,
+  evidenceReferences: readonly EvidenceReference[],
+): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  return value.map((item) =>
+    normalizeEvidenceReferencesRecord(item, evidenceReferences),
+  );
+}
+
+function normalizeEvidenceReferencesRecord(
+  value: unknown,
+  evidenceReferences: readonly EvidenceReference[],
+): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return {
+    ...value,
+    confidence: normalizeConfidence(value.confidence),
+    evidenceReferences: normalizeEvidenceReferences(
+      value.evidenceReferences,
+      evidenceReferences,
+    ),
+  };
+}
+
+function normalizeConfidence(value: unknown): unknown {
+  if (!isRecord(value) || typeof value.rationale === "string") {
+    return value;
+  }
+
+  return {
+    ...value,
+    rationale:
+      "Reviewer did not provide a confidence rationale; treat this confidence as lower assurance.",
+  };
+}
+
+function normalizeEvidenceReferences(
+  value: unknown,
+  evidenceReferences: readonly EvidenceReference[],
+): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  return value.map((item) =>
+    normalizeEvidenceReference(item, evidenceReferences),
+  );
+}
+
+function normalizeEvidenceReference(
+  value: unknown,
+  evidenceReferences: readonly EvidenceReference[],
+): unknown {
+  if (typeof value === "string") {
+    return evidenceReferenceForReviewerText(value, evidenceReferences);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const normalizedReference = { ...value };
+  removeInvalidOptionalTextProperty(normalizedReference, "path");
+  removeInvalidOptionalTextProperty(normalizedReference, "notes");
+  removeInvalidOptionalLineProperty(normalizedReference, "lineStart");
+  removeInvalidOptionalLineProperty(normalizedReference, "lineEnd");
+  removeInvertedOptionalLineEnd(normalizedReference);
+  return normalizedReference;
+}
+
+function removeInvalidOptionalTextProperty(
+  record: Record<string, unknown>,
+  key: "notes" | "path",
+): void {
+  if (record[key] === undefined) {
+    return;
+  }
+
+  if (typeof record[key] !== "string" || record[key].trim() === "") {
+    delete record[key];
+  }
+}
+
+function removeInvalidOptionalLineProperty(
+  record: Record<string, unknown>,
+  key: "lineEnd" | "lineStart",
+): void {
+  if (record[key] === undefined) {
+    return;
+  }
+
+  if (
+    typeof record[key] !== "number" ||
+    !Number.isInteger(record[key]) ||
+    record[key] <= 0
+  ) {
+    delete record[key];
+  }
+}
+
+function removeInvertedOptionalLineEnd(record: Record<string, unknown>): void {
+  if (
+    typeof record.lineStart === "number" &&
+    typeof record.lineEnd === "number" &&
+    record.lineEnd < record.lineStart
+  ) {
+    delete record.lineEnd;
+  }
+}
+
+function evidenceReferenceForReviewerText(
+  text: string,
+  evidenceReferences: readonly EvidenceReference[],
+): EvidenceReference {
+  const matchingReference = evidenceReferences.find(
+    (reference) =>
+      reference.id === text ||
+      reference.label === text ||
+      reference.path === text,
+  );
+
+  if (matchingReference !== undefined) {
+    return matchingReference;
+  }
+
+  return {
+    id: `reviewer:${stableReferenceId(text)}`,
+    kind: "reviewer",
+    label: text,
+  };
+}
+
+function stableReferenceId(text: string): string {
+  const normalized = text
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+  return normalized === "" ? "reference" : normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function jsonCandidates(content: string): readonly string[] {
@@ -272,41 +513,20 @@ function malformedResponse(options: {
 
 function chatControlsProperty(
   controls: OpenRouterReviewerControls | undefined,
-):
-  | { readonly controls: OpenRouterChatCompletionControls }
-  | Record<string, never> {
-  const chatCompletionControls = chatControls(controls);
-
-  if (chatCompletionControls === undefined) {
-    return {};
-  }
-
+): { readonly controls: OpenRouterChatCompletionControls } {
   return {
-    controls: chatCompletionControls,
+    controls: chatControls(controls),
   };
 }
 
 function chatControls(
   controls: OpenRouterReviewerControls | undefined,
-): OpenRouterChatCompletionControls | undefined {
-  if (controls === undefined) {
-    return undefined;
-  }
-
-  if (
-    controls.maxOutputTokens === undefined &&
-    controls.temperature === undefined
-  ) {
-    return undefined;
-  }
-
+): OpenRouterChatCompletionControls {
   return {
-    ...(controls.maxOutputTokens === undefined
-      ? {}
-      : { maxOutputTokens: controls.maxOutputTokens }),
-    ...(controls.temperature === undefined
-      ? {}
-      : { temperature: controls.temperature }),
+    maxOutputTokens:
+      controls?.maxOutputTokens ?? DefaultReviewerMaxOutputTokens,
+    responseFormat: controls?.responseFormat ?? "json_object",
+    temperature: controls?.temperature ?? 0,
   };
 }
 

--- a/src/infrastructure/reviewer/openrouter-reviewer.ts
+++ b/src/infrastructure/reviewer/openrouter-reviewer.ts
@@ -19,7 +19,7 @@ import {
 import type { OpenRouterProviderConfig } from "../llm/openrouter-config";
 
 export const OpenRouterReviewerVersion = "openrouter-reviewer.v1";
-const DefaultReviewerMaxOutputTokens = 6_000;
+const DefaultReviewerMaxOutputTokens = 10_000;
 
 export type OpenRouterReviewerControls = OpenRouterChatCompletionControls & {
   readonly maxEvidenceSummaryCharacters?: number;

--- a/test/infrastructure/llm/openrouter-chat-provider.test.ts
+++ b/test/infrastructure/llm/openrouter-chat-provider.test.ts
@@ -47,6 +47,10 @@ describe("OpenRouterChatCompletionProvider", () => {
       "Bearer sk-or-v1-request-scoped",
     );
     expect(request?.headers.get("content-type")).toBe("application/json");
+    expect(request?.headers.get("HTTP-Referer")).toBe(
+      "https://repo-analyzer-green.vercel.app",
+    );
+    expect(request?.headers.get("X-Title")).toBe("Repo Analyzer Green");
     expect(await request?.json()).toEqual({
       model: OpenRouterDefaultModelId,
       messages: [{ role: "user", content: "Review this evidence." }],
@@ -78,6 +82,7 @@ describe("OpenRouterChatCompletionProvider", () => {
       messages: [{ role: "user", content: "Review this evidence." }],
       controls: {
         maxOutputTokens: 1_500,
+        responseFormat: "json_object",
         temperature: 0,
       },
     });
@@ -87,6 +92,7 @@ describe("OpenRouterChatCompletionProvider", () => {
       messages: [{ role: "user", content: "Review this evidence." }],
       metadata: { usageContext: "reviewer-assessment" },
       max_tokens: 1_500,
+      response_format: { type: "json_object" },
       temperature: 0,
     });
   });
@@ -144,7 +150,35 @@ describe("OpenRouterChatCompletionProvider", () => {
       code: "provider-error",
       status: 429,
       userFacingCaveat:
-        "OpenRouter reviewer output is unavailable because the provider request failed.",
+        "OpenRouter reviewer output is unavailable because OpenRouter returned status 429 for openrouter/free. The selected model or account may be rate limited; retry later or choose another structured-output-capable model.",
+    });
+  });
+
+  it("maps network failures to retryable redacted diagnostics", async () => {
+    const provider = new OpenRouterChatCompletionProvider({
+      fetcher: async () => {
+        throw new TypeError("fetch failed");
+      },
+    });
+
+    await expect(
+      provider.complete({
+        config: {
+          provider: "openrouter",
+          apiKey: "sk-or-v1-request-scoped",
+          model: OpenRouterDefaultModelId,
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+        metadata: { usageContext: "reviewer-assessment" },
+        messages: [{ role: "user", content: "Review this evidence." }],
+      }),
+    ).resolves.toEqual({
+      kind: "provider-failure",
+      provider: "openrouter",
+      model: OpenRouterDefaultModelId,
+      code: "network-error",
+      userFacingCaveat:
+        "OpenRouter reviewer output is unavailable because the network request to OpenRouter could not be completed for openrouter/free. Retry the request; if it persists, choose another structured-output-capable model or check provider connectivity.",
     });
   });
 

--- a/test/infrastructure/llm/openrouter-live-contract.test.ts
+++ b/test/infrastructure/llm/openrouter-live-contract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenRouterChatCompletionProvider } from "../../../src/infrastructure/llm/openrouter-chat-provider";
+
+const shouldRunLiveOpenRouter =
+  process.env.RUN_OPENROUTER_LIVE === "1" &&
+  process.env.OPENROUTER_API_KEY !== undefined &&
+  process.env.OPENROUTER_API_KEY.trim() !== "";
+
+const describeLiveOpenRouter = shouldRunLiveOpenRouter
+  ? describe
+  : describe.skip;
+
+describeLiveOpenRouter("OpenRouter live contract", () => {
+  it.each(["openai/gpt-4.1-mini", "openrouter/free"])(
+    "returns JSON object content from %s",
+    async (model) => {
+      const provider = new OpenRouterChatCompletionProvider();
+
+      const result = await provider.complete({
+        config: {
+          provider: "openrouter",
+          apiKey: requiredOpenRouterKey(),
+          model,
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+        metadata: {
+          usageContext: "reviewer-assessment",
+          repository: "github:lightstrikelabs/repo-analyzer-green",
+        },
+        messages: [
+          {
+            role: "system",
+            content: "Return JSON only.",
+          },
+          {
+            role: "user",
+            content: 'Return {"ok":true,"reason":"live-contract"} as JSON.',
+          },
+        ],
+        controls: {
+          maxOutputTokens: 1_000,
+          responseFormat: "json_object",
+          temperature: 0,
+        },
+      });
+
+      expect(result.kind).toBe("completed");
+      if (result.kind !== "completed") {
+        throw new Error(result.userFacingCaveat);
+      }
+      expect(normalizeLiveJson(JSON.parse(result.content))).toMatchObject({
+        ok: true,
+        reason: "live-contract",
+      });
+    },
+  );
+});
+
+function normalizeLiveJson(value: unknown): unknown {
+  return Array.isArray(value) && value.length === 1 ? value[0] : value;
+}
+
+function requiredOpenRouterKey(): string {
+  const apiKey = process.env.OPENROUTER_API_KEY?.trim();
+
+  if (apiKey === undefined || apiKey === "") {
+    throw new Error(
+      "OPENROUTER_API_KEY is required for live OpenRouter tests.",
+    );
+  }
+
+  return apiKey;
+}

--- a/test/infrastructure/reviewer/openrouter-reviewer.test.ts
+++ b/test/infrastructure/reviewer/openrouter-reviewer.test.ts
@@ -117,6 +117,7 @@ describe("OpenRouterReviewer", () => {
         repository: "local-fixture:minimal-node-library @ fixture",
       },
       max_tokens: 2_000,
+      response_format: { type: "json_object" },
       temperature: 0,
     });
     expect(body.messages).toHaveLength(2);
@@ -125,6 +126,42 @@ describe("OpenRouterReviewer", () => {
     expect(body.messages[1].content).toContain(
       "[Evidence summary truncated at 32 characters.]",
     );
+  });
+
+  it("requests structured JSON output with reviewer-safe defaults", async () => {
+    const requests: Parameters<OpenRouterReviewer["assess"]>[0][] = [];
+    const completionRequests: Parameters<
+      OpenRouterChatCompletionProvider["complete"]
+    >[0][] = [];
+    const reviewer = new OpenRouterReviewer({
+      chatProvider: {
+        complete: async (completionRequest) => {
+          completionRequests.push(completionRequest);
+          return {
+            kind: "completed",
+            provider: "openrouter",
+            model: OpenRouterDefaultModelId,
+            content: JSON.stringify(assessment),
+          };
+        },
+      },
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    requests.push(request);
+    await reviewer.assess(request);
+
+    expect(completionRequests[0]?.controls).toEqual({
+      maxOutputTokens: 6_000,
+      responseFormat: "json_object",
+      temperature: 0,
+    });
   });
 
   it("returns malformed-response when model content is not JSON", async () => {
@@ -184,6 +221,217 @@ describe("OpenRouterReviewer", () => {
     const result = await reviewer.assess(request);
 
     expect(result).toEqual({ kind: "assessment", assessment });
+  });
+
+  it("accepts reviewer JSON returned as a JSON-encoded string", async () => {
+    const reviewer = new OpenRouterReviewer({
+      chatProvider: completionProviderForContent(
+        JSON.stringify(JSON.stringify(assessment)),
+      ),
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result).toEqual({ kind: "assessment", assessment });
+  });
+
+  it("accepts reviewer JSON wrapped in a single-item array", async () => {
+    const reviewer = new OpenRouterReviewer({
+      chatProvider: completionProviderForContent(JSON.stringify([assessment])),
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result).toEqual({ kind: "assessment", assessment });
+  });
+
+  it("normalizes reviewer evidence reference strings against collected evidence", async () => {
+    const reviewer = new OpenRouterReviewer({
+      chatProvider: completionProviderForContent(
+        JSON.stringify({
+          ...assessment,
+          assessedArchetype: {
+            ...assessment.assessedArchetype,
+            evidenceReferences: ["evidence:package-json"],
+          },
+          dimensions: [
+            {
+              ...assessment.dimensions[0],
+              evidenceReferences: [
+                "test/add.spec.ts",
+                "Reviewer-only reference",
+              ],
+            },
+          ],
+          caveats: [
+            {
+              id: "caveat:reviewer-only",
+              summary: "Reviewer cited an unknown but useful reference.",
+              affectedDimensions: ["verifiability"],
+              missingEvidence: ["Additional test plan context"],
+              confidence: {
+                level: "medium",
+                score: 0.6,
+                rationale: "The reference came from reviewer output.",
+              },
+              evidenceReferences: ["Reviewer-only reference"],
+            },
+          ],
+        }),
+      ),
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result.kind).toBe("assessment");
+    if (result.kind !== "assessment") {
+      throw new Error("Expected reviewer assessment");
+    }
+    expect(result.assessment.assessedArchetype.evidenceReferences).toEqual([
+      packageManifestReference,
+    ]);
+    expect(result.assessment.dimensions[0]?.evidenceReferences).toEqual([
+      testFileReference,
+      {
+        id: "reviewer:reviewer-only-reference",
+        kind: "reviewer",
+        label: "Reviewer-only reference",
+      },
+    ]);
+    expect(result.assessment.caveats[0]?.evidenceReferences).toEqual([
+      {
+        id: "reviewer:reviewer-only-reference",
+        kind: "reviewer",
+        label: "Reviewer-only reference",
+      },
+    ]);
+  });
+
+  it("normalizes missing reviewer confidence rationales with a cautious default", async () => {
+    const reviewer = new OpenRouterReviewer({
+      chatProvider: completionProviderForContent(
+        JSON.stringify({
+          ...assessment,
+          assessedArchetype: {
+            ...assessment.assessedArchetype,
+            confidence: {
+              level: "high",
+              score: 0.91,
+            },
+          },
+          dimensions: [
+            {
+              ...assessment.dimensions[0],
+              confidence: {
+                level: "high",
+                score: 0.9,
+              },
+            },
+          ],
+        }),
+      ),
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result.kind).toBe("assessment");
+    if (result.kind !== "assessment") {
+      throw new Error("Expected reviewer assessment");
+    }
+    expect(result.assessment.assessedArchetype.confidence.rationale).toContain(
+      "did not provide",
+    );
+    expect(result.assessment.dimensions[0]?.confidence.rationale).toContain(
+      "did not provide",
+    );
+  });
+
+  it("normalizes loose reviewer evidence objects and missing archetype rationale", async () => {
+    const reviewer = new OpenRouterReviewer({
+      chatProvider: completionProviderForContent(
+        JSON.stringify({
+          ...assessment,
+          assessedArchetype: {
+            ...assessment.assessedArchetype,
+            rationale: undefined,
+            evidenceReferences: [
+              {
+                ...packageManifestReference,
+                notes: "",
+              },
+            ],
+          },
+          dimensions: [
+            {
+              ...assessment.dimensions[0],
+              evidenceReferences: [
+                {
+                  ...testFileReference,
+                  path: null,
+                  notes: "",
+                  lineStart: 0,
+                  lineEnd: 0,
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const result = await reviewer.assess(request);
+
+    expect(result.kind).toBe("assessment");
+    if (result.kind !== "assessment") {
+      throw new Error("Expected reviewer assessment");
+    }
+    expect(result.assessment.assessedArchetype.rationale).toContain(
+      "did not provide",
+    );
+    expect(
+      result.assessment.assessedArchetype.evidenceReferences[0]?.notes,
+    ).toBeUndefined();
+    expect(
+      result.assessment.dimensions[0]?.evidenceReferences[0]?.path,
+    ).toBeUndefined();
+    expect(
+      result.assessment.dimensions[0]?.evidenceReferences[0]?.lineStart,
+    ).toBeUndefined();
   });
 
   it("returns malformed-response when model JSON does not match the reviewer assessment schema", async () => {
@@ -249,7 +497,7 @@ describe("OpenRouterReviewer", () => {
         {
           path: [],
           message:
-            "OpenRouter reviewer output is unavailable because the provider request failed.",
+            "OpenRouter reviewer output is unavailable because OpenRouter returned status 429 for openrouter/free. The selected model or account may be rate limited; retry later or choose another structured-output-capable model.",
         },
       ],
     });

--- a/test/infrastructure/reviewer/openrouter-reviewer.test.ts
+++ b/test/infrastructure/reviewer/openrouter-reviewer.test.ts
@@ -158,7 +158,7 @@ describe("OpenRouterReviewer", () => {
     await reviewer.assess(request);
 
     expect(completionRequests[0]?.controls).toEqual({
-      maxOutputTokens: 6_000,
+      maxOutputTokens: 10_000,
       responseFormat: "json_object",
       temperature: 0,
     });


### PR DESCRIPTION
## Summary

- Requests JSON object output and stable app-identification headers from OpenRouter.
- Adds safer provider diagnostics for status/network/empty-response failures without raw provider bodies or credentials.
- Tightens the reviewer prompt so evidence references must be full objects, not string ids.
- Normalizes recoverable reviewer-output drift observed in live runs: JSON-encoded objects, single-item arrays, string evidence refs, empty/null optional evidence fields, invalid line metadata, and missing confidence/archetype rationales.
- Adds a skipped-by-default live OpenRouter contract test for local/manual verification.

Closes #134.

## Live Diagnostics

Using the request-scoped key from local shell only, without logging the secret:

- Direct OpenRouter contract passed for `openai/gpt-4.1-mini`.
- Direct OpenRouter contract passed for `openrouter/free` when output budget was high enough.
- Full local application-service analysis of `https://github.com/lightstrikelabs/repo-analyzer-red` returned LLM-backed reports for `openai/gpt-4.1-mini` and `openrouter/free` after normalization.
- Full local `/api/analyze` returned an LLM-backed six-dimension report for `openai/gpt-4.1-mini` with no fallback caveat.
- Full local `/api/analyze` showed `openrouter/free` remains provider-variable: sampled route attempts returned fallback due empty content or malformed metadata. The fallback now reports model-specific diagnostics and recommends `openai/gpt-4.1-mini`.

## Verification

- `pnpm vitest run src/domain/reviewer/reviewer-prompt.test.ts test/infrastructure/llm/openrouter-chat-provider.test.ts test/infrastructure/reviewer/openrouter-reviewer.test.ts test/infrastructure/llm/openrouter-live-contract.test.ts`
- `OPENROUTER_API_KEY=<redacted> RUN_OPENROUTER_LIVE=1 pnpm vitest run test/infrastructure/llm/openrouter-live-contract.test.ts`
- `npx -y node@24 $(command -v pnpm) check`
- `npx -y node@24 $(command -v pnpm) build`
- `npx -y node@24 $(command -v pnpm) test:e2e`
- Local `/api/analyze` integration with `openai/gpt-4.1-mini` returned reviewerKind `llm`, no fallback caveat, and six dimensions.
