### PR TITLE
feat(reviewer): default OpenRouter to GPT-5 Mini

### DIFF
--- a/docs/how-tos/openrouter-e2e.md
+++ b/docs/how-tos/openrouter-e2e.md
@@ -59,7 +59,8 @@ The test should pass the key only through environment variables or request-scope
 OpenRouter configuration is parsed at the provider boundary in `src/infrastructure/llm/openrouter-config.ts`.
 
 - `OPENROUTER_API_KEY` is request-scoped configuration. This slice does not store it.
-- Empty or missing model input defaults to `openrouter/free`.
+- Empty or missing model input defaults to `openai/gpt-5-mini`.
+- `openrouter/free` remains available as an explicit best-effort option, but it should not be treated as the reliability default.
 - Empty API key input is normalized to an unavailable provider configuration.
 - Provider request metadata stays in infrastructure and currently supports `reviewer-assessment` and `follow-up-answer` usage contexts.
 
@@ -73,14 +74,14 @@ The normal test suite must not depend on live model calls. To verify the OpenRou
 OPENROUTER_API_KEY="<local key>" RUN_OPENROUTER_LIVE=1 pnpm vitest run test/infrastructure/llm/openrouter-live-contract.test.ts
 ```
 
-This test uses `openai/gpt-4.1-mini`, requests JSON object output, and asserts that OpenRouter returns parseable JSON content. Do not commit keys, paste keys into issue bodies, or include raw provider responses in logs.
+This test uses the configured default `openai/gpt-5-mini` and the explicit `openrouter/free` option, requests JSON object output, and asserts that OpenRouter returns parseable JSON content. Do not commit keys, paste keys into issue bodies, or include raw provider responses in logs.
 
 ## Safety Rules
 
 - Keep the deterministic foundational E2E fake-backed.
 - Put live OpenRouter E2E in its own clearly named job.
 - Avoid running live-provider E2E on untrusted fork pull requests unless secrets are unavailable or the job is explicitly guarded.
-- Use a low-cost/free model default where possible.
+- Use a low-cost, structured-output-capable default where possible.
 - Fail with a clear missing-secret message if a live-provider job is manually requested without `OPENROUTER_API_KEY`.
 - Redact provider errors before showing them in user-facing UI or persisted artifacts.
 

--- a/src/app/api/analyze/route.test.ts
+++ b/src/app/api/analyze/route.test.ts
@@ -7,7 +7,10 @@ import type {
 } from "../../../application/analyze-repository/analyze-repository";
 import { buildAnalyzeRepositoryResponse } from "../../../application/analyze-repository/analyze-repository-response";
 import { RepositorySourceError } from "../../../domain/repository/repository-source";
-import { OpenRouterDefaultBaseUrl } from "../../../infrastructure/llm/openrouter-config";
+import {
+  OpenRouterDefaultBaseUrl,
+  OpenRouterDefaultModelId,
+} from "../../../infrastructure/llm/openrouter-config";
 import { handleAnalyzeRequest, type AnalyzeRouteOptions } from "./route";
 
 const validRequestBody = {
@@ -235,6 +238,28 @@ describe("POST /api/analyze", () => {
 
     expect(response.status).toBe(200);
     expect(receivedOptions).toEqual({});
+  });
+
+  it("defaults request-scoped reviewer config to GPT-5 Mini when no model is supplied", async () => {
+    let receivedOptions: AnalyzeRouteOptions | undefined;
+
+    const response = await handleAnalyzeRequest(
+      jsonRequest({
+        repoUrl: "https://github.com/lightstrikelabs/repo-analyzer-green",
+        apiKey: "sk-or-v1-test",
+      }),
+      {
+        analyze: async (_input, options) => {
+          receivedOptions = options;
+          return reportResult;
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(receivedOptions?.openRouterConfig).toMatchObject({
+      model: OpenRouterDefaultModelId,
+    });
   });
 
   it("rejects red-style requests that are not GitHub repository URLs", async () => {

--- a/src/components/report/analyze-repository-panel.test.tsx
+++ b/src/components/report/analyze-repository-panel.test.tsx
@@ -14,7 +14,10 @@ import userEvent from "@testing-library/user-event";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { OpenRouterDefaultModelId } from "../../infrastructure/llm/openrouter-config";
+import {
+  OpenRouterDefaultModelId,
+  OpenRouterFreeModelId,
+} from "../../infrastructure/llm/openrouter-config";
 import { BrowserLocalSessionStorageKey } from "../../infrastructure/persistence/browser-local-session-storage";
 import { analyzeRepositoryResponseFixture } from "../../../test/support/analyze-repository-response-fixture";
 
@@ -83,7 +86,17 @@ describe("AnalyzeRepositoryPanel", () => {
     expect(rawSession).not.toContain("sk-test");
   });
 
-  it("resets the advanced model field to the free router default", async () => {
+  it("defaults the advanced model field to GPT-5 Mini", async () => {
+    const user = userEvent.setup();
+
+    render(<AnalyzeRepositoryPanel />);
+
+    await user.click(screen.getByText("Advanced"));
+
+    expect(modelInputValue()).toBe(OpenRouterDefaultModelId);
+  });
+
+  it("offers GPT-5 Mini and free router model presets", async () => {
     const user = userEvent.setup();
 
     render(<AnalyzeRepositoryPanel />);
@@ -92,6 +105,10 @@ describe("AnalyzeRepositoryPanel", () => {
     await user.clear(screen.getByLabelText("OpenRouter Model"));
     await user.type(screen.getByLabelText("OpenRouter Model"), "custom/model");
     await user.click(screen.getByRole("button", { name: "Use Free Router" }));
+
+    expect(modelInputValue()).toBe(OpenRouterFreeModelId);
+
+    await user.click(screen.getByRole("button", { name: "Use GPT-5 Mini" }));
 
     expect(modelInputValue()).toBe(OpenRouterDefaultModelId);
   });

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -15,6 +15,7 @@ import {
 import { GitHubRepositoryUrlSchema } from "../../infrastructure/github/github-repository-url";
 import {
   OpenRouterDefaultModelId,
+  OpenRouterFreeModelId,
   OpenRouterModelIdSchema,
 } from "../../infrastructure/llm/openrouter-config";
 import {
@@ -291,7 +292,7 @@ export function AnalyzeRepositoryPanel() {
               <summary className="cursor-pointer text-sm font-semibold text-slate-800">
                 Advanced
               </summary>
-              <div className="mt-3 grid gap-3 rounded-md border border-slate-200 bg-slate-50 p-3 sm:grid-cols-[minmax(220px,420px)_auto]">
+              <div className="mt-3 grid gap-3 rounded-md border border-slate-200 bg-slate-50 p-3 sm:grid-cols-[minmax(220px,420px)_auto_auto]">
                 <Field label="OpenRouter Model">
                   <input
                     value={repositoryForm.selectedModel}
@@ -311,6 +312,19 @@ export function AnalyzeRepositoryPanel() {
                     updateRepositoryForm((current) => ({
                       ...current,
                       selectedModel: OpenRouterDefaultModelId,
+                    }))
+                  }
+                  disabled={status.kind === "loading"}
+                  className="h-10 self-end rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                >
+                  Use GPT-5 Mini
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    updateRepositoryForm((current) => ({
+                      ...current,
+                      selectedModel: OpenRouterFreeModelId,
                     }))
                   }
                   disabled={status.kind === "loading"}

--- a/src/infrastructure/llm/openrouter-config.ts
+++ b/src/infrastructure/llm/openrouter-config.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
-export const OpenRouterDefaultModelId = "openrouter/free";
+export const OpenRouterDefaultModelId = "openai/gpt-5-mini";
+export const OpenRouterFreeModelId = "openrouter/free";
+export const OpenRouterFallbackModelId = "openai/gpt-4.1-mini";
 export const OpenRouterDefaultBaseUrl = "https://openrouter.ai/api/v1";
 
 export const OpenRouterModelIdSchema = z.preprocess(

--- a/src/infrastructure/reviewer/openrouter-reviewer-fallback.ts
+++ b/src/infrastructure/reviewer/openrouter-reviewer-fallback.ts
@@ -9,6 +9,10 @@ import type {
   ReviewerAssessment,
   ReviewerCaveat,
 } from "../../domain/reviewer/reviewer-assessment";
+import {
+  OpenRouterDefaultModelId,
+  OpenRouterFallbackModelId,
+} from "../llm/openrouter-config";
 
 export type OpenRouterReviewerFallbackOptions = {
   readonly primary: Reviewer;
@@ -81,7 +85,7 @@ function fallbackCaveat(
   return {
     id: fallbackCaveatId,
     summary: providerFailure
-      ? `OpenRouter reviewer enrichment failed for ${modelLabel(malformedResponse)}, so the report falls back to deterministic static analysis. Try openai/gpt-4.1-mini or another structured-output-capable model.`
+      ? `OpenRouter reviewer enrichment failed for ${modelLabel(malformedResponse)}, so the report falls back to deterministic static analysis. Try ${suggestedModelLabel(malformedResponse)} or another structured-output-capable model.`
       : "OpenRouter reviewer output could not be parsed or validated, so the report falls back to deterministic static analysis while preserving validation details.",
     affectedDimensions: [...affectedDimensions],
     missingEvidence: providerFailure
@@ -130,4 +134,12 @@ function modelLabel(malformedResponse: MalformedReviewerResponse): string {
     malformedResponse.reviewer.modelName !== undefined
     ? malformedResponse.reviewer.modelName
     : "the selected model";
+}
+
+function suggestedModelLabel(
+  malformedResponse: MalformedReviewerResponse,
+): string {
+  return modelLabel(malformedResponse) === OpenRouterDefaultModelId
+    ? OpenRouterFallbackModelId
+    : OpenRouterDefaultModelId;
 }

--- a/test/infrastructure/llm/openrouter-chat-provider.test.ts
+++ b/test/infrastructure/llm/openrouter-chat-provider.test.ts
@@ -149,8 +149,7 @@ describe("OpenRouterChatCompletionProvider", () => {
       model: OpenRouterDefaultModelId,
       code: "provider-error",
       status: 429,
-      userFacingCaveat:
-        "OpenRouter reviewer output is unavailable because OpenRouter returned status 429 for openrouter/free. The selected model or account may be rate limited; retry later or choose another structured-output-capable model.",
+      userFacingCaveat: `OpenRouter reviewer output is unavailable because OpenRouter returned status 429 for ${OpenRouterDefaultModelId}. The selected model or account may be rate limited; retry later or choose another structured-output-capable model.`,
     });
   });
 
@@ -177,8 +176,7 @@ describe("OpenRouterChatCompletionProvider", () => {
       provider: "openrouter",
       model: OpenRouterDefaultModelId,
       code: "network-error",
-      userFacingCaveat:
-        "OpenRouter reviewer output is unavailable because the network request to OpenRouter could not be completed for openrouter/free. Retry the request; if it persists, choose another structured-output-capable model or check provider connectivity.",
+      userFacingCaveat: `OpenRouter reviewer output is unavailable because the network request to OpenRouter could not be completed for ${OpenRouterDefaultModelId}. Retry the request; if it persists, choose another structured-output-capable model or check provider connectivity.`,
     });
   });
 

--- a/test/infrastructure/llm/openrouter-config.test.ts
+++ b/test/infrastructure/llm/openrouter-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   OpenRouterDefaultModelId,
+  OpenRouterFreeModelId,
   OpenRouterModelIdSchema,
   OpenRouterProviderConfigSchema,
   OpenRouterRequestMetadataSchema,
@@ -9,12 +10,20 @@ import {
 } from "../../../src/infrastructure/llm/openrouter-config";
 
 describe("OpenRouter provider configuration", () => {
-  it("defaults empty model input to the documented free model", () => {
+  it("defaults empty model input to GPT-5 Mini", () => {
+    expect(OpenRouterDefaultModelId).toBe("openai/gpt-5-mini");
     expect(OpenRouterModelIdSchema.parse(undefined)).toBe(
       OpenRouterDefaultModelId,
     );
     expect(OpenRouterModelIdSchema.parse("")).toBe(OpenRouterDefaultModelId);
     expect(OpenRouterModelIdSchema.parse("   ")).toBe(OpenRouterDefaultModelId);
+  });
+
+  it("keeps the free router model available as an explicit option", () => {
+    expect(OpenRouterFreeModelId).toBe("openrouter/free");
+    expect(OpenRouterModelIdSchema.parse(OpenRouterFreeModelId)).toBe(
+      OpenRouterFreeModelId,
+    );
   });
 
   it("trims provided model ids and rejects whitespace inside ids", () => {

--- a/test/infrastructure/llm/openrouter-live-contract.test.ts
+++ b/test/infrastructure/llm/openrouter-live-contract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  OpenRouterDefaultModelId,
+  OpenRouterFreeModelId,
+} from "../../../src/infrastructure/llm/openrouter-config";
 import { OpenRouterChatCompletionProvider } from "../../../src/infrastructure/llm/openrouter-chat-provider";
 
 const shouldRunLiveOpenRouter =
@@ -12,7 +16,7 @@ const describeLiveOpenRouter = shouldRunLiveOpenRouter
   : describe.skip;
 
 describeLiveOpenRouter("OpenRouter live contract", () => {
-  it.each(["openai/gpt-4.1-mini", "openrouter/free"])(
+  it.each([OpenRouterDefaultModelId, OpenRouterFreeModelId])(
     "returns JSON object content from %s",
     async (model) => {
       const provider = new OpenRouterChatCompletionProvider();

--- a/test/infrastructure/persistence/browser-analysis-session-storage.test.ts
+++ b/test/infrastructure/persistence/browser-analysis-session-storage.test.ts
@@ -98,7 +98,7 @@ describe("browser-analysis-session-storage", () => {
     expect(loadBrowserLocalSession(storage)).toBeNull();
   });
 
-  it("defaults to an empty repo URL and the free router model", () => {
+  it("defaults to an empty repo URL and GPT-5 Mini", () => {
     expect(defaultBrowserRepositoryForm()).toEqual({
       repoUrl: "",
       selectedModel: OpenRouterDefaultModelId,

--- a/test/infrastructure/reviewer/openrouter-reviewer-fallback.test.ts
+++ b/test/infrastructure/reviewer/openrouter-reviewer-fallback.test.ts
@@ -11,6 +11,11 @@ import {
   ReviewerAssessmentSchemaVersion,
   type ReviewerAssessment,
 } from "../../../src/domain/reviewer/reviewer-assessment";
+import {
+  OpenRouterDefaultModelId,
+  OpenRouterFallbackModelId,
+  OpenRouterFreeModelId,
+} from "../../../src/infrastructure/llm/openrouter-config";
 import { OpenRouterReviewerFallback } from "../../../src/infrastructure/reviewer/openrouter-reviewer-fallback";
 
 const evidenceReference = {
@@ -86,7 +91,7 @@ const openRouterMetadata: ReviewerMetadata = {
   name: "OpenRouter reviewer",
   reviewerVersion: "openrouter-reviewer.v1",
   modelProvider: "openrouter",
-  modelName: "openrouter/free",
+  modelName: OpenRouterFreeModelId,
   reviewedAt: "2026-04-26T12:01:00-07:00",
 };
 
@@ -139,10 +144,39 @@ describe("OpenRouterReviewerFallback", () => {
     expect(result.assessment.caveats).toContainEqual(
       expect.objectContaining({
         id: "caveat:openrouter-reviewer-fallback",
-        summary: expect.stringContaining("openai/gpt-4.1-mini"),
+        summary: expect.stringContaining(OpenRouterDefaultModelId),
         missingEvidence: expect.arrayContaining([
           "Successful reviewer response from the selected OpenRouter model",
         ]),
+      }),
+    );
+  });
+
+  it("suggests the fallback model when the default model cannot complete", async () => {
+    const primary = new StubReviewer(
+      malformedOpenRouterResult({
+        rawResponse: "",
+        message:
+          "OpenRouter reviewer output is unavailable because the provider request could not be completed.",
+        modelName: OpenRouterDefaultModelId,
+      }),
+    );
+    const fallback = new StubReviewer({
+      kind: "assessment",
+      assessment: fallbackAssessment,
+    });
+    const reviewer = new OpenRouterReviewerFallback({ primary, fallback });
+
+    const result = await reviewer.assess(request);
+
+    expect(result.kind).toBe("assessment");
+    if (result.kind !== "assessment") {
+      throw new Error("Expected fallback reviewer assessment");
+    }
+    expect(result.assessment.caveats).toContainEqual(
+      expect.objectContaining({
+        id: "caveat:openrouter-reviewer-fallback",
+        summary: expect.stringContaining(OpenRouterFallbackModelId),
       }),
     );
   });
@@ -192,10 +226,17 @@ class StubReviewer implements Reviewer {
 function malformedOpenRouterResult(options: {
   readonly rawResponse: string;
   readonly message: string;
+  readonly modelName?: string;
 }): MalformedReviewerResponse {
   return {
     kind: "malformed-response",
-    reviewer: openRouterMetadata,
+    reviewer:
+      options.modelName === undefined
+        ? openRouterMetadata
+        : {
+            ...openRouterMetadata,
+            modelName: options.modelName,
+          },
     rawResponse: options.rawResponse,
     validationIssues: [
       {

--- a/test/infrastructure/reviewer/openrouter-reviewer.test.ts
+++ b/test/infrastructure/reviewer/openrouter-reviewer.test.ts
@@ -496,8 +496,7 @@ describe("OpenRouterReviewer", () => {
       validationIssues: [
         {
           path: [],
-          message:
-            "OpenRouter reviewer output is unavailable because OpenRouter returned status 429 for openrouter/free. The selected model or account may be rate limited; retry later or choose another structured-output-capable model.",
+          message: `OpenRouter reviewer output is unavailable because OpenRouter returned status 429 for ${OpenRouterDefaultModelId}. The selected model or account may be rate limited; retry later or choose another structured-output-capable model.`,
         },
       ],
     });


### PR DESCRIPTION
## Summary

- Defaults OpenRouter reviewer configuration to `openai/gpt-5-mini`.
- Keeps `openrouter/free` as an explicit Advanced-form preset and live contract-test option.
- Updates fallback guidance and OpenRouter E2E docs for the new reliability default.

Closes #136

## Testing

- `npx -y node@24 $(command -v pnpm) check`
- `npx -y node@24 $(command -v pnpm) build`
- `npx -y node@24 $(command -v pnpm) test:e2e`
- OpenRouter public model catalog check for `openai/gpt-5-mini` and `openrouter/free`

## Notes

No API keys are stored or documented. The live OpenRouter contract test remains opt-in through request-scoped environment variables.