### PR TITLE
feat(api): add evidence-backed follow-up route

### DIFF
--- a/src/app/api/follow-up/route.test.ts
+++ b/src/app/api/follow-up/route.test.ts
@@ -1,0 +1,560 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ChatAnswerSchemaVersion,
+  type ChatAnswerContract,
+} from "../../../domain/chat/chat-answer";
+import type { Conversation } from "../../../domain/chat/conversation";
+import type { EvidenceContentResult } from "../../../domain/chat/evidence-retrieval";
+import type { ReportCard } from "../../../domain/report/report-card";
+import type { EvidenceReference } from "../../../domain/shared/evidence-reference";
+import type {
+  ChatReviewer,
+  ConversationRepository,
+} from "../../../application/follow-up-chat/follow-up-chat";
+import { OpenRouterDefaultBaseUrl } from "../../../infrastructure/llm/openrouter-config";
+import {
+  FollowUpAnswerValidationError,
+  FollowUpProviderError,
+  handleFollowUpRequest,
+  type FollowUpRouteOptions,
+} from "./route";
+
+const packageEvidence: EvidenceReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+  lineStart: 1,
+  lineEnd: 5,
+};
+
+const ciEvidence: EvidenceReference = {
+  id: "evidence:ci-workflow",
+  kind: "file",
+  label: "CI workflow",
+  path: ".github/workflows/ci.yml",
+};
+
+const reportCard: ReportCard = {
+  id: "report:repo-analyzer-green",
+  schemaVersion: "report-card.v1",
+  generatedAt: "2026-04-26T12:00:00-07:00",
+  scoringPolicy: {
+    name: "repo-analyzer-green scoring policy",
+    version: "0.1.0",
+  },
+  repository: {
+    provider: "github",
+    owner: "lightstrikelabs",
+    name: "repo-analyzer-green",
+    url: "https://github.com/lightstrikelabs/repo-analyzer-green",
+    revision: "main",
+  },
+  assessedArchetype: "web-app",
+  reviewerMetadata: {
+    kind: "fake",
+    name: "Fixture reviewer",
+    reviewedAt: "2026-04-26T12:00:00-07:00",
+  },
+  evidenceReferences: [packageEvidence, ciEvidence],
+  dimensionAssessments: [
+    {
+      dimension: "verifiability",
+      title: "Verifiability",
+      summary: "Tests and CI are present.",
+      rating: "good",
+      score: 82,
+      confidence: {
+        level: "high",
+        score: 0.86,
+        rationale: "Package and workflow evidence were collected.",
+      },
+      evidenceReferences: [packageEvidence, ciEvidence],
+      findings: [
+        {
+          id: "finding:verifiability:test-script",
+          dimension: "verifiability",
+          severity: "medium",
+          title: "Test script exists",
+          summary: "The package manifest exposes a test script.",
+          confidence: {
+            level: "high",
+            score: 0.9,
+            rationale: "package.json was collected.",
+          },
+          evidenceReferences: [packageEvidence],
+        },
+      ],
+      caveatIds: ["caveat:deployment-missing"],
+    },
+  ],
+  caveats: [
+    {
+      id: "caveat:deployment-missing",
+      title: "Deployment evidence missing",
+      summary: "Deployment workflow context was not collected.",
+      affectedDimensions: ["verifiability"],
+      missingEvidence: ["Deployment workflow"],
+    },
+  ],
+  recommendedNextQuestions: [],
+};
+
+describe("POST /api/follow-up", () => {
+  it("starts a live follow-up from a red-style report section target and preserves evidence snippets", async () => {
+    const repository = new InMemoryConversationRepository();
+    const reviewer = new RecordingChatReviewer(answeredContract());
+    const response = await handleFollowUpRequest(
+      jsonRequest({
+        reportCard,
+        target: {
+          kind: "report-section",
+          sectionId: "testing",
+        },
+        messages: [
+          {
+            role: "user",
+            content: "What should I verify first?",
+          },
+        ],
+        question: "What should I verify first?",
+        apiKey: " sk-or-v1-test ",
+        model: "openai/gpt-4.1-mini",
+      }),
+      dependencies({ repository, reviewer }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.conversation.target).toEqual({
+      kind: "dimension",
+      dimension: "verifiability",
+    });
+    expect(body.answer.answer.status).toBe("answered");
+    expect(body.evidence.snippets[0]).toMatchObject({
+      evidenceReference: packageEvidence,
+      text: expect.stringContaining('"test": "vitest"'),
+      source: "fresh-content",
+      targetRelevance: "dimension",
+    });
+    expect(reviewer.requests[0]?.question).toBe("What should I verify first?");
+    expect(reviewer.options).toEqual([
+      {
+        openRouterConfig: {
+          provider: "openrouter",
+          apiKey: "sk-or-v1-test",
+          model: "openai/gpt-4.1-mini",
+          baseUrl: OpenRouterDefaultBaseUrl,
+        },
+      },
+    ]);
+    expect(JSON.stringify(repository.saved)).not.toContain("sk-or-v1-test");
+  });
+
+  it("continues a persisted conversation by id", async () => {
+    const repository = new InMemoryConversationRepository();
+    const reviewer = new RecordingChatReviewer(answeredContract());
+    const startResponse = await handleFollowUpRequest(
+      jsonRequest(validStartRequest()),
+      dependencies({ repository, reviewer }),
+    );
+    const started = await startResponse.json();
+
+    const response = await handleFollowUpRequest(
+      jsonRequest({
+        reportCard,
+        conversationId: started.conversation.id,
+        messages: started.conversation.messages.map(
+          (message: { readonly role: string; readonly content: string }) => ({
+            role: message.role,
+            content: message.content,
+          }),
+        ),
+        question: "Which file proves that?",
+        apiKey: "sk-or-v1-test",
+      }),
+      dependencies({ repository, reviewer }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.conversation.id).toBe(started.conversation.id);
+    expect(body.conversation.messages).toHaveLength(4);
+    expect(reviewer.requests[1]?.conversation.messages).toHaveLength(3);
+  });
+
+  it("requires an API key for live follow-up without persisting a conversation", async () => {
+    const repository = new InMemoryConversationRepository();
+    const response = await handleFollowUpRequest(
+      jsonRequest({
+        ...validStartRequest(),
+        apiKey: "",
+      }),
+      dependencies({
+        repository,
+        reviewer: new RecordingChatReviewer(answeredContract()),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toEqual({
+      code: "openrouter-api-key-required",
+      message: "OpenRouter API key is required for follow-up questions.",
+    });
+    expect(repository.saved).toEqual([]);
+  });
+
+  it("returns invalid target details", async () => {
+    const response = await handleFollowUpRequest(
+      jsonRequest({
+        ...validStartRequest(),
+        target: {
+          kind: "finding",
+          findingId: "finding:missing",
+        },
+      }),
+      dependencies({
+        repository: new InMemoryConversationRepository(),
+        reviewer: new RecordingChatReviewer(answeredContract()),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toEqual({
+      code: "invalid-target",
+      message: "Follow-up target could not be resolved.",
+      reason: "finding-not-found",
+      targetId: "finding:missing",
+    });
+  });
+
+  it("returns missing conversation details", async () => {
+    const response = await handleFollowUpRequest(
+      jsonRequest({
+        reportCard,
+        conversationId: "conversation:missing",
+        messages: [],
+        question: "What changed?",
+        apiKey: "sk-or-v1-test",
+      }),
+      dependencies({
+        repository: new InMemoryConversationRepository(),
+        reviewer: new RecordingChatReviewer(answeredContract()),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toEqual({
+      code: "conversation-not-found",
+      message: "Follow-up conversation could not be found.",
+      conversationId: "conversation:missing",
+    });
+  });
+
+  it("maps malformed model output to a bad gateway response", async () => {
+    const response = await handleFollowUpRequest(
+      jsonRequest(validStartRequest()),
+      dependencies({
+        repository: new InMemoryConversationRepository(),
+        reviewer: new ThrowingChatReviewer(
+          new FollowUpAnswerValidationError([
+            {
+              path: ["answer", "evidenceBackedClaims", 0, "citations"],
+              message: "Evidence-backed claims must include citations.",
+            },
+          ]),
+        ),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error).toEqual({
+      code: "follow-up-answer-malformed",
+      message: "Follow-up answer could not be validated.",
+      issues: [
+        {
+          path: ["answer", "evidenceBackedClaims", 0, "citations"],
+          message: "Evidence-backed claims must include citations.",
+        },
+      ],
+    });
+  });
+
+  it("maps provider failures without leaking credentials", async () => {
+    const response = await handleFollowUpRequest(
+      jsonRequest(validStartRequest()),
+      dependencies({
+        repository: new InMemoryConversationRepository(),
+        reviewer: new ThrowingChatReviewer(
+          new FollowUpProviderError(
+            "provider-error",
+            "OpenRouter follow-up answer is unavailable because the provider request failed.",
+            502,
+          ),
+        ),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(JSON.stringify(body)).not.toContain("sk-or-v1-test");
+    expect(body.error).toEqual({
+      code: "provider-error",
+      message:
+        "OpenRouter follow-up answer is unavailable because the provider request failed.",
+      status: 502,
+    });
+  });
+
+  it("preserves insufficient-context answers and missing evidence state", async () => {
+    const response = await handleFollowUpRequest(
+      jsonRequest({
+        ...validStartRequest(),
+        target: {
+          kind: "caveat",
+          caveatId: "caveat:deployment-missing",
+        },
+      }),
+      dependencies({
+        repository: new InMemoryConversationRepository(),
+        reviewer: new RecordingChatReviewer(insufficientContextContract()),
+        contentByPath: new Map(),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.answer.answer.status).toBe("insufficient-context");
+    expect(body.answer.answer.missingContext).toEqual([
+      {
+        reason: "Deployment workflow evidence was not available.",
+        requestedEvidence: "Deployment workflow",
+      },
+    ]);
+    expect(body.evidence.missingContext).toEqual([
+      {
+        evidenceReference: packageEvidence,
+        reason: "package.json was not available in the content source",
+      },
+      {
+        evidenceReference: ciEvidence,
+        reason:
+          ".github/workflows/ci.yml was not available in the content source",
+      },
+    ]);
+  });
+
+  it("rejects malformed request bodies with validation issues", async () => {
+    const response = await handleFollowUpRequest(
+      jsonRequest({
+        reportCard,
+        target: {
+          kind: "dimension",
+          dimension: "testing",
+        },
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+          },
+        ],
+        question: "",
+        apiKey: "sk-or-v1-test",
+      }),
+      dependencies({
+        repository: new InMemoryConversationRepository(),
+        reviewer: new RecordingChatReviewer(answeredContract()),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("invalid-request");
+    expect(body.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["question"],
+        }),
+        expect.objectContaining({
+          path: ["target"],
+        }),
+      ]),
+    );
+  });
+});
+
+function validStartRequest() {
+  return {
+    reportCard,
+    target: {
+      kind: "finding",
+      findingId: "finding:verifiability:test-script",
+    },
+    messages: [
+      {
+        role: "user",
+        content: "What test signal matters most?",
+      },
+    ],
+    question: "What test signal matters most?",
+    apiKey: "sk-or-v1-test",
+  } as const;
+}
+
+function dependencies(input: {
+  readonly repository: InMemoryConversationRepository;
+  readonly reviewer: ChatReviewer;
+  readonly contentByPath?: ReadonlyMap<string, string>;
+}) {
+  const recorder =
+    input.reviewer instanceof RecordingChatReviewer
+      ? input.reviewer
+      : undefined;
+
+  return {
+    conversationRepository: input.repository,
+    createChatReviewer: (options: FollowUpRouteOptions) => {
+      recorder?.options.push(options);
+      return input.reviewer;
+    },
+    contentSource: {
+      readEvidence: async (
+        reference: EvidenceReference,
+      ): Promise<EvidenceContentResult> => {
+        const content = input.contentByPath?.get(reference.path ?? "");
+        if (content !== undefined) {
+          return {
+            kind: "content",
+            text: content,
+          };
+        }
+
+        if (input.contentByPath !== undefined) {
+          return {
+            kind: "missing",
+            reason: `${reference.path ?? reference.id} was not available in the content source`,
+          };
+        }
+
+        return {
+          kind: "content",
+          text: [
+            "{",
+            '  "scripts": {',
+            '    "test": "vitest",',
+            '    "lint": "oxlint ."',
+            "  }",
+            "}",
+          ].join("\n"),
+        };
+      },
+    },
+    now: () => new Date("2026-04-26T12:30:00-07:00"),
+    createId: (() => {
+      let index = 0;
+      return (prefix: string) => `${prefix}:${++index}`;
+    })(),
+  };
+}
+
+function answeredContract(): ChatAnswerContract {
+  return {
+    answer: {
+      schemaVersion: ChatAnswerSchemaVersion,
+      status: "answered",
+      summary: "package.json defines a Vitest test script.",
+      evidenceBackedClaims: [
+        {
+          claim: "The package manifest includes a test script.",
+          citations: [
+            {
+              evidenceReference: packageEvidence,
+              quote: '"test": "vitest"',
+            },
+          ],
+        },
+      ],
+      assumptions: [],
+      caveats: [],
+      suggestedNextQuestions: [],
+    },
+    metadata: {
+      provider: "fixture-provider",
+      modelName: "fixture-model",
+      generatedAt: "2026-04-26T12:31:00-07:00",
+    },
+  };
+}
+
+function insufficientContextContract(): ChatAnswerContract {
+  return {
+    answer: {
+      schemaVersion: ChatAnswerSchemaVersion,
+      status: "insufficient-context",
+      summary: "Deployment workflow evidence was not available.",
+      missingContext: [
+        {
+          reason: "Deployment workflow evidence was not available.",
+          requestedEvidence: "Deployment workflow",
+        },
+      ],
+      suggestedNextQuestions: [],
+    },
+    metadata: {
+      provider: "fixture-provider",
+      modelName: "fixture-model",
+      generatedAt: "2026-04-26T12:31:00-07:00",
+    },
+  };
+}
+
+class RecordingChatReviewer implements ChatReviewer {
+  readonly requests: Parameters<ChatReviewer["answer"]>[0][] = [];
+  readonly options: FollowUpRouteOptions[] = [];
+
+  constructor(private readonly contract: ChatAnswerContract) {}
+
+  async answer(
+    request: Parameters<ChatReviewer["answer"]>[0],
+  ): Promise<ChatAnswerContract> {
+    this.requests.push(request);
+    return this.contract;
+  }
+}
+
+class ThrowingChatReviewer implements ChatReviewer {
+  constructor(private readonly error: Error) {}
+
+  async answer(): Promise<ChatAnswerContract> {
+    throw this.error;
+  }
+}
+
+class InMemoryConversationRepository implements ConversationRepository {
+  readonly saved: Conversation[] = [];
+  private readonly conversations = new Map<string, Conversation>();
+
+  async get(id: string): Promise<Conversation | undefined> {
+    return this.conversations.get(id);
+  }
+
+  async save(conversation: Conversation): Promise<void> {
+    this.saved.push(conversation);
+    this.conversations.set(conversation.id, conversation);
+  }
+}
+
+function jsonRequest(body: object): Request {
+  return new Request("http://localhost/api/follow-up", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/app/api/follow-up/route.ts
+++ b/src/app/api/follow-up/route.ts
@@ -1,0 +1,387 @@
+import { z } from "zod";
+
+import {
+  continueFollowUpConversation,
+  startFollowUpConversation,
+  type ChatReviewer,
+  type ConversationRepository,
+  type FollowUpChatDependencies,
+  type FollowUpChatResult,
+} from "../../../application/follow-up-chat/follow-up-chat";
+import {
+  ConversationTargetSelectorSchema,
+  type ConversationTargetSelector,
+} from "../../../domain/chat/conversation-target-resolver";
+import { ChatMessageRoleSchema } from "../../../domain/chat/conversation";
+import type { EvidenceContentSource } from "../../../domain/chat/evidence-retrieval";
+import { ReportCardSchema } from "../../../domain/report/report-card";
+import {
+  OpenRouterDefaultBaseUrl,
+  OpenRouterDefaultModelId,
+  OpenRouterModelIdSchema,
+  type OpenRouterProviderConfig,
+} from "../../../infrastructure/llm/openrouter-config";
+import { InMemoryConversationRepository } from "../../../infrastructure/persistence/in-memory-conversation-repository";
+import {
+  FollowUpAnswerValidationError,
+  FollowUpProviderError,
+  OpenRouterChatReviewer,
+} from "../../../infrastructure/reviewer/openrouter-chat-reviewer";
+
+export {
+  FollowUpAnswerValidationError,
+  FollowUpProviderError,
+} from "../../../infrastructure/reviewer/openrouter-chat-reviewer";
+
+export type FollowUpRouteOptions = {
+  readonly openRouterConfig: OpenRouterProviderConfig;
+};
+
+type FollowUpRouteDependencies = {
+  readonly conversationRepository: ConversationRepository;
+  readonly createChatReviewer: (options: FollowUpRouteOptions) => ChatReviewer;
+  readonly contentSource?: EvidenceContentSource;
+  readonly now?: () => Date;
+  readonly createId?: (prefix: string) => string;
+};
+
+type ApiValidationIssue = {
+  readonly path: readonly (string | number)[];
+  readonly message: string;
+};
+
+const RedSectionIdSchema = z.enum([
+  "maintainability",
+  "testing",
+  "security",
+  "architecture",
+  "documentation",
+]);
+
+const RedSectionTargetSchema = z
+  .union([
+    z
+      .object({
+        kind: z.enum(["section", "report-section"]),
+        sectionId: RedSectionIdSchema,
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.enum(["section", "report-section"]),
+        id: RedSectionIdSchema,
+      })
+      .strict(),
+  ])
+  .transform((target) => ({
+    kind: target.kind,
+    sectionId: "sectionId" in target ? target.sectionId : target.id,
+  }));
+
+const RedSectionSchema = z
+  .object({
+    id: RedSectionIdSchema,
+  })
+  .passthrough();
+
+const FollowUpMessageInputSchema = z
+  .object({
+    role: ChatMessageRoleSchema,
+    content: z.string().trim().min(1),
+  })
+  .strict();
+
+const FollowUpRequestSchema = z
+  .object({
+    reportCard: ReportCardSchema,
+    target: z
+      .union([ConversationTargetSelectorSchema, RedSectionTargetSchema])
+      .optional(),
+    section: RedSectionSchema.optional(),
+    conversationId: z.string().trim().min(1).optional(),
+    messages: z.array(FollowUpMessageInputSchema).default([]),
+    question: z.string().trim().min(1),
+    apiKey: z.preprocess(normalizeOptionalText, z.string().min(1).optional()),
+    model: OpenRouterModelIdSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (request) =>
+      request.conversationId !== undefined ||
+      request.target !== undefined ||
+      request.section !== undefined,
+    {
+      message: "A target or conversationId is required.",
+      path: ["target"],
+    },
+  );
+
+type FollowUpRequest = z.infer<typeof FollowUpRequestSchema>;
+
+const defaultConversationRepository = new InMemoryConversationRepository();
+
+export async function POST(request: Request): Promise<Response> {
+  return handleFollowUpRequest(request, {
+    conversationRepository: defaultConversationRepository,
+    createChatReviewer: (options) =>
+      new OpenRouterChatReviewer({
+        config: options.openRouterConfig,
+        controls: {
+          maxOutputTokens: 900,
+          temperature: 0.25,
+        },
+      }),
+  });
+}
+
+export async function handleFollowUpRequest(
+  request: Request,
+  dependencies: FollowUpRouteDependencies,
+): Promise<Response> {
+  const bodyResult = await readRequestBody(request);
+
+  if (bodyResult.kind === "invalid-json") {
+    return jsonError(400, {
+      code: "invalid-json",
+      message: "Request body must be valid JSON.",
+    });
+  }
+
+  const requestResult = FollowUpRequestSchema.safeParse(bodyResult.body);
+  if (!requestResult.success) {
+    return jsonError(400, {
+      code: "invalid-request",
+      message: "Request body did not match the follow-up contract.",
+      issues: requestResult.error.issues.map(toApiValidationIssue),
+    });
+  }
+
+  const parsedRequest = requestResult.data;
+  if (parsedRequest.apiKey === undefined) {
+    return jsonError(400, {
+      code: "openrouter-api-key-required",
+      message: "OpenRouter API key is required for follow-up questions.",
+    });
+  }
+
+  const routeOptions = openRouterRouteOptions(
+    parsedRequest,
+    parsedRequest.apiKey,
+  );
+  const chatDependencies = chatDependenciesFor(dependencies, routeOptions);
+
+  try {
+    const result =
+      parsedRequest.conversationId === undefined
+        ? await startFollowUpConversation(
+            {
+              reportCard: parsedRequest.reportCard,
+              targetSelector: targetSelectorFor(parsedRequest),
+              question: parsedRequest.question,
+            },
+            chatDependencies,
+          )
+        : await continueFollowUpConversation(
+            {
+              reportCard: parsedRequest.reportCard,
+              conversationId: parsedRequest.conversationId,
+              question: parsedRequest.question,
+            },
+            chatDependencies,
+          );
+
+    return responseForResult(result);
+  } catch (error) {
+    if (error instanceof FollowUpAnswerValidationError) {
+      return jsonError(502, {
+        code: "follow-up-answer-malformed",
+        message: "Follow-up answer could not be validated.",
+        issues: error.issues,
+      });
+    }
+
+    if (error instanceof FollowUpProviderError) {
+      return jsonError(502, {
+        code: error.code,
+        message: error.message,
+        ...(error.status === undefined ? {} : { status: error.status }),
+      });
+    }
+
+    if (error instanceof z.ZodError) {
+      return jsonError(502, {
+        code: "follow-up-answer-malformed",
+        message: "Follow-up answer could not be validated.",
+        issues: error.issues.map(toApiValidationIssue),
+      });
+    }
+
+    return jsonError(500, {
+      code: "internal-error",
+      message: "Follow-up answer failed unexpectedly.",
+    });
+  }
+}
+
+function responseForResult(result: FollowUpChatResult): Response {
+  switch (result.kind) {
+    case "conversation":
+      return Response.json({
+        conversation: result.conversation,
+        answer: result.answer,
+        answerText: result.answer.answer.summary,
+        evidence: result.evidence,
+      });
+    case "invalid-target":
+      return jsonError(404, {
+        code: "invalid-target",
+        message: "Follow-up target could not be resolved.",
+        reason: result.reason,
+        targetId: result.targetId,
+      });
+    case "conversation-not-found":
+      return jsonError(404, {
+        code: "conversation-not-found",
+        message: "Follow-up conversation could not be found.",
+        conversationId: result.conversationId,
+      });
+  }
+}
+
+function targetSelectorFor(
+  request: FollowUpRequest,
+): ConversationTargetSelector {
+  if (request.target !== undefined) {
+    if (isRedSectionTarget(request.target)) {
+      return targetSelectorForRedSection(request.target.sectionId);
+    }
+
+    return request.target;
+  }
+
+  if (request.section !== undefined) {
+    return targetSelectorForRedSection(request.section.id);
+  }
+
+  return { kind: "report" };
+}
+
+function isRedSectionTarget(
+  target: ConversationTargetSelector | z.infer<typeof RedSectionTargetSchema>,
+): target is z.infer<typeof RedSectionTargetSchema> {
+  return target.kind === "section" || target.kind === "report-section";
+}
+
+function targetSelectorForRedSection(
+  sectionId: z.infer<typeof RedSectionIdSchema>,
+): ConversationTargetSelector {
+  switch (sectionId) {
+    case "maintainability":
+      return {
+        kind: "dimension",
+        dimension: "maintainability",
+      };
+    case "testing":
+      return {
+        kind: "dimension",
+        dimension: "verifiability",
+      };
+    case "security":
+      return {
+        kind: "dimension",
+        dimension: "security",
+      };
+    case "architecture":
+      return {
+        kind: "dimension",
+        dimension: "architecture-boundaries",
+      };
+    case "documentation":
+      return {
+        kind: "dimension",
+        dimension: "documentation",
+      };
+  }
+}
+
+function chatDependenciesFor(
+  dependencies: FollowUpRouteDependencies,
+  options: FollowUpRouteOptions,
+): FollowUpChatDependencies {
+  return {
+    conversationRepository: dependencies.conversationRepository,
+    chatReviewer: dependencies.createChatReviewer(options),
+    ...(dependencies.contentSource === undefined
+      ? {}
+      : { contentSource: dependencies.contentSource }),
+    ...(dependencies.now === undefined ? {} : { now: dependencies.now }),
+    ...(dependencies.createId === undefined
+      ? {}
+      : { createId: dependencies.createId }),
+  };
+}
+
+function openRouterRouteOptions(
+  request: FollowUpRequest,
+  apiKey: string,
+): FollowUpRouteOptions {
+  return {
+    openRouterConfig: {
+      provider: "openrouter",
+      apiKey,
+      model: request.model ?? OpenRouterDefaultModelId,
+      baseUrl: OpenRouterDefaultBaseUrl,
+    },
+  };
+}
+
+async function readRequestBody(request: Request): Promise<
+  | {
+      readonly kind: "body";
+      readonly body: unknown;
+    }
+  | {
+      readonly kind: "invalid-json";
+    }
+> {
+  try {
+    const body: unknown = await request.json();
+    return {
+      kind: "body",
+      body,
+    };
+  } catch {
+    return {
+      kind: "invalid-json",
+    };
+  }
+}
+
+function normalizeOptionalText(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue === "" ? undefined : trimmedValue;
+}
+
+function toApiValidationIssue(issue: z.core.$ZodIssue): ApiValidationIssue {
+  return {
+    path: issue.path.map((segment) =>
+      typeof segment === "number" ? segment : String(segment),
+    ),
+    message: issue.message,
+  };
+}
+
+function jsonError(status: number, error: object): Response {
+  return Response.json(
+    {
+      error,
+    },
+    {
+      status,
+    },
+  );
+}

--- a/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
+++ b/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
@@ -54,6 +54,9 @@ export type OpenRouterChatReviewerOptions = {
   readonly now?: () => Date;
 };
 
+const DefaultFollowUpMaxOutputTokens = 1_200;
+const DefaultFollowUpTemperature = 0.2;
+
 const ProviderChatAnswerResponseSchema = z
   .object({
     answer: ChatAnswerSchema,
@@ -73,7 +76,7 @@ export class OpenRouterChatReviewer implements ChatReviewer {
     this.chatProvider =
       options.chatProvider ?? new OpenRouterChatCompletionProvider();
     this.config = options.config;
-    this.controls = options.controls;
+    this.controls = chatControls(options.controls);
     this.now = options.now ?? (() => new Date());
   }
 
@@ -148,6 +151,17 @@ export class OpenRouterChatReviewer implements ChatReviewer {
 
     return parsedContract.data;
   }
+}
+
+function chatControls(
+  controls: OpenRouterChatCompletionControls | undefined,
+): OpenRouterChatCompletionControls {
+  return {
+    maxOutputTokens:
+      controls?.maxOutputTokens ?? DefaultFollowUpMaxOutputTokens,
+    responseFormat: controls?.responseFormat ?? "json_object",
+    temperature: controls?.temperature ?? DefaultFollowUpTemperature,
+  };
 }
 
 type JsonParseResult =

--- a/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
+++ b/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
@@ -1,0 +1,224 @@
+import { z } from "zod";
+
+import {
+  ChatAnswerSchema,
+  ChatAnswerContractSchema,
+  type ChatAnswerContract,
+} from "../../domain/chat/chat-answer";
+import type {
+  ChatReviewer,
+  ChatReviewerRequest,
+} from "../../application/follow-up-chat/follow-up-chat";
+import {
+  type OpenRouterChatCompletionControls,
+  OpenRouterChatCompletionProvider,
+  type OpenRouterProviderFailureCode,
+} from "../llm/openrouter-chat-provider";
+import type { OpenRouterProviderConfig } from "../llm/openrouter-config";
+
+export type FollowUpValidationIssue = {
+  readonly path: readonly (string | number)[];
+  readonly message: string;
+};
+
+export class FollowUpAnswerValidationError extends Error {
+  readonly issues: readonly FollowUpValidationIssue[];
+
+  constructor(issues: readonly FollowUpValidationIssue[]) {
+    super("Follow-up answer could not be validated.");
+    this.name = "FollowUpAnswerValidationError";
+    this.issues = issues;
+  }
+}
+
+export class FollowUpProviderError extends Error {
+  readonly code: OpenRouterProviderFailureCode;
+  readonly status: number | undefined;
+
+  constructor(
+    code: OpenRouterProviderFailureCode,
+    message: string,
+    status?: number,
+  ) {
+    super(message);
+    this.name = "FollowUpProviderError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export type OpenRouterChatReviewerOptions = {
+  readonly chatProvider?: Pick<OpenRouterChatCompletionProvider, "complete">;
+  readonly config: OpenRouterProviderConfig;
+  readonly controls?: OpenRouterChatCompletionControls;
+  readonly now?: () => Date;
+};
+
+const ProviderChatAnswerResponseSchema = z
+  .object({
+    answer: ChatAnswerSchema,
+  })
+  .strict();
+
+export class OpenRouterChatReviewer implements ChatReviewer {
+  private readonly chatProvider: Pick<
+    OpenRouterChatCompletionProvider,
+    "complete"
+  >;
+  private readonly config: OpenRouterProviderConfig;
+  private readonly controls: OpenRouterChatCompletionControls | undefined;
+  private readonly now: () => Date;
+
+  constructor(options: OpenRouterChatReviewerOptions) {
+    this.chatProvider =
+      options.chatProvider ?? new OpenRouterChatCompletionProvider();
+    this.config = options.config;
+    this.controls = options.controls;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async answer(request: ChatReviewerRequest): Promise<ChatAnswerContract> {
+    const result = await this.chatProvider.complete({
+      config: this.config,
+      metadata: {
+        usageContext: "follow-up-answer",
+        repository: repositoryLabel(request),
+      },
+      messages: [
+        {
+          role: "system",
+          content: systemPrompt(),
+        },
+        {
+          role: "user",
+          content: JSON.stringify(promptContext(request)),
+        },
+        ...request.conversation.messages.map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+      ],
+      ...(this.controls === undefined ? {} : { controls: this.controls }),
+    });
+
+    if (result.kind === "provider-failure") {
+      throw new FollowUpProviderError(
+        result.code,
+        followUpProviderMessage(result.userFacingCaveat),
+        result.status,
+      );
+    }
+
+    const parsedJson = parseJson(result.content);
+    if (!parsedJson.success) {
+      throw new FollowUpAnswerValidationError([
+        {
+          path: [],
+          message: "Follow-up answer response was not valid JSON.",
+        },
+      ]);
+    }
+
+    const parsedAnswer = ProviderChatAnswerResponseSchema.safeParse(
+      parsedJson.value,
+    );
+    if (!parsedAnswer.success) {
+      throw new FollowUpAnswerValidationError(
+        parsedAnswer.error.issues.map(toValidationIssue),
+      );
+    }
+
+    const parsedContract = ChatAnswerContractSchema.safeParse({
+      answer: parsedAnswer.data.answer,
+      metadata: {
+        provider: "openrouter",
+        modelName: result.model,
+        ...(result.rawResponseId === undefined
+          ? {}
+          : { responseId: result.rawResponseId }),
+        generatedAt: this.now().toISOString(),
+      },
+    });
+
+    if (!parsedContract.success) {
+      throw new FollowUpAnswerValidationError(
+        parsedContract.error.issues.map(toValidationIssue),
+      );
+    }
+
+    return parsedContract.data;
+  }
+}
+
+type JsonParseResult =
+  | {
+      readonly success: true;
+      readonly value: unknown;
+    }
+  | {
+      readonly success: false;
+    };
+
+function systemPrompt(): string {
+  return [
+    "You answer follow-up questions about a repository quality report.",
+    "Return JSON only matching the chat-answer contract.",
+    "Cite evidence references for every evidence-backed claim.",
+    "Use insufficient-context when snippets or report context cannot support an answer.",
+  ].join(" ");
+}
+
+function promptContext(request: ChatReviewerRequest) {
+  return {
+    reportCard: request.reportCard,
+    target: request.target,
+    question: request.question,
+    evidence: request.evidence,
+    responseShape: {
+      answer: {
+        schemaVersion: "chat-answer.v1",
+        status: "answered | insufficient-context",
+      },
+    },
+  };
+}
+
+function repositoryLabel(request: ChatReviewerRequest): string {
+  const repository = request.reportCard.repository;
+  const ownerPrefix =
+    repository.owner === undefined ? "" : `${repository.owner}/`;
+  const revisionSuffix =
+    repository.revision === undefined ? "" : ` @ ${repository.revision}`;
+
+  return `${repository.provider}:${ownerPrefix}${repository.name}${revisionSuffix}`;
+}
+
+function parseJson(content: string): JsonParseResult {
+  try {
+    return {
+      success: true,
+      value: JSON.parse(content),
+    };
+  } catch {
+    return {
+      success: false,
+    };
+  }
+}
+
+function toValidationIssue(issue: z.core.$ZodIssue): FollowUpValidationIssue {
+  return {
+    path: issue.path.filter(
+      (segment): segment is string | number =>
+        typeof segment === "string" || typeof segment === "number",
+    ),
+    message: issue.message,
+  };
+}
+
+function followUpProviderMessage(message: string): string {
+  return message.replace(
+    "OpenRouter reviewer output",
+    "OpenRouter follow-up answer",
+  );
+}

--- a/test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts
+++ b/test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ChatAnswerSchemaVersion,
+  type ChatAnswer,
+} from "../../../src/domain/chat/chat-answer";
+import {
+  ConversationSchemaVersion,
+  type Conversation,
+} from "../../../src/domain/chat/conversation";
+import type { RetrieveEvidenceForFollowUpResult } from "../../../src/domain/chat/evidence-retrieval";
+import type { EvidenceReference } from "../../../src/domain/shared/evidence-reference";
+import type { OpenRouterChatCompletionProvider } from "../../../src/infrastructure/llm/openrouter-chat-provider";
+import {
+  OpenRouterDefaultBaseUrl,
+  OpenRouterDefaultModelId,
+} from "../../../src/infrastructure/llm/openrouter-config";
+import { OpenRouterChatReviewer } from "../../../src/infrastructure/reviewer/openrouter-chat-reviewer";
+import { analyzeRepositoryResponseFixture } from "../../support/analyze-repository-response-fixture";
+
+const reportCard = analyzeRepositoryResponseFixture.reportCard;
+
+const packageEvidence: EvidenceReference = {
+  id: "evidence:package-json",
+  kind: "file",
+  label: "Package manifest",
+  path: "package.json",
+};
+
+describe("OpenRouterChatReviewer", () => {
+  it("requests structured JSON output with follow-up-safe defaults", async () => {
+    const completionRequests: Parameters<
+      OpenRouterChatCompletionProvider["complete"]
+    >[0][] = [];
+    const reviewer = new OpenRouterChatReviewer({
+      chatProvider: {
+        complete: async (completionRequest) => {
+          completionRequests.push(completionRequest);
+          return {
+            kind: "completed",
+            provider: "openrouter",
+            model: OpenRouterDefaultModelId,
+            content: JSON.stringify({ answer: answeredChatAnswer() }),
+            rawResponseId: "completion:follow-up",
+          };
+        },
+      },
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: OpenRouterDefaultBaseUrl,
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const answer = await reviewer.answer({
+      reportCard,
+      conversation: conversation(),
+      target: { kind: "report" },
+      question: "What should we verify first?",
+      evidence: evidenceResult(),
+    });
+
+    expect(answer.metadata).toEqual({
+      provider: "openrouter",
+      modelName: OpenRouterDefaultModelId,
+      responseId: "completion:follow-up",
+      generatedAt: "2026-04-26T19:00:00.000Z",
+    });
+    expect(completionRequests[0]?.controls).toEqual({
+      maxOutputTokens: 1_200,
+      responseFormat: "json_object",
+      temperature: 0.2,
+    });
+    expect(completionRequests[0]?.metadata).toEqual({
+      usageContext: "follow-up-answer",
+      repository: "local-fixture:minimal-node-library @ fixture",
+    });
+  });
+
+  it("keeps caller-provided output budget and temperature while enforcing JSON mode", async () => {
+    const completionRequests: Parameters<
+      OpenRouterChatCompletionProvider["complete"]
+    >[0][] = [];
+    const reviewer = new OpenRouterChatReviewer({
+      chatProvider: {
+        complete: async (completionRequest) => {
+          completionRequests.push(completionRequest);
+          return {
+            kind: "completed",
+            provider: "openrouter",
+            model: OpenRouterDefaultModelId,
+            content: JSON.stringify({ answer: answeredChatAnswer() }),
+          };
+        },
+      },
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: OpenRouterDefaultBaseUrl,
+      },
+      controls: {
+        maxOutputTokens: 900,
+        temperature: 0.25,
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    await reviewer.answer({
+      reportCard,
+      conversation: conversation(),
+      target: { kind: "report" },
+      question: "What should we verify first?",
+      evidence: evidenceResult(),
+    });
+
+    expect(completionRequests[0]?.controls).toEqual({
+      maxOutputTokens: 900,
+      responseFormat: "json_object",
+      temperature: 0.25,
+    });
+  });
+});
+
+function conversation(): Conversation {
+  const timestamp = "2026-04-26T19:00:00.000Z";
+  return {
+    id: "conversation:1",
+    schemaVersion: ConversationSchemaVersion,
+    reportCardId: reportCard.id,
+    repository: reportCard.repository,
+    target: { kind: "report" },
+    messages: [
+      {
+        id: "message:1",
+        role: "user",
+        content: "What should we verify first?",
+        citations: [],
+        assumptions: [],
+        createdAt: timestamp,
+      },
+    ],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function evidenceResult(): RetrieveEvidenceForFollowUpResult {
+  return {
+    snippets: [
+      {
+        evidenceReference: packageEvidence,
+        text: '"test": "vitest"',
+        source: "fresh-content",
+        targetRelevance: "report",
+        rank: 100,
+      },
+    ],
+    missingContext: [],
+  };
+}
+
+function answeredChatAnswer(): ChatAnswer {
+  return {
+    schemaVersion: ChatAnswerSchemaVersion,
+    status: "answered",
+    summary: "package.json defines a Vitest test script.",
+    evidenceBackedClaims: [
+      {
+        claim: "The package manifest includes a test script.",
+        citations: [
+          {
+            evidenceReference: packageEvidence,
+            quote: '"test": "vitest"',
+          },
+        ],
+      },
+    ],
+    assumptions: [],
+    caveats: [],
+    suggestedNextQuestions: [],
+  };
+}


### PR DESCRIPTION
## Summary

- Add `POST /api/follow-up` over the follow-up chat application service with Zod validation for report cards, red-style section targets, conversation ids, messages, questions, API keys, and model ids.
- Add an OpenRouter chat reviewer adapter for live evidence-backed follow-up answers, including structured JSON-mode defaults.
- Cover start/continue flows, invalid targets, missing conversations, malformed model output, provider failures, missing evidence, and request validation with fake reviewers/content sources.

Closes #120

## Verification

- `npx -y node@24 $(command -v pnpm) exec vitest run src/app/api/follow-up/route.test.ts test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts src/application/follow-up-chat/follow-up-chat.test.ts src/domain/chat/chat-answer.test.ts src/domain/chat/conversation-target-resolver.test.ts test/infrastructure/llm/openrouter-chat-provider.test.ts`
- `npx -y node@24 $(command -v pnpm) check`
- `npx -y node@24 $(command -v pnpm) build`
- `npx -y node@24 $(command -v pnpm) test:e2e`

## Notes

This route intentionally returns `openrouter-api-key-required` when no key is supplied for live follow-up. The red-style slideout UI wiring remains tracked by #121.