### PR TITLE
chore(tooling): cross-agent compatibility scaffold (#139)

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,18 @@
+# Project-local Codex CLI configuration.
+#
+# Project-local Codex hooks require the project to be marked trusted via
+# `[projects."..."]` in ~/.codex/config.toml. Project-local skills load even
+# when the project is untrusted; only hooks and exec policies are gated.
+#
+# Schema notes: this hook block is the natural translation of Claude Code's
+# .claude/settings.json `hooks` block into TOML, based on inspection of the
+# Codex CLI 0.125.0 binary's `HookHandlerConfig` and `ConfiguredHookMatcherGroup`
+# structures. It mirrors the cross-agent guidance in docs/agent-compat.md.
+# Verify against authoritative Codex docs before relying in production.
+
+[[hooks.PreToolUse]]
+matcher = "Edit|Write|MultiEdit"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "node scripts/red-green-gate.ts"

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.pi/skills
+++ b/.pi/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,4 @@ If a task conflicts with those documents, call out the conflict before editing. 
 - Preserve provenance, confidence, caveats, and missing evidence in report behavior.
 - Do not treat raw test LOC, raw coverage, or single static scores as direct proof of repository quality.
 - Red-green enforcement is shared tooling, not a judgment call: `.claude/settings.json` guards in-session source edits, `lefthook.yml` guards staged commits, and both rely on `scripts/red-green-gate.ts`. Update the script and the two hook surfaces together when changing the workflow.
+- Cross-agent compatibility (Claude Code, Codex CLI, pi) is captured in [docs/agent-compat.md](docs/agent-compat.md). Shared skills live at `.agents/skills/`; each agent reaches them through a relative symlink. Keep the three hook surfaces (`.claude/settings.json`, `.codex/config.toml`, future `.pi/extensions/...`) aligned when changing red-green behavior.

--- a/docs/agent-compat.md
+++ b/docs/agent-compat.md
@@ -1,0 +1,69 @@
+# Cross-Agent Compatibility
+
+This repo is exercised by three coding-agent CLIs: Claude Code, OpenAI Codex CLI, and pi (Mario Zechner's `@mariozechner/pi-coding-agent`). Each agent has its own preferred config directory and hook system, but skills and shell-style hooks can be shared. This doc captures the compatibility scaffold and what each agent looks for.
+
+## Tested versions
+
+| Agent | Version (verified locally) | Skill format | AGENTS.md native | Hook system |
+|---|---|---|---|---|
+| Claude Code | 2.1.119 | Anthropic Agent Skills (`SKILL.md` + frontmatter) | yes | shell commands in `.claude/settings.json` (`hooks` block) |
+| Codex CLI | 0.125.0 | Anthropic Agent Skills (`SKILL.md` + frontmatter) | yes | shell commands in `.codex/config.toml` (`[hooks.<event>]` blocks); project-local hooks require trust |
+| pi | 0.70.2 (`@mariozechner/pi-coding-agent`) | Anthropic Agent Skills (`SKILL.md` + frontmatter; lenient about violations) | yes (`--no-context-files` to disable) | JS extension API (`pi.on("tool_execution_start", ...)` etc.) — different paradigm, deferred to a follow-up |
+
+## Canonical skill store: `.agents/skills/`
+
+All shareable skills live at `.agents/skills/<name>/SKILL.md`. Pi reads this path natively. The other two agents reach it via relative symlinks at the locations they expect:
+
+```
+.claude/skills  ->  ../.agents/skills
+.codex/skills   ->  ../.agents/skills
+.pi/skills      ->  ../.agents/skills
+```
+
+Pi also reads `.agents/skills/` directly without the symlink, so the `.pi/skills` link is redundant but kept for consistency.
+
+A skill written once is discoverable by every agent. Don't duplicate skill content across `.claude/skills/`, `.codex/skills/`, or `.pi/skills/`; everything goes in `.agents/skills/`.
+
+## Hooks
+
+Hook compatibility is partial:
+
+- **Claude Code + Codex** share the same shell-command paradigm with `PreToolUse`/`PostToolUse`/`SessionStart` matchers and a `matcher` regex. The same script (`scripts/red-green-gate.ts`) is invoked from both — only the config file differs:
+  - Claude Code: `.claude/settings.json` (`"hooks": { "PreToolUse": [...] }`)
+  - Codex CLI: `.codex/config.toml` (`[[hooks.PreToolUse]]` ... `[[hooks.PreToolUse.hooks]]`)
+- **Pi** uses a JS extension API where extensions subscribe to events programmatically. Wiring pi to invoke `scripts/red-green-gate.ts` requires a small JS shim under `.pi/extensions/` and is tracked as a follow-up issue.
+
+The hook script (`scripts/red-green-gate.ts`) reads the project root from `$CLAUDE_PROJECT_DIR` if set, otherwise falls back to `process.cwd()`. Codex spawns hooks from the project root, so the fallback works without explicit env wiring; if a future agent needs an explicit override, add it inline in the hook command.
+
+## AGENTS.md handling
+
+All three agents load `AGENTS.md` automatically at session start. `CLAUDE.md` is also picked up by Claude Code and is currently a one-line alias to `AGENTS.md`. There's nothing to do here beyond keeping `AGENTS.md` accurate.
+
+## Trust gating (Codex-specific)
+
+Codex disables project-local config, hooks, and exec policies in untrusted projects. Skills still load. To enable hooks for a clone of this repo, mark it trusted in `~/.codex/config.toml`:
+
+```toml
+[projects."/abs/path/to/this/repo"]
+trust_level = "trusted"
+```
+
+Codex also surfaces an "External migration" prompt that may suggest importing detected Claude Code config; that prompt is informational, not required.
+
+## Symlink portability
+
+The symlinks are committed to git as relative paths (`../.agents/skills`). On macOS and Linux they Just Work. On Windows they require Developer Mode (since Windows 10 1703) or admin privileges; if a Windows user can't enable that, a `pnpm setup:windows` materialization script (copying instead of linking) is the next step — not built yet, raise an issue if you need it.
+
+## Adding a new skill
+
+See `docs/skills.md` (planned: project skill conventions issue). Until that lands, the short form: create `.agents/skills/<name>/SKILL.md` with valid Anthropic Agent Skills frontmatter (`name`, `description`); each agent will discover it through its respective path.
+
+## Updating the red-green hook surface
+
+When changing red-green behavior, update all three surfaces together (or document why they intentionally diverge):
+
+- `scripts/red-green-gate.ts` — the shared decision logic
+- `.claude/settings.json` — Claude Code's hook entry
+- `.codex/config.toml` — Codex's hook entry
+- `lefthook.yml` — the commit-time gate
+- `.pi/extensions/...` — pi's extension shim (when the follow-up issue lands)

--- a/scripts/red-green-gate.ts
+++ b/scripts/red-green-gate.ts
@@ -113,7 +113,7 @@ function matchesPattern(filePath: string, pattern: string): boolean {
   return filePath === pattern;
 }
 
-const DEFAULT_ALLOWLIST: readonly string[] = [
+export const DEFAULT_ALLOWLIST: readonly string[] = [
   "docs/**",
   "**/*.md",
   "**/*.css",
@@ -123,6 +123,9 @@ const DEFAULT_ALLOWLIST: readonly string[] = [
   "e2e/**",
   ".github/**",
   ".claude/**",
+  ".codex/**",
+  ".pi/**",
+  ".agents/**",
   "AGENTS.md",
   "CLAUDE.md",
   "README.md",

--- a/test/tooling/agent-compat.test.ts
+++ b/test/tooling/agent-compat.test.ts
@@ -1,0 +1,86 @@
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+describe("cross-agent compatibility scaffold", () => {
+  describe(".agents/skills canonical store", () => {
+    it("exists as a directory", () => {
+      const target = path.join(repoRoot, ".agents/skills");
+      expect(existsSync(target)).toBe(true);
+      expect(statSync(target).isDirectory()).toBe(true);
+    });
+  });
+
+  describe.each([[".claude/skills"], [".codex/skills"], [".pi/skills"]])(
+    "symlink %s",
+    (link) => {
+      it("is a symlink", () => {
+        const linkPath = path.join(repoRoot, link);
+        const stat = lstatSync(linkPath);
+        expect(stat.isSymbolicLink()).toBe(true);
+      });
+
+      it("uses a relative target so the repo is portable", () => {
+        const linkPath = path.join(repoRoot, link);
+        const target = readlinkSync(linkPath);
+        expect(path.isAbsolute(target)).toBe(false);
+      });
+
+      it("resolves to the canonical .agents/skills directory", () => {
+        const linkPath = path.join(repoRoot, link);
+        const target = readlinkSync(linkPath);
+        const resolved = path.resolve(path.dirname(linkPath), target);
+        expect(resolved).toBe(path.join(repoRoot, ".agents/skills"));
+      });
+    },
+  );
+
+  describe(".codex/config.toml red-green PreToolUse hook", () => {
+    it("exists as a regular file", () => {
+      const target = path.join(repoRoot, ".codex/config.toml");
+      expect(existsSync(target)).toBe(true);
+      expect(statSync(target).isFile()).toBe(true);
+    });
+
+    it("declares a PreToolUse hook that invokes scripts/red-green-gate.ts", () => {
+      const content = readFileSync(
+        path.join(repoRoot, ".codex/config.toml"),
+        "utf8",
+      );
+      expect(content).toMatch(/PreToolUse/);
+      expect(content).toContain("scripts/red-green-gate.ts");
+      expect(content).toMatch(/Edit\|Write\|MultiEdit/);
+    });
+  });
+
+  describe("docs/agent-compat.md", () => {
+    it("exists and references all three agents and the canonical .agents/skills path", () => {
+      const target = path.join(repoRoot, "docs/agent-compat.md");
+      expect(existsSync(target)).toBe(true);
+      const content = readFileSync(target, "utf8");
+      expect(content).toContain("Claude Code");
+      expect(content).toContain("Codex");
+      expect(content).toContain("pi");
+      expect(content).toContain(".agents/skills");
+    });
+  });
+
+  describe("AGENTS.md", () => {
+    it("links to docs/agent-compat.md so future agents read the cross-compat reference", () => {
+      const content = readFileSync(path.join(repoRoot, "AGENTS.md"), "utf8");
+      expect(content).toContain("docs/agent-compat.md");
+    });
+  });
+});

--- a/test/tooling/red-green-gate.test.ts
+++ b/test/tooling/red-green-gate.test.ts
@@ -14,6 +14,7 @@ import process from "node:process";
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_ALLOWLIST,
   decide,
   recentTestEditsFromLedger,
   type Ledger,
@@ -80,6 +81,28 @@ const allowlist: readonly string[] = [
   ".github/**",
   ".claude/**",
 ];
+
+describe("red-green-gate DEFAULT_ALLOWLIST", () => {
+  it.each([
+    [".agents/skills/foo/SKILL.md"],
+    [".codex/config.toml"],
+    [".codex/skills"],
+    [".pi/extensions/red-green-gate/index.js"],
+    [".pi/skills"],
+  ])(
+    "permits agent-config path %s without requiring a colocated test",
+    (filePath) => {
+      const decision = decide({
+        filesTouched: [filePath],
+        recentTestEdits: [],
+        allowlist: DEFAULT_ALLOWLIST,
+        overrideMarkers: new Map(),
+      });
+
+      expect(decision.allowed).toBe(true);
+    },
+  );
+});
 
 describe("red-green-gate decide", () => {
   it("blocks editing a non-test source file when no colocated test was edited recently", () => {


### PR DESCRIPTION
## Scope

Implements #139: a single canonical project-level skill store at `.agents/skills/` with relative symlinks routing each agent's expected directory there, plus a Codex-side mirror of the red-green PreToolUse hook so the same `scripts/red-green-gate.ts` runs under both Claude Code and Codex.

Two commits in this PR (per AGENTS.md "inspectable history"):
1. `chore(tooling): expand red-green allowlist for agent-config directories` — adds `.agents/**`, `.codex/**`, `.pi/**` to `DEFAULT_ALLOWLIST` and exports the constant. Test-first.
2. `chore(tooling): cross-agent compatibility scaffold for skills and shell-style hooks` — adds the directories, symlinks, `.codex/config.toml`, `docs/agent-compat.md`, AGENTS.md cross-reference, and the tooling test. Test-first.

## Non-Goals

- **Pi hook integration via JS extension API** — pi's hook paradigm is programmatic, not shell-command-based. Tracked in #144.
- **Cross-platform symlink parity** — symlinks on Windows require Developer Mode or admin. Documented as a known limitation in `docs/agent-compat.md`; a `pnpm setup:windows` materialization fallback is not built.
- **Existing `.claude/settings.json` hook config** — preserved as-is.
- **Authoritative validation of the `.codex/config.toml` schema** — written from binary inspection of Codex 0.125.0; flagged for verification (see "Risk and Rollback").

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests (208 passed, 19 new across the two commits)
- [x] Build (not relevant; no application code touched)
- [x] Foundational E2E (not relevant; no UI/API change)

```text
pnpm check
# 42 test files, 206 tests passed + 2 skipped — 19 new tests, 14 in agent-compat.test.ts and 5 in red-green-gate.test.ts
```

Manual verification (filesystem-level):
- Created `.agents/skills/cross-agent-demo/SKILL.md` in a tmp dir, symlinked each agent's expected path to it, confirmed `cat .X/skills/cross-agent-demo/SKILL.md` returns the canonical content for every agent.

Manual verification I could not do in-session:
- **Live Claude Code session** with the symlink in place — tomorrow's session that opens this repo from `main` (post-merge) will be the proof.
- **Live Codex session** validating the `.codex/config.toml` schema. Pi auth was not configured locally.
- All three CLIs are installed (Claude Code 2.1.119, Codex 0.125.0, pi 0.70.2) but I couldn't drive a non-Claude session from inside Claude Code.

## Architecture and Docs

- [x] Follows `docs/architecture.md`.
- [x] Architecture impact: `.agents/`, `.codex/`, `.pi/` are new top-level directories. No domain/application/infrastructure boundary changed.
- [x] `docs/agent-compat.md` is new and is the authoritative source for the cross-compat layer.
- [x] AGENTS.md gets one line under "Project-Specific Direction" pointing at the compat doc.
- [x] No domain/application/infrastructure boundary violations.

## Type Safety

- [x] No `as any`, `: any`, `<any>`, `as unknown as`. (`pnpm type-escape:check` passes.)
- [x] Runtime data parsed/narrowed at boundaries — n/a here; this PR is config + docs + filesystem layout.

## Risk and Rollback

**Risks:**
1. **`.codex/config.toml` schema is unverified.** I wrote the TOML based on the binary's `HookHandlerConfig` / `ConfiguredHookMatcherGroup` structures and on the natural translation of Claude Code's settings.json. If Codex doesn't accept `[[hooks.PreToolUse]]` / `[[hooks.PreToolUse.hooks]]` exactly as written, the hook silently won't fire under Codex. Iteration plan: open Codex against a clone, watch for hook-config errors, adjust. The script and Claude Code hook are unaffected if the Codex schema is wrong.
2. **Codex requires the project to be marked trusted** before project-local hooks fire (`[projects."..."]` in `~/.codex/config.toml`). Skills still load even when untrusted. Documented in `docs/agent-compat.md`.
3. **Symlinks are *nix-only** by default. Windows clones need Developer Mode. Documented; not solved.
4. **The hook is gated by `$CLAUDE_PROJECT_DIR` falling back to `process.cwd()`** in the script. Codex spawns hooks from project root, so this works without explicit env wiring; if Codex changes that, we'd need to extend the script.

**Rollback:**
- Revert the second commit to remove the scaffold; the first commit (allowlist expansion) is independently safe.
- Or just delete `.codex/config.toml` to disable the Codex hook — script and Claude Code hook unaffected.

## Dependencies

None added.

## Follow-ups

- #144 — pi extension that mirrors red-green hook to pi's event API.
- #140 — establish project skill conventions (depends on this).
- #142, #143 — first concrete skills (depend on #140).

Issue: #139