### PR TITLE
feat(ui): render red-style report dashboard

### DIFF
--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -21,12 +21,27 @@ test("runs the repository analysis workflow", async ({ page }) => {
   await expect(
     page.getByText("local-fixture:minimal-node-library @ fixture"),
   ).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Dimensions" })).toBeVisible();
+  await expect(page.getByText("Overall Score", { exact: true })).toBeVisible();
+  await expect(page.getByText("Source Files", { exact: true })).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Caveats And Missing Evidence" }),
+    page.getByRole("heading", { name: "Language Mix" }),
+  ).toBeVisible();
+  const testingPanel = page.locator("article").filter({
+    has: page.getByRole("heading", { name: "Testing" }),
+  });
+  await expect(
+    testingPanel.getByText("Signals", { exact: true }),
   ).toBeVisible();
   await expect(
-    page.getByLabel("Dimensions").getByText("evidence:test-file").first(),
+    testingPanel.getByText("Next Checks", { exact: true }),
+  ).toBeVisible();
+
+  await page
+    .getByText("Evidence, Caveats, And Suggested Follow-Ups", { exact: true })
+    .click();
+  await expect(page.getByText("No caveats were reported.")).toBeVisible();
+  await expect(
+    page.getByText("Package manifest", { exact: true }),
   ).toBeVisible();
 
   await page.reload();

--- a/e2e/red-ui-parity.spec.ts
+++ b/e2e/red-ui-parity.spec.ts
@@ -43,11 +43,15 @@ test.describe("red UI/UX parity", () => {
       .fill("https://github.com/lightstrikelabs/repo-analyzer-green");
     await page.getByRole("button", { name: "Analyze" }).click();
 
-    await expect(page.getByText("Reviewer Notes")).toBeVisible();
-    await expect(page.getByText("Overall Score")).toBeVisible();
-    await expect(page.getByText("Source Files")).toBeVisible();
-    await expect(page.getByText("Code Lines")).toBeVisible();
-    await expect(page.getByText("Test Ratio")).toBeVisible();
+    await expect(
+      page.getByText("Reviewer Notes", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Overall Score", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Source Files", { exact: true })).toBeVisible();
+    await expect(page.getByText("Code Lines", { exact: true })).toBeVisible();
+    await expect(page.getByText("Test Ratio", { exact: true })).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Language Mix" }),
     ).toBeVisible();
@@ -66,10 +70,14 @@ test.describe("red UI/UX parity", () => {
       "Architecture",
       "Documentation",
     ]) {
-      const panel = page.locator("article").filter({ hasText: section });
+      const panel = page.locator("article").filter({
+        has: page.getByRole("heading", { name: section }),
+      });
       await expect(panel.getByRole("heading", { name: section })).toBeVisible();
-      await expect(panel.getByText("Signals")).toBeVisible();
-      await expect(panel.getByText("Next Checks")).toBeVisible();
+      await expect(panel.getByText("Signals", { exact: true })).toBeVisible();
+      await expect(
+        panel.getByText("Next Checks", { exact: true }),
+      ).toBeVisible();
       await expect(panel.getByLabel(`Ask About ${section}`)).toBeVisible();
       await expect(
         panel.getByRole("button", { name: "Open Chat" }),

--- a/src/components/report/report-card-view.test.tsx
+++ b/src/components/report/report-card-view.test.tsx
@@ -139,26 +139,34 @@ const analysis: AnalyzeRepositoryResponse = {
 };
 
 describe("ReportCardView", () => {
-  it("renders dashboard summary, language mix, dimensions, findings, caveats, missing evidence, and evidence references", () => {
+  it("renders the red-style dashboard overview, big numbers, language mix, notes, and sections", () => {
     const html = renderToStaticMarkup(<ReportCardView analysis={analysis} />);
 
     expect(html).toContain("minimal-node-library");
-    expect(html).toContain("library");
-    expect(html).toContain("Report overview");
+    expect(html).toContain("Overall Score");
+    expect(html).toContain("Source Files");
+    expect(html).toContain("Code Lines");
+    expect(html).toContain("Test Ratio");
+    expect(html).toContain("Strongest Area");
     expect(html).toContain("Language Mix");
     expect(html).toContain("TypeScript");
-    expect(html).toContain("80% of code");
+    expect(html).toContain("80%");
     expect(html).toContain("Reviewer Notes");
-    expect(html).toContain("Dimensions");
-    expect(html).toContain("Verifiability");
-    expect(html).toContain("good");
+    expect(html).toContain("Maintainability");
+    expect(html).toContain("Testing");
+    expect(html).toContain("Security");
+    expect(html).toContain("Architecture");
+    expect(html).toContain("Documentation");
+    expect(html).toContain("Good");
     expect(html).toContain("high confidence");
-    expect(html).toContain("Dimension score");
+    expect(html).toContain("Score");
+    expect(html).toContain("Signals");
+    expect(html).toContain("Next Checks");
     expect(html).toContain("Test depth");
     expect(html).toContain("Limited fixture evidence");
     expect(html).toContain("Release workflow history");
-    expect(html).toContain("evidence:test-file");
-    expect(html).toContain("How is this package released and verified?");
+    expect(html).toContain("Ask About Testing");
+    expect(html).toContain("Open Chat");
   });
 
   it("renders a Download PDF button so users can export the report", () => {
@@ -193,13 +201,6 @@ describe("ReportCardView", () => {
     );
   });
 
-  it("does not collapse the report into a single overall score", () => {
-    const html = renderToStaticMarkup(<ReportCardView analysis={analysis} />);
-
-    expect(html).not.toContain("Overall score");
-    expect(html).not.toContain("Total score");
-  });
-
   it("renders explicit empty states when language mix and caveats are absent", () => {
     const html = renderToStaticMarkup(
       <ReportCardView
@@ -208,6 +209,12 @@ describe("ReportCardView", () => {
           reportCard: {
             ...reportCard,
             caveats: [],
+            dimensionAssessments: reportCard.dimensionAssessments.map(
+              (assessment) => ({
+                ...assessment,
+                findings: [],
+              }),
+            ),
           },
           dashboardInsights: {
             ...analysis.dashboardInsights,
@@ -220,6 +227,32 @@ describe("ReportCardView", () => {
     expect(html).toContain(
       "No language mix was available in the collected evidence.",
     );
-    expect(html).toContain("No caveats were reported.");
+    expect(html).toContain("No reviewer notes were available.");
+  });
+
+  it("renders missing-score sections without pretending evidence exists", () => {
+    const html = renderToStaticMarkup(
+      <ReportCardView
+        analysis={{
+          ...analysis,
+          reportCard: {
+            ...reportCard,
+            dimensionAssessments: reportCard.dimensionAssessments.map(
+              (assessment) => ({
+                ...assessment,
+                score: undefined,
+                rating: "not-assessed",
+              }),
+            ),
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("N/A");
+    expect(html).toContain("Not assessed");
+    expect(html).toContain(
+      "Security evidence was not available in this report.",
+    );
   });
 });

--- a/src/components/report/report-card-view.tsx
+++ b/src/components/report/report-card-view.tsx
@@ -1,191 +1,433 @@
+import { buildReportDashboardViewModel } from "../../application/report-dashboard/report-dashboard-view-model";
 import type {
-  DimensionAssessment,
-  ReportCard,
-  ReportCaveat,
-  ReportFinding,
-  ReportRating,
-} from "../../domain/report/report-card";
-import type { EvidenceReference } from "../../domain/shared/evidence-reference";
-import type {
-  AnalyzeRepositoryResponse,
-  DashboardLanguageMixItem,
-} from "../../application/analyze-repository/analyze-repository-response";
+  ReportDashboardBigNumber,
+  ReportDashboardLanguageSlice,
+  ReportDashboardReviewerNote,
+  ReportDashboardSection,
+} from "../../application/report-dashboard/report-dashboard-view-model";
+import type { AnalyzeRepositoryResponse } from "../../application/analyze-repository/analyze-repository-response";
 import { FollowUpPanel } from "../chat/follow-up-panel";
 import { PrintReportButton } from "./print-report-button";
+import { ScoreRing } from "./score-ring";
+import { Sparkline } from "./sparkline";
 
 export function ReportCardView({
   analysis,
 }: {
   readonly analysis: AnalyzeRepositoryResponse;
 }) {
-  const reportCard = analysis.reportCard;
-  const findings = reportCard.dimensionAssessments.flatMap(
-    (assessment) => assessment.findings,
-  );
-  const strongestDimension = strongestAssessedDimension(
-    reportCard.dimensionAssessments,
-  );
-  const bigNumbers = [
-    {
-      label: "Dimensions",
-      value: String(reportCard.dimensionAssessments.length),
-      caption: "Assessed with reviewer confidence",
-    },
-    {
-      label: "Findings",
-      value: String(findings.length),
-      caption: "Linked to evidence references",
-    },
-    {
-      label: "Evidence",
-      value: String(reportCard.evidenceReferences.length),
-      caption: "References preserved for follow-up",
-    },
-    {
-      label: "Caveats",
-      value: String(reportCard.caveats.length),
-      caption: "Missing context stays visible",
-    },
-  ] as const;
+  const dashboard = buildReportDashboardViewModel(analysis);
+  const strongestArea = dashboard.sections
+    .filter((section) => section.score !== undefined)
+    .toSorted((left, right) => (right.score ?? 0) - (left.score ?? 0))[0];
 
   return (
-    <article className="space-y-6" aria-labelledby="report-title">
-      <header className="border-b border-slate-200 pb-5">
-        <p className="text-sm font-medium text-slate-600">
-          {repositoryLabel(reportCard)}
-        </p>
-        <div className="mt-2 flex flex-wrap items-end justify-between gap-3">
-          <div>
-            <h2
-              id="report-title"
-              className="text-2xl font-semibold text-slate-950"
-            >
-              Evidence-backed report
-            </h2>
-            <p className="mt-2 text-sm text-slate-700">
-              Archetype:{" "}
-              <span className="font-medium text-slate-950">
-                {reportCard.assessedArchetype}
-              </span>
-            </p>
-          </div>
-          <p className="text-sm text-slate-600">
-            Reviewer: {reportCard.reviewerMetadata.name}
+    <article className="space-y-5" aria-labelledby="report-title">
+      <header className="flex flex-wrap items-start justify-between gap-4 print:hidden">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700">
+            Repository Quality
           </p>
+          <h2
+            id="report-title"
+            className="mt-1 text-3xl font-semibold text-slate-950"
+          >
+            Report Card
+          </h2>
         </div>
         <PrintReportButton />
       </header>
 
       <section
         aria-labelledby="overview-title"
-        className="grid gap-4 lg:grid-cols-[minmax(260px,0.9fr)_minmax(0,1.1fr)]"
+        className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto]"
       >
         <div className="rounded-md border border-slate-200 bg-white p-5">
-          <p className="text-sm font-medium uppercase text-emerald-700">
-            Report overview
-          </p>
-          <h3
-            id="overview-title"
-            className="mt-2 text-xl font-semibold text-slate-950"
-          >
-            {reportCard.assessedArchetype} quality assessment
-          </h3>
-          <p className="mt-4 text-sm leading-6 text-slate-700">
-            {analysis.dashboardInsights.evidenceSummary}
-          </p>
-          <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
+          <div className="flex flex-wrap items-start justify-between gap-5">
+            <div className="min-w-0">
+              <p className="break-words text-sm font-medium text-slate-600">
+                {dashboard.overview.repositoryLabel}
+              </p>
+              <h3
+                id="overview-title"
+                className="mt-2 text-2xl font-semibold text-slate-950"
+              >
+                Evidence-backed report
+              </h3>
+              <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-700">
+                {dashboard.overview.summary}
+              </p>
+            </div>
+            <ScoreRing
+              score={dashboard.overview.overallScore}
+              grade={dashboard.overview.grade}
+            />
+          </div>
+
+          <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
             <MetadataItem
-              label="Generated"
-              value={formatDateTime(reportCard.generatedAt)}
+              label="Analyzed"
+              value={formatDateTime(dashboard.overview.analyzedAt)}
             />
             <MetadataItem
-              label="Scoring policy"
-              value={`${reportCard.scoringPolicy.name} ${reportCard.scoringPolicy.version}`}
+              label="Strongest Area"
+              value={strongestArea?.title ?? "Not assessed"}
             />
-            <MetadataItem
-              label="Reviewer kind"
-              value={reportCard.reviewerMetadata.kind}
-            />
-            <MetadataItem
-              label="Strongest dimension"
-              value={strongestDimension?.title ?? "Not scored"}
-            />
+            <MetadataItem label="Grade" value={dashboard.overview.grade} />
           </dl>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          {bigNumbers.map((item) => (
-            <div
-              key={item.label}
-              className="rounded-md border border-slate-200 bg-white p-4"
-            >
-              <p className="text-sm font-medium text-slate-600">{item.label}</p>
-              <p className="mt-2 text-3xl font-semibold text-slate-950">
-                {item.value}
-              </p>
-              <p className="mt-1 text-sm leading-5 text-slate-600">
-                {item.caption}
+        <div className="rounded-md border border-slate-200 bg-white p-5 lg:w-72">
+          <p className="text-sm font-semibold text-slate-950">Reviewer Notes</p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {dashboard.overview.reviewerNote}
+          </p>
+        </div>
+      </section>
+
+      <section
+        aria-label="Report metrics"
+        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"
+      >
+        {dashboard.bigNumbers.map((bigNumber) => (
+          <BigNumberTile key={bigNumber.id} bigNumber={bigNumber} />
+        ))}
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <LanguageMixPanel
+          languageSlices={dashboard.languageSlices}
+          emptyMessage={dashboard.emptyLanguageMessage}
+        />
+        <ReviewerNotesPanel notes={dashboard.reviewerNotes} />
+      </section>
+
+      <section aria-labelledby="sections-title" className="space-y-3">
+        <h3 id="sections-title" className="sr-only">
+          Report Sections
+        </h3>
+        {dashboard.sections.map((section) => (
+          <ReportSectionPanel key={section.id} section={section} />
+        ))}
+      </section>
+
+      <details className="rounded-md border border-slate-200 bg-white p-4">
+        <summary className="cursor-pointer text-sm font-semibold text-slate-900">
+          Evidence, Caveats, And Suggested Follow-Ups
+        </summary>
+        <div className="mt-4 grid gap-4 lg:grid-cols-3">
+          <DetailList
+            title="Caveats"
+            emptyMessage="No caveats were reported."
+            items={analysis.reportCard.caveats.map((caveat) => ({
+              title: caveat.title,
+              detail: caveat.summary,
+              meta: caveat.missingEvidence.join(", "),
+            }))}
+          />
+          <DetailList
+            title="Evidence References"
+            emptyMessage="No evidence references were preserved."
+            items={analysis.reportCard.evidenceReferences.map((reference) => ({
+              title: reference.label,
+              detail: reference.path ?? reference.id,
+              meta: reference.id,
+            }))}
+          />
+          <DetailList
+            title="Suggested Follow-Ups"
+            emptyMessage="No follow-up questions were recommended."
+            items={analysis.reportCard.recommendedNextQuestions.map(
+              (question) => ({
+                title: question.question,
+                detail: question.rationale,
+                meta: question.targetDimension,
+              }),
+            )}
+          />
+        </div>
+      </details>
+
+      <FollowUpPanel analysis={analysis} />
+    </article>
+  );
+}
+
+function BigNumberTile({
+  bigNumber,
+}: {
+  readonly bigNumber: ReportDashboardBigNumber;
+}) {
+  return (
+    <div className="rounded-md border border-slate-200 bg-white p-4">
+      <p className="text-sm font-medium text-slate-600">{bigNumber.label}</p>
+      <p className="mt-2 break-words text-3xl font-semibold text-slate-950">
+        {bigNumber.value}
+      </p>
+      <p className="mt-1 text-sm leading-5 text-slate-600">
+        {bigNumber.detail}
+      </p>
+    </div>
+  );
+}
+
+function LanguageMixPanel({
+  languageSlices,
+  emptyMessage,
+}: {
+  readonly languageSlices: readonly ReportDashboardLanguageSlice[];
+  readonly emptyMessage: string | undefined;
+}) {
+  return (
+    <section
+      aria-labelledby="language-mix-title"
+      className="rounded-md border border-slate-200 bg-white p-5"
+    >
+      <p className="text-sm font-medium uppercase text-emerald-700">
+        Static evidence
+      </p>
+      <h3
+        id="language-mix-title"
+        className="mt-1 text-lg font-semibold text-slate-950"
+      >
+        Language Mix
+      </h3>
+
+      {emptyMessage === undefined ? (
+        <div className="mt-5 grid gap-4">
+          {languageSlices.map((slice) => (
+            <div key={slice.language}>
+              <div className="flex items-center justify-between gap-3 text-sm">
+                <span className="font-medium text-slate-900">
+                  {slice.language}
+                </span>
+                <span className="text-slate-600">{slice.percentOfCode}%</span>
+              </div>
+              <div className="mt-2 h-3 overflow-hidden rounded-full bg-slate-200">
+                <div
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${Math.max(slice.percentOfCode, 3)}%`,
+                    backgroundColor: slice.color,
+                  }}
+                />
+              </div>
+              <p className="mt-2 text-xs text-slate-600">
+                {formatNumber(slice.fileCount)} files,{" "}
+                {formatNumber(slice.codeLineCount)} code lines
               </p>
             </div>
           ))}
         </div>
-      </section>
+      ) : (
+        <p className="mt-5 text-sm leading-6 text-slate-700">{emptyMessage}</p>
+      )}
+    </section>
+  );
+}
 
-      <section className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-        <LanguageMixPanel
-          languageMix={analysis.dashboardInsights.languageMix}
-          totalCodeLineCount={
-            analysis.dashboardInsights.codeShapeSummary.totalCodeLineCount
-          }
-        />
-        <ReviewerNotesPanel findings={findings} />
-      </section>
-
-      <section aria-labelledby="dimensions-title" className="space-y-3">
-        <h3
-          id="dimensions-title"
-          className="text-lg font-semibold text-slate-950"
-        >
-          Dimensions
-        </h3>
-        <div className="space-y-3">
-          {reportCard.dimensionAssessments.map((assessment) => (
-            <DimensionPanel
-              key={assessment.dimension}
-              assessment={assessment}
-              caveats={reportCard.caveats}
-            />
-          ))}
-        </div>
-      </section>
-
-      <section className="grid gap-4 xl:grid-cols-2">
-        <CaveatsPanel caveats={reportCard.caveats} />
-        <EvidencePanel references={reportCard.evidenceReferences} />
-      </section>
-
-      <section aria-labelledby="questions-title" className="space-y-3">
-        <h3
-          id="questions-title"
-          className="text-lg font-semibold text-slate-950"
-        >
-          Follow-Up Questions
-        </h3>
-        <ul className="grid gap-2 lg:grid-cols-2">
-          {reportCard.recommendedNextQuestions.map((question) => (
-            <li
-              key={question.id}
-              className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-800"
-            >
-              <p className="font-medium text-slate-950">{question.question}</p>
-              <p className="mt-1 text-slate-600">{question.rationale}</p>
+function ReviewerNotesPanel({
+  notes,
+}: {
+  readonly notes: readonly ReportDashboardReviewerNote[];
+}) {
+  return (
+    <section
+      aria-labelledby="reviewer-notes-title"
+      className="rounded-md border border-slate-200 bg-white p-5"
+    >
+      <p className="text-sm font-medium uppercase text-emerald-700">
+        Reviewer assessment
+      </p>
+      <h3
+        id="reviewer-notes-title"
+        className="mt-1 text-lg font-semibold text-slate-950"
+      >
+        Reviewer Notes
+      </h3>
+      {notes.length === 0 ? (
+        <p className="mt-5 text-sm leading-6 text-slate-700">
+          No reviewer notes were available.
+        </p>
+      ) : (
+        <ul className="mt-5 divide-y divide-slate-200">
+          {notes.map((note, index) => (
+            <li key={`${note.tone}-${index}`} className="py-3 first:pt-0">
+              <p className="text-sm leading-6 text-slate-800">{note.text}</p>
+              <p className="mt-1 text-xs font-semibold uppercase text-slate-500">
+                {note.tone}
+              </p>
             </li>
           ))}
         </ul>
-      </section>
+      )}
+    </section>
+  );
+}
 
-      <FollowUpPanel analysis={analysis} />
+function ReportSectionPanel({
+  section,
+}: {
+  readonly section: ReportDashboardSection;
+}) {
+  const signals = [...section.highlights, ...section.risks, ...section.caveats];
+
+  return (
+    <article className="rounded-md border border-slate-200 bg-white p-5">
+      <div className="grid gap-5 xl:grid-cols-[170px_minmax(0,1fr)_minmax(220px,300px)]">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="text-lg font-semibold text-slate-950">
+              {section.title}
+            </h4>
+            <span className="rounded border border-slate-300 bg-slate-50 px-2 py-1 text-xs font-semibold uppercase text-slate-700">
+              {formatRating(section.rating)}
+            </span>
+          </div>
+          <div className="mt-4">
+            <ScoreRing
+              score={section.score}
+              grade={formatRating(section.rating)}
+            />
+          </div>
+          <p className="mt-4 text-sm font-medium text-slate-900">
+            {section.confidenceLabel}
+          </p>
+          <div className="mt-4">
+            <Sparkline points={section.chartPoints} />
+          </div>
+        </div>
+
+        <div className="min-w-0">
+          <p className="text-sm leading-6 text-slate-700">{section.summary}</p>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            {section.metrics.map((metric) => (
+              <MetricTile key={metric.label} metric={metric} />
+            ))}
+          </div>
+
+          <div className="mt-5 grid gap-4 lg:grid-cols-2">
+            <TextList
+              title="Signals"
+              emptyMessage="No reviewer signals were available."
+              items={signals}
+            />
+            <TextList
+              title="Next Checks"
+              emptyMessage="No next checks were recommended."
+              items={section.nextChecks}
+            />
+          </div>
+        </div>
+
+        <SectionAskBox sectionTitle={section.title} />
+      </div>
     </article>
+  );
+}
+
+function SectionAskBox({ sectionTitle }: { readonly sectionTitle: string }) {
+  return (
+    <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
+      <label className="block">
+        <span className="text-sm font-semibold text-slate-900">
+          Ask About {sectionTitle}
+        </span>
+        <textarea
+          aria-label={`Ask About ${sectionTitle}`}
+          className="mt-2 h-24 w-full resize-none rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
+          placeholder={`Ask about ${sectionTitle.toLowerCase()}...`}
+        />
+      </label>
+      <button
+        type="button"
+        className="mt-3 h-10 w-full rounded-md bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800"
+      >
+        Open Chat
+      </button>
+    </div>
+  );
+}
+
+function MetricTile({
+  metric,
+}: {
+  readonly metric: ReportDashboardSection["metrics"][number];
+}) {
+  return (
+    <div className="border-t border-slate-200 pt-3">
+      <p className="text-xs font-semibold uppercase text-slate-500">
+        {metric.label}
+      </p>
+      <p className="mt-1 break-words text-2xl font-semibold text-slate-950">
+        {metric.value}
+      </p>
+      <p className="mt-1 text-xs leading-5 text-slate-600">{metric.detail}</p>
+    </div>
+  );
+}
+
+function TextList({
+  title,
+  emptyMessage,
+  items,
+}: {
+  readonly title: string;
+  readonly emptyMessage: string;
+  readonly items: readonly string[];
+}) {
+  return (
+    <section>
+      <h5 className="text-sm font-semibold text-slate-950">{title}</h5>
+      {items.length === 0 ? (
+        <p className="mt-2 text-sm leading-6 text-slate-600">{emptyMessage}</p>
+      ) : (
+        <ul className="mt-2 space-y-2 text-sm leading-6 text-slate-700">
+          {items.map((item) => (
+            <li key={item} className="rounded-md bg-slate-50 px-3 py-2">
+              {item}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function DetailList({
+  title,
+  emptyMessage,
+  items,
+}: {
+  readonly title: string;
+  readonly emptyMessage: string;
+  readonly items: readonly {
+    readonly title: string;
+    readonly detail: string;
+    readonly meta: string | undefined;
+  }[];
+}) {
+  return (
+    <section>
+      <h4 className="text-sm font-semibold text-slate-950">{title}</h4>
+      {items.length === 0 ? (
+        <p className="mt-2 text-sm leading-6 text-slate-600">{emptyMessage}</p>
+      ) : (
+        <ul className="mt-2 space-y-2">
+          {items.map((item) => (
+            <li key={`${item.title}-${item.detail}`} className="text-sm">
+              <p className="font-medium text-slate-950">{item.title}</p>
+              <p className="mt-1 leading-6 text-slate-700">{item.detail}</p>
+              {item.meta === undefined || item.meta === "" ? null : (
+                <p className="mt-1 break-words text-xs text-slate-500">
+                  {item.meta}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }
 
@@ -201,372 +443,9 @@ function MetadataItem({
       <dt className="text-xs font-semibold uppercase text-slate-500">
         {label}
       </dt>
-      <dd className="mt-1 break-words text-slate-900">{value}</dd>
+      <dd className="mt-1 break-words font-medium text-slate-950">{value}</dd>
     </div>
   );
-}
-
-function LanguageMixPanel({
-  languageMix,
-  totalCodeLineCount,
-}: {
-  readonly languageMix: readonly DashboardLanguageMixItem[];
-  readonly totalCodeLineCount: number;
-}) {
-  return (
-    <section
-      aria-labelledby="language-mix-title"
-      className="rounded-md border border-slate-200 bg-white p-5"
-    >
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <p className="text-sm font-medium uppercase text-emerald-700">
-            Static evidence
-          </p>
-          <h3
-            id="language-mix-title"
-            className="mt-1 text-lg font-semibold text-slate-950"
-          >
-            Language Mix
-          </h3>
-        </div>
-        <p className="text-sm text-slate-600">
-          {formatNumber(totalCodeLineCount)} code lines
-        </p>
-      </div>
-
-      {languageMix.length === 0 ? (
-        <p className="mt-5 text-sm leading-6 text-slate-700">
-          No language mix was available in the collected evidence.
-        </p>
-      ) : (
-        <div className="mt-5 grid gap-4">
-          {languageMix.map((item, index) => (
-            <div key={item.language}>
-              <div className="flex items-center justify-between gap-3 text-sm">
-                <span className="font-medium text-slate-900">
-                  {item.language}
-                </span>
-                <span className="text-slate-600">
-                  {item.percentOfCode}% of code
-                </span>
-              </div>
-              <div className="mt-2 h-3 overflow-hidden rounded-full bg-slate-200">
-                <div
-                  className="h-full rounded-full"
-                  style={{
-                    width: `${Math.max(item.percentOfCode, 3)}%`,
-                    backgroundColor: languageColor(index),
-                  }}
-                />
-              </div>
-              <p className="mt-2 text-xs text-slate-600">
-                {formatNumber(item.fileCount)} files,{" "}
-                {formatNumber(item.sourceFileCount)} source files,{" "}
-                {formatNumber(item.codeLineCount)} code lines
-              </p>
-            </div>
-          ))}
-        </div>
-      )}
-    </section>
-  );
-}
-
-function ReviewerNotesPanel({
-  findings,
-}: {
-  readonly findings: readonly ReportFinding[];
-}) {
-  return (
-    <section
-      aria-labelledby="reviewer-notes-title"
-      className="rounded-md border border-slate-200 bg-white p-5"
-    >
-      <p className="text-sm font-medium uppercase text-blue-700">
-        Reviewer assessment
-      </p>
-      <h3
-        id="reviewer-notes-title"
-        className="mt-1 text-lg font-semibold text-slate-950"
-      >
-        Reviewer Notes
-      </h3>
-      {findings.length === 0 ? (
-        <p className="mt-5 text-sm leading-6 text-slate-700">
-          No findings were reported by the reviewer.
-        </p>
-      ) : (
-        <div className="mt-5 divide-y divide-slate-200">
-          {findings.map((finding) => (
-            <FindingRow key={finding.id} finding={finding} compact />
-          ))}
-        </div>
-      )}
-    </section>
-  );
-}
-
-function DimensionPanel({
-  assessment,
-  caveats,
-}: {
-  readonly assessment: DimensionAssessment;
-  readonly caveats: readonly ReportCaveat[];
-}) {
-  const relevantCaveats = caveats.filter((caveat) =>
-    caveat.affectedDimensions.includes(assessment.dimension),
-  );
-
-  return (
-    <section className="rounded-md border border-slate-200 bg-white p-5">
-      <div className="grid gap-5 lg:grid-cols-[240px_minmax(0,1fr)]">
-        <div>
-          <div className="flex flex-wrap items-center gap-2">
-            <h4 className="text-lg font-semibold text-slate-950">
-              {assessment.title}
-            </h4>
-            <RatingBadge rating={assessment.rating} />
-          </div>
-          <ScoreStrip score={assessment.score} />
-          <p className="mt-4 text-sm font-medium text-slate-900">
-            {assessment.confidence.level} confidence
-          </p>
-          <p className="mt-1 text-xs leading-5 text-slate-600">
-            {assessment.confidence.rationale}
-          </p>
-        </div>
-
-        <div>
-          <p className="text-sm leading-6 text-slate-700">
-            {assessment.summary}
-          </p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-3">
-            <MetricTile
-              label="Evidence"
-              value={String(assessment.evidenceReferences.length)}
-              detail="References for this dimension"
-            />
-            <MetricTile
-              label="Findings"
-              value={String(assessment.findings.length)}
-              detail="Reviewer observations"
-            />
-            <MetricTile
-              label="Caveats"
-              value={String(relevantCaveats.length)}
-              detail="Known missing context"
-            />
-          </div>
-
-          {assessment.findings.length === 0 ? null : (
-            <div className="mt-5 space-y-2">
-              {assessment.findings.map((finding) => (
-                <FindingRow key={finding.id} finding={finding} />
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function ScoreStrip({ score }: { readonly score: number | undefined }) {
-  if (score === undefined) {
-    return (
-      <p className="mt-4 text-sm text-slate-600">
-        No numeric score assigned for this dimension.
-      </p>
-    );
-  }
-
-  return (
-    <div className="mt-4" aria-label={`Dimension score ${score}`}>
-      <div className="flex items-end justify-between text-sm">
-        <span className="font-medium text-slate-700">Dimension score</span>
-        <span className="text-2xl font-semibold text-slate-950">{score}</span>
-      </div>
-      <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-200">
-        <div
-          className="h-full rounded-full bg-emerald-600"
-          style={{ width: `${score}%` }}
-        />
-      </div>
-    </div>
-  );
-}
-
-function RatingBadge({ rating }: { readonly rating: ReportRating }) {
-  return (
-    <span
-      className={`rounded border px-2 py-1 text-xs font-medium uppercase ${ratingStyle(
-        rating,
-      )}`}
-    >
-      {rating}
-    </span>
-  );
-}
-
-function MetricTile({
-  label,
-  value,
-  detail,
-}: {
-  readonly label: string;
-  readonly value: string;
-  readonly detail: string;
-}) {
-  return (
-    <div className="border-t border-slate-200 pt-3">
-      <p className="text-xs font-semibold uppercase text-slate-500">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-slate-950">{value}</p>
-      <p className="mt-1 text-xs text-slate-600">{detail}</p>
-    </div>
-  );
-}
-
-function FindingRow({
-  finding,
-  compact = false,
-}: {
-  readonly finding: ReportFinding;
-  readonly compact?: boolean;
-}) {
-  return (
-    <section
-      className={
-        compact
-          ? "py-3 first:pt-0 last:pb-0"
-          : "rounded-md border border-slate-200 bg-slate-50 p-3"
-      }
-    >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h5 className="font-medium text-slate-950">{finding.title}</h5>
-        <span
-          className={`rounded px-2 py-1 text-xs font-medium uppercase ${severityStyle(
-            finding.severity,
-          )}`}
-        >
-          {finding.severity}
-        </span>
-      </div>
-      <p className="mt-1 text-sm leading-6 text-slate-700">{finding.summary}</p>
-      <p className="mt-2 text-xs text-slate-600">
-        Evidence: {referenceIds(finding.evidenceReferences)}
-      </p>
-    </section>
-  );
-}
-
-function CaveatsPanel({
-  caveats,
-}: {
-  readonly caveats: readonly ReportCaveat[];
-}) {
-  return (
-    <section aria-labelledby="caveats-title" className="space-y-3">
-      <h3 id="caveats-title" className="text-lg font-semibold text-slate-950">
-        Caveats And Missing Evidence
-      </h3>
-      {caveats.length === 0 ? (
-        <p className="rounded-md border border-slate-200 bg-white p-3 text-sm text-slate-600">
-          No caveats were reported.
-        </p>
-      ) : (
-        <div className="space-y-2">
-          {caveats.map((caveat) => (
-            <CaveatRow key={caveat.id} caveat={caveat} />
-          ))}
-        </div>
-      )}
-    </section>
-  );
-}
-
-function CaveatRow({ caveat }: { readonly caveat: ReportCaveat }) {
-  return (
-    <section className="rounded-md border border-amber-200 bg-amber-50 p-3">
-      <h4 className="font-medium text-slate-950">{caveat.title}</h4>
-      <p className="mt-1 text-sm leading-6 text-slate-700">{caveat.summary}</p>
-      {caveat.missingEvidence.length > 0 ? (
-        <ul className="mt-2 list-inside list-disc text-sm text-slate-700">
-          {caveat.missingEvidence.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
-      ) : null}
-    </section>
-  );
-}
-
-function EvidencePanel({
-  references,
-}: {
-  readonly references: readonly EvidenceReference[];
-}) {
-  return (
-    <section aria-labelledby="evidence-title" className="space-y-3">
-      <h3 id="evidence-title" className="text-lg font-semibold text-slate-950">
-        Evidence References
-      </h3>
-      <ul className="grid gap-2">
-        {references.map((reference) => (
-          <EvidenceReferenceItem key={reference.id} reference={reference} />
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-function EvidenceReferenceItem({
-  reference,
-}: {
-  readonly reference: EvidenceReference;
-}) {
-  return (
-    <li className="rounded-md border border-slate-200 bg-white p-3 text-sm">
-      <p className="font-medium text-slate-950">{reference.id}</p>
-      <p className="mt-1 text-slate-700">{reference.label}</p>
-      {reference.path === undefined ? null : (
-        <p className="mt-1 break-all font-mono text-xs text-slate-600">
-          {reference.path}
-        </p>
-      )}
-    </li>
-  );
-}
-
-function strongestAssessedDimension(
-  assessments: readonly DimensionAssessment[],
-): DimensionAssessment | undefined {
-  return assessments
-    .filter((assessment) => assessment.score !== undefined)
-    .toSorted((left, right) => {
-      const leftScore = left.score ?? 0;
-      const rightScore = right.score ?? 0;
-      return rightScore - leftScore;
-    })[0];
-}
-
-function repositoryLabel(reportCard: ReportCard): string {
-  const owner = reportCard.repository.owner;
-  const ownerPrefix = owner === undefined ? "" : `${owner}/`;
-  const revision =
-    reportCard.repository.revision === undefined
-      ? ""
-      : ` @ ${reportCard.repository.revision}`;
-
-  return `${reportCard.repository.provider}:${ownerPrefix}${reportCard.repository.name}${revision}`;
-}
-
-function referenceIds(references: readonly EvidenceReference[]): string {
-  return references.map((reference) => reference.id).join(", ");
-}
-
-function formatNumber(value: number): string {
-  return new Intl.NumberFormat("en-US").format(value);
 }
 
 function formatDateTime(value: string): string {
@@ -576,39 +455,13 @@ function formatDateTime(value: string): string {
   }).format(new Date(value));
 }
 
-function languageColor(index: number): string {
-  const colors = ["#047857", "#2563eb", "#d97706", "#be123c", "#7c3aed"];
-  return colors[index % colors.length] ?? "#047857";
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
 }
 
-function ratingStyle(rating: ReportRating): string {
-  switch (rating) {
-    case "excellent":
-      return "border-emerald-300 bg-emerald-50 text-emerald-800";
-    case "good":
-      return "border-blue-300 bg-blue-50 text-blue-800";
-    case "fair":
-      return "border-amber-300 bg-amber-50 text-amber-800";
-    case "weak":
-      return "border-orange-300 bg-orange-50 text-orange-800";
-    case "poor":
-      return "border-red-300 bg-red-50 text-red-800";
-    case "not-assessed":
-      return "border-slate-300 bg-slate-50 text-slate-700";
-  }
-}
-
-function severityStyle(severity: ReportFinding["severity"]): string {
-  switch (severity) {
-    case "info":
-      return "bg-slate-100 text-slate-700";
-    case "low":
-      return "bg-blue-100 text-blue-800";
-    case "medium":
-      return "bg-amber-100 text-amber-800";
-    case "high":
-      return "bg-orange-100 text-orange-800";
-    case "critical":
-      return "bg-red-100 text-red-800";
-  }
+function formatRating(rating: string): string {
+  return rating
+    .split("-")
+    .map((word) => word.slice(0, 1).toUpperCase() + word.slice(1))
+    .join(" ");
 }

--- a/src/components/report/report-card-view.tsx
+++ b/src/components/report/report-card-view.tsx
@@ -22,7 +22,7 @@ export function ReportCardView({
     .toSorted((left, right) => (right.score ?? 0) - (left.score ?? 0))[0];
 
   return (
-    <article className="space-y-5" aria-labelledby="report-title">
+    <section className="space-y-5" aria-labelledby="report-title">
       <header className="flex flex-wrap items-start justify-between gap-4 print:hidden">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700">
@@ -78,7 +78,7 @@ export function ReportCardView({
         </div>
 
         <div className="rounded-md border border-slate-200 bg-white p-5 lg:w-72">
-          <p className="text-sm font-semibold text-slate-950">Reviewer Notes</p>
+          <p className="text-sm font-semibold text-slate-950">Reviewer</p>
           <p className="mt-2 text-sm leading-6 text-slate-700">
             {dashboard.overview.reviewerNote}
           </p>
@@ -149,7 +149,7 @@ export function ReportCardView({
       </details>
 
       <FollowUpPanel analysis={analysis} />
-    </article>
+    </section>
   );
 }
 
@@ -383,8 +383,11 @@ function TextList({
         <p className="mt-2 text-sm leading-6 text-slate-600">{emptyMessage}</p>
       ) : (
         <ul className="mt-2 space-y-2 text-sm leading-6 text-slate-700">
-          {items.map((item) => (
-            <li key={item} className="rounded-md bg-slate-50 px-3 py-2">
+          {items.map((item, index) => (
+            <li
+              key={`${item}-${index}`}
+              className="rounded-md bg-slate-50 px-3 py-2"
+            >
               {item}
             </li>
           ))}
@@ -414,8 +417,11 @@ function DetailList({
         <p className="mt-2 text-sm leading-6 text-slate-600">{emptyMessage}</p>
       ) : (
         <ul className="mt-2 space-y-2">
-          {items.map((item) => (
-            <li key={`${item.title}-${item.detail}`} className="text-sm">
+          {items.map((item, index) => (
+            <li
+              key={`${item.title}-${item.detail}-${index}`}
+              className="text-sm"
+            >
               <p className="font-medium text-slate-950">{item.title}</p>
               <p className="mt-1 leading-6 text-slate-700">{item.detail}</p>
               {item.meta === undefined || item.meta === "" ? null : (

--- a/src/components/report/score-ring.test.tsx
+++ b/src/components/report/score-ring.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ScoreRing } from "./score-ring";
+
+describe("ScoreRing", () => {
+  it("renders numeric score and grade", () => {
+    const html = renderToStaticMarkup(<ScoreRing score={86} grade="B" />);
+
+    expect(html).toContain("86");
+    expect(html).toContain("B");
+    expect(html).toContain('aria-label="Score 86, grade B"');
+  });
+
+  it("renders a missing-score state", () => {
+    const html = renderToStaticMarkup(
+      <ScoreRing score={undefined} grade="Not assessed" />,
+    );
+
+    expect(html).toContain("N/A");
+    expect(html).toContain("Not assessed");
+    expect(html).toContain('aria-label="Score not assessed"');
+  });
+});

--- a/src/components/report/score-ring.tsx
+++ b/src/components/report/score-ring.tsx
@@ -1,0 +1,38 @@
+export function ScoreRing({
+  score,
+  grade,
+}: {
+  readonly score: number | undefined;
+  readonly grade: string;
+}) {
+  const scoreLabel = score === undefined ? "N/A" : String(score);
+  const ariaLabel =
+    score === undefined
+      ? "Score not assessed"
+      : `Score ${score}, grade ${grade}`;
+
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      className="grid size-28 shrink-0 place-items-center rounded-full border border-slate-200 bg-white"
+      style={{
+        background:
+          score === undefined
+            ? "conic-gradient(#cbd5e1 0deg, #e2e8f0 0deg)"
+            : `conic-gradient(#047857 ${Math.round(score * 3.6)}deg, #e2e8f0 0deg)`,
+      }}
+    >
+      <div className="grid size-20 place-items-center rounded-full bg-white text-center">
+        <div>
+          <p className="text-2xl font-semibold leading-none text-slate-950">
+            {scoreLabel}
+          </p>
+          <p className="mt-1 text-xs font-semibold uppercase text-slate-600">
+            {grade}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/report/sparkline.test.tsx
+++ b/src/components/report/sparkline.test.tsx
@@ -1,0 +1,30 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Sparkline } from "./sparkline";
+
+describe("Sparkline", () => {
+  it("renders a stable svg polyline for score points", () => {
+    const html = renderToStaticMarkup(
+      <Sparkline
+        points={[
+          { label: "Score", value: 80 },
+          { label: "Confidence", value: 90 },
+          { label: "Evidence", value: 50 },
+          { label: "Risk", value: 25 },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Section signal trend");
+    expect(html).toContain("<polyline");
+    expect(html).toContain("Score 80");
+    expect(html).toContain("Confidence 90");
+  });
+
+  it("renders an empty state when no chart points exist", () => {
+    const html = renderToStaticMarkup(<Sparkline points={[]} />);
+
+    expect(html).toContain("No chart data");
+  });
+});

--- a/src/components/report/sparkline.tsx
+++ b/src/components/report/sparkline.tsx
@@ -1,0 +1,62 @@
+export type SparklinePoint = {
+  readonly label: "Score" | "Confidence" | "Evidence" | "Risk";
+  readonly value: number;
+};
+
+export function Sparkline({
+  points,
+}: {
+  readonly points: readonly SparklinePoint[];
+}) {
+  if (points.length === 0) {
+    return (
+      <div className="grid h-16 place-items-center rounded-md border border-dashed border-slate-300 text-xs font-medium text-slate-500">
+        No chart data
+      </div>
+    );
+  }
+
+  const polylinePoints = points
+    .map((point, index) => {
+      const x = points.length === 1 ? 50 : (index / (points.length - 1)) * 100;
+      const y = 100 - clamp(point.value);
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <figure className="space-y-2">
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className="h-16 w-full overflow-visible"
+        role="img"
+        aria-label="Section signal trend"
+      >
+        <title>Section signal trend</title>
+        <polyline
+          points={polylinePoints}
+          fill="none"
+          stroke="#047857"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="5"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      <figcaption className="sr-only">
+        <ul>
+          {points.map((point) => (
+            <li key={point.label}>
+              {point.label} {point.value}
+            </li>
+          ))}
+        </ul>
+      </figcaption>
+    </figure>
+  );
+}
+
+function clamp(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}


### PR DESCRIPTION
## Summary

- Replace the raw report debug layout with the dashboard view model surface from #118: overview score ring, big-number metrics, language mix, reviewer notes, and red-style report section panels.
- Add focused score ring and sparkline component tests.
- Update the foundational E2E and red-parity report checks to assert the new dashboard surface with stable locators.
- Preserve PDF export and the existing embedded follow-up panel until #121 replaces chat with the red-style slideout.

Closes #119

## Verification

- `npx -y node@24 $(command -v pnpm) check`
- `npx -y node@24 $(command -v pnpm) build`
- `npx -y node@24 $(command -v pnpm) test:e2e`
- `RED_UI_PARITY=1 npx -y node@24 $(command -v pnpm) exec playwright test e2e/red-ui-parity.spec.ts -g "first-screen|report dashboard"`

## Notes

The full red-parity chat workflow remains intentionally out of this PR and is tracked by #121.