### PR TITLE
refactor(ui): match red visual design and responsive polish

### DIFF
--- a/e2e/red-ui-parity.spec.ts
+++ b/e2e/red-ui-parity.spec.ts
@@ -13,6 +13,19 @@ test.describe("red UI/UX parity", () => {
   test("matches the red first-screen analysis workflow", async ({ page }) => {
     await page.goto("/");
 
+    await expect(page.locator("body")).toHaveCSS(
+      "background-color",
+      "rgb(246, 245, 241)",
+    );
+    await expect(page.locator("body")).toHaveCSS("font-family", /Geist/);
+    await expect(page.locator("main").first()).toHaveCSS(
+      "background-color",
+      "rgb(246, 245, 241)",
+    );
+    await expect(page.locator("section").first()).toHaveCSS(
+      "background-color",
+      "rgb(251, 250, 247)",
+    );
     await expect(
       page.getByText("Repository Quality", { exact: true }),
     ).toBeVisible();
@@ -21,7 +34,19 @@ test.describe("red UI/UX parity", () => {
     ).toBeVisible();
     await expect(page.getByLabel("GitHub repository URL")).toBeVisible();
     await expect(page.getByLabel("OpenRouter API key")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Analyze" })).toBeVisible();
+    await expect(
+      page.getByTestId("repo-url-control").locator("svg"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("api-key-control").locator("svg"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Analyze" }).locator("svg"),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Analyze" })).toHaveCSS(
+      "background-color",
+      "rgb(17, 17, 17)",
+    );
 
     await page.getByText("Advanced", { exact: true }).click();
     await expect(page.getByLabel("OpenRouter Model")).toBeVisible();
@@ -73,6 +98,8 @@ test.describe("red UI/UX parity", () => {
       const panel = page.locator("article").filter({
         has: page.getByRole("heading", { name: section }),
       });
+      await expect(panel).toHaveCSS("background-color", "rgb(255, 255, 255)");
+      await expect(panel).toHaveCSS("border-color", "rgb(216, 210, 197)");
       await expect(panel.getByRole("heading", { name: section })).toBeVisible();
       await expect(panel.getByText("Signals", { exact: true })).toBeVisible();
       await expect(
@@ -112,8 +139,14 @@ test.describe("red UI/UX parity", () => {
     await expect(
       page.getByRole("heading", { name: "What should we fix first?" }),
     ).toBeVisible();
-    await expect(page.getByText("Conversations")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Conversations" }),
+    ).toBeVisible();
     await expect(page.getByText("Searches matching repo files")).toBeVisible();
+    await expect(page.getByRole("complementary")).toHaveCSS(
+      "background-color",
+      "rgb(251, 250, 247)",
+    );
 
     await page.getByRole("button", { name: "Close chat" }).click();
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.0",
+    "lucide-react": "^1.11.0",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.0
         version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
+      lucide-react:
+        specifier: ^1.11.0
+        version: 1.11.0(react@19.2.5)
       next:
         specifier: ^16.0.0
         version: 16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1071,6 +1074,11 @@ packages:
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
+
+  lucide-react@1.11.0:
+    resolution: {integrity: sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -2149,6 +2157,10 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lru-cache@11.3.5: {}
+
+  lucide-react@1.11.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   lz-string@1.5.0: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,14 +1,77 @@
 @import "tailwindcss";
 
 :root {
+  --background: #f6f5f1;
+  --foreground: #161616;
   color-scheme: light;
 }
 
 body {
   margin: 0;
-  background: #f8fafc;
-  color: #0f172a;
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
+}
+
+.markdown-body {
+  color: #3f3b35;
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+.markdown-body p + p,
+.markdown-body ul + p,
+.markdown-body ol + p {
+  margin-top: 0.75rem;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  color: #161616;
+  font-weight: 650;
+  line-height: 1.25;
+  margin-bottom: 0.5rem;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0.5rem;
+  padding-left: 1.25rem;
+}
+
+.markdown-body li + li {
+  margin-top: 0.35rem;
+}
+
+.markdown-body code {
+  border: 1px solid #d8d2c5;
+  background: #f6f5f1;
+  padding: 0.1rem 0.3rem;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.82rem;
+}
+
+.markdown-body pre {
+  overflow-x: auto;
+  border: 1px solid #d8d2c5;
+  background: #111111;
+  color: #fbfaf7;
+  padding: 0.75rem;
+}
+
+.markdown-body pre code {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.markdown-body blockquote {
+  border-left: 3px solid #146c60;
+  padding-left: 0.8rem;
+  color: #5f5b53;
 }
 
 @media print {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,16 @@
 import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+
+const geistSans = Geist({
+  subsets: ["latin"],
+  variable: "--font-geist-sans",
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
+});
 
 export const metadata: Metadata = {
   title: "Repo Analyzer Green",
@@ -13,7 +24,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/application/report-dashboard/report-dashboard-view-model.test.ts
+++ b/src/application/report-dashboard/report-dashboard-view-model.test.ts
@@ -60,7 +60,7 @@ describe("buildReportDashboardViewModel", () => {
         percentOfCode: 80,
         codeLineCount: 800,
         fileCount: 10,
-        color: "#047857",
+        color: "#146c60",
         provenance: {
           source: "language-mix",
           referenceIds: ["language-code-shape:file:src/app.ts"],
@@ -71,7 +71,7 @@ describe("buildReportDashboardViewModel", () => {
         percentOfCode: 20,
         codeLineCount: 200,
         fileCount: 2,
-        color: "#2563eb",
+        color: "#d97706",
         provenance: {
           source: "language-mix",
           referenceIds: ["language-code-shape:file:README.md"],

--- a/src/application/report-dashboard/report-dashboard-view-model.ts
+++ b/src/application/report-dashboard/report-dashboard-view-model.ts
@@ -132,7 +132,7 @@ const dashboardSections = [
   readonly sourceDimension: ReportDimensionKey;
 }[];
 
-const languageColors = ["#047857", "#2563eb", "#d97706", "#be123c", "#7c3aed"];
+const languageColors = ["#146c60", "#d97706", "#3b5bdb", "#c2410c", "#7c3aed"];
 
 export function buildReportDashboardViewModel(
   analysis: AnalyzeRepositoryResponse,

--- a/src/components/chat/follow-up-slideout.tsx
+++ b/src/components/chat/follow-up-slideout.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Loader2, MessageSquare, Send, X } from "lucide-react";
+
 import type { ChatAnswer } from "../../domain/chat/chat-answer";
 import type {
   ChatMessage,
@@ -54,51 +56,56 @@ export function FollowUpSlideout({
   }
 
   return (
-    <aside
-      aria-labelledby="follow-up-chat-title"
-      className="fixed inset-y-0 right-0 z-40 grid w-full max-w-5xl grid-rows-[auto_minmax(0,1fr)] border-l border-slate-200 bg-white shadow-2xl print:hidden lg:w-[86vw]"
-    >
-      <header className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 px-4 py-4 sm:px-5">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-blue-700">
-            Follow-up
-          </p>
-          <h2
-            id="follow-up-chat-title"
-            className="mt-1 text-xl font-semibold text-slate-950"
-          >
-            Conversations
-          </h2>
-        </div>
-        <button
-          type="button"
-          className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-          onClick={onClose}
-        >
-          Close chat
-        </button>
-      </header>
-
-      <div className="grid min-h-0 lg:grid-cols-[280px_minmax(0,1fr)]">
+    <>
+      <button
+        className="fixed inset-0 z-40 bg-black/20 print:hidden"
+        aria-label="Dismiss chat backdrop"
+        type="button"
+        onClick={onClose}
+      />
+      <aside
+        aria-labelledby="follow-up-chat-title"
+        className="fixed inset-y-0 right-0 z-50 grid w-full max-w-5xl grid-cols-1 border-l border-[#cfc9bb] bg-[#fbfaf7] shadow-2xl print:hidden md:grid-cols-[280px_minmax(0,1fr)]"
+      >
         <nav
           aria-label="Conversations"
-          className="hidden min-h-0 border-r border-slate-200 bg-slate-50 p-3 lg:block"
+          className="hidden min-h-0 border-r border-[#d8d2c5] bg-white md:block"
         >
-          <ConversationList
-            activeConversationId={activeSession?.conversation.id ?? null}
-            onSelectConversation={onSelectConversation}
-            sessions={sessions}
-          />
+          <div className="border-b border-[#e4dfd4] p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[#146c60]">
+              Conversations
+            </p>
+            <p className="mt-2 text-sm text-[#7b7468]">
+              {sessions.length} active thread{sessions.length === 1 ? "" : "s"}
+            </p>
+          </div>
+          <div className="p-3">
+            <ConversationList
+              activeConversationId={activeSession?.conversation.id ?? null}
+              onSelectConversation={onSelectConversation}
+              sessions={sessions}
+            />
+          </div>
         </nav>
 
         <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto]">
-          <div className="border-b border-slate-200 bg-slate-50 px-4 py-3 lg:hidden">
-            <label className="block">
-              <span className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
-                Conversation
-              </span>
+          <div className="flex items-start justify-between gap-4 border-b border-[#d8d2c5] bg-white p-4">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[#146c60]">
+                Follow-up
+              </p>
+              <h2
+                id="follow-up-chat-title"
+                className="mt-1 truncate text-lg font-semibold text-[#161616]"
+              >
+                Conversations
+              </h2>
+              <p className="mt-1 text-xs text-[#7b7468]">
+                Evidence-focused follow-up
+              </p>
               <select
-                className="mt-2 h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900"
+                aria-label="Conversation"
+                className="mt-3 h-10 w-full border border-[#cfc9bb] bg-[#fbfaf7] px-2 text-sm outline-none md:hidden"
                 value={activeSession?.conversation.id ?? ""}
                 onChange={(event) => onSelectConversation(event.target.value)}
               >
@@ -111,7 +118,16 @@ export function FollowUpSlideout({
                   </option>
                 ))}
               </select>
-            </label>
+            </div>
+            <button
+              type="button"
+              className="grid h-9 w-9 shrink-0 place-items-center border border-[#cfc9bb] text-[#3f3b35] transition hover:bg-[#f6f5f1]"
+              onClick={onClose}
+              title="Close chat"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Close chat</span>
+            </button>
           </div>
 
           {activeSession === null ? (
@@ -120,22 +136,22 @@ export function FollowUpSlideout({
             <ActiveThread session={activeSession} />
           )}
 
-          <div className="border-t border-slate-200 bg-white p-4">
+          <div className="border-t border-[#d8d2c5] bg-white p-4">
             {error === "" ? null : (
               <p
-                className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                className="mb-3 rounded-md border border-[#be123c] bg-[#fff1f2] px-3 py-2 text-sm text-[#9f1239]"
                 role="alert"
               >
                 {error}
               </p>
             )}
-            <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
-              <label className="block">
+            <div className="flex gap-3">
+              <label className="min-w-0 flex-1">
                 <span className="sr-only">Follow-up question</span>
                 <textarea
                   value={draft}
                   onChange={(event) => onDraftChange(event.target.value)}
-                  className="min-h-16 w-full resize-none rounded-md border border-slate-300 bg-slate-50 p-3 text-sm text-slate-900 outline-none transition focus:border-blue-500"
+                  className="min-h-14 w-full resize-none border border-[#cfc9bb] bg-[#fbfaf7] p-3 text-sm text-[#161616] outline-none focus:border-[#146c60]"
                   placeholder="Ask a follow-up about this conversation..."
                   disabled={isLoading || activeSession === null}
                 />
@@ -148,15 +164,20 @@ export function FollowUpSlideout({
                   activeSession === null ||
                   draft.trim().length === 0
                 }
-                className="rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                className="inline-flex h-14 items-center justify-center gap-2 bg-[#146c60] px-4 text-sm font-semibold text-white transition hover:bg-[#0f554b] disabled:cursor-not-allowed disabled:bg-[#8aa7a0]"
               >
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
                 {isLoading ? "Sending" : "Send"}
               </button>
             </div>
           </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+    </>
   );
 }
 
@@ -170,32 +191,53 @@ function FloatingChatMenu({
   readonly sessions: readonly BrowserFollowUpSession[];
 }) {
   return (
-    <div className="fixed bottom-4 right-4 z-30 w-[min(92vw,320px)] rounded-md border border-slate-200 bg-white p-3 shadow-xl print:hidden">
+    <div className="fixed bottom-4 right-4 z-30 print:hidden">
       <button
-        type="button"
-        className="flex w-full items-center justify-between rounded-md bg-slate-950 px-4 py-3 text-left text-sm font-semibold text-white"
+        className="flex items-center gap-2 rounded-md border border-[#cfc9bb] bg-white px-3 py-3 text-sm font-semibold text-[#25221e] shadow-lg transition hover:bg-[#f6f5f1]"
         onClick={onOpen}
+        type="button"
       >
+        <MessageSquare className="h-4 w-4 text-[#146c60]" aria-hidden="true" />
         <span>Chats</span>
-        <span>{sessions.length}</span>
+        <span className="grid h-5 min-w-5 place-items-center rounded-full bg-[#146c60] px-1 text-xs text-white">
+          {sessions.length}
+        </span>
       </button>
-      <p className="mt-3 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
-        Recent Threads
-      </p>
-      <div className="mt-2 grid gap-2">
-        {sessions.slice(0, 3).map((session) => (
+      <div className="absolute bottom-14 right-0 w-[min(320px,calc(100vw-2rem))] rounded-md border border-[#cfc9bb] bg-white p-3 shadow-xl">
+        <div className="flex items-center justify-between gap-3 border-b border-[#e4dfd4] pb-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#146c60]">
+              Recent Threads
+            </p>
+          </div>
           <button
-            key={session.conversation.id}
+            className="h-9 rounded-md bg-[#111111] px-3 text-xs font-semibold text-white transition hover:bg-[#333333]"
+            onClick={onOpen}
             type="button"
-            className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-left text-sm text-slate-800"
-            onClick={() => {
-              onSelectConversation(session.conversation.id);
-              onOpen();
-            }}
           >
-            {firstUserQuestion(session)}
+            Open
           </button>
-        ))}
+        </div>
+        <div className="mt-3 grid gap-2">
+          {sessions.slice(0, 3).map((session) => (
+            <button
+              key={session.conversation.id}
+              type="button"
+              className="rounded-md border border-[#e4dfd4] bg-[#fbfaf7] p-3 text-left transition hover:border-[#146c60] hover:bg-[#eef8f5]"
+              onClick={() => {
+                onSelectConversation(session.conversation.id);
+                onOpen();
+              }}
+            >
+              <p className="line-clamp-1 text-sm font-semibold text-[#25221e]">
+                {firstUserQuestion(session)}
+              </p>
+              <p className="mt-1 text-xs text-[#7b7468]">
+                {targetLabel(session.target)}
+              </p>
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );
@@ -212,7 +254,7 @@ function ConversationList({
 }) {
   if (sessions.length === 0) {
     return (
-      <p className="rounded-md border border-dashed border-slate-300 bg-white p-3 text-sm leading-6 text-slate-600">
+      <p className="rounded-md border border-dashed border-[#d8d2c5] bg-[#fbfaf7] p-3 text-sm leading-6 text-[#7b7468]">
         Ask a section question to start a thread.
       </p>
     );
@@ -227,14 +269,14 @@ function ConversationList({
           onClick={() => onSelectConversation(session.conversation.id)}
           className={`rounded-md border p-3 text-left transition ${
             session.conversation.id === activeConversationId
-              ? "border-blue-300 bg-blue-50"
-              : "border-slate-200 bg-white hover:bg-slate-50"
+              ? "border-[#146c60] bg-[#eef8f5]"
+              : "border-[#e4dfd4] bg-white hover:bg-[#f6f5f1]"
           }`}
         >
-          <p className="line-clamp-2 text-sm font-semibold text-slate-950">
+          <p className="line-clamp-2 text-sm font-semibold text-[#25221e]">
             {firstUserQuestion(session)}
           </p>
-          <p className="mt-1 text-xs text-slate-600">
+          <p className="mt-2 text-xs text-[#7b7468]">
             {targetLabel(session.target)}
           </p>
         </button>
@@ -245,12 +287,16 @@ function ConversationList({
 
 function EmptyThread() {
   return (
-    <div className="grid min-h-0 place-items-center bg-slate-50 p-6 text-center">
+    <div className="grid min-h-0 place-items-center bg-[#fbfaf7] p-6 text-center">
       <div>
-        <p className="text-lg font-semibold text-slate-950">
+        <MessageSquare
+          className="mx-auto h-10 w-10 text-[#146c60]"
+          aria-hidden="true"
+        />
+        <p className="mt-4 text-lg font-semibold text-[#161616]">
           No conversation selected
         </p>
-        <p className="mt-2 text-sm leading-6 text-slate-700">
+        <p className="mt-2 text-sm leading-6 text-[#7b7468]">
           Ask a section question to start a thread.
         </p>
       </div>
@@ -264,19 +310,19 @@ function ActiveThread({
   readonly session: BrowserFollowUpSession;
 }) {
   return (
-    <div className="min-h-0 overflow-y-auto bg-slate-50 p-4">
+    <div className="min-h-0 overflow-y-auto bg-[#fbfaf7] p-4">
       <div className="mx-auto grid max-w-3xl gap-4">
-        <div className="rounded-md border border-slate-200 bg-white p-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+        <div className="border border-[#d8d2c5] bg-white p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[#7b7468]">
             {targetLabel(session.target)}
           </p>
-          <h3 className="mt-2 text-xl font-semibold text-slate-950">
+          <h3 className="mt-2 text-xl font-semibold text-[#161616]">
             {firstUserQuestion(session)}
           </h3>
-          <p className="mt-3 text-sm font-semibold text-blue-700">
+          <p className="mt-3 text-sm font-semibold text-[#3b5bdb]">
             Searches matching repo files
           </p>
-          <p className="mt-1 text-sm leading-6 text-slate-700">
+          <p className="mt-1 text-sm leading-6 text-[#3f3b35]">
             {session.evidenceSummary}
           </p>
         </div>
@@ -296,18 +342,18 @@ function MessageBubble({ message }: { readonly message: ChatMessage }) {
     <div
       className={`max-w-[90%] rounded-md border p-4 ${
         message.role === "user"
-          ? "ml-auto border-emerald-200 bg-emerald-50"
-          : "mr-auto border-slate-200 bg-white"
+          ? "ml-auto border-[#146c60] bg-[#eef8f5]"
+          : "mr-auto border-[#d8d2c5] bg-white"
       }`}
     >
-      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
         {message.role === "user" ? "You" : "Reviewer"}
       </p>
-      <p className="whitespace-pre-wrap text-sm leading-6 text-slate-800">
+      <p className="whitespace-pre-wrap text-sm leading-6 text-[#3f3b35]">
         {message.content}
       </p>
       {message.citations.length > 0 ? (
-        <p className="mt-2 break-words text-xs text-slate-600">
+        <p className="mt-2 break-words text-xs text-[#7b7468]">
           Evidence:{" "}
           {message.citations
             .map((citation) => citation.evidenceReference.id)
@@ -315,7 +361,7 @@ function MessageBubble({ message }: { readonly message: ChatMessage }) {
         </p>
       ) : null}
       {message.assumptions.length > 0 ? (
-        <p className="mt-2 text-xs text-slate-600">
+        <p className="mt-2 text-xs text-[#7b7468]">
           Assumptions:{" "}
           {message.assumptions
             .map((assumption) => assumption.statement)
@@ -329,11 +375,11 @@ function MessageBubble({ message }: { readonly message: ChatMessage }) {
 function AnswerSections({ answer }: { readonly answer: ChatAnswer }) {
   if (answer.status === "insufficient-context") {
     return (
-      <div className="rounded-md border border-amber-200 bg-amber-50 p-3">
-        <p className="text-sm font-semibold uppercase tracking-[0.12em] text-amber-800">
+      <div className="rounded-md border border-[#d97706] bg-[#fff7ed] p-3">
+        <p className="text-sm font-semibold uppercase tracking-[0.12em] text-[#c2410c]">
           Insufficient context
         </p>
-        <p className="mt-2 text-sm leading-6 text-slate-800">
+        <p className="mt-2 text-sm leading-6 text-[#3f3b35]">
           {answer.summary}
         </p>
         <SectionList
@@ -351,12 +397,12 @@ function AnswerSections({ answer }: { readonly answer: ChatAnswer }) {
   }
 
   return (
-    <div className="grid gap-3 rounded-md border border-slate-200 bg-white p-3">
+    <div className="grid gap-3 rounded-md border border-[#d8d2c5] bg-white p-3">
       <div>
-        <p className="text-sm font-semibold uppercase tracking-[0.12em] text-emerald-700">
+        <p className="text-sm font-semibold uppercase tracking-[0.12em] text-[#146c60]">
           Evidence-backed answer
         </p>
-        <p className="mt-2 text-sm leading-6 text-slate-800">
+        <p className="mt-2 text-sm leading-6 text-[#3f3b35]">
           {answer.summary}
         </p>
       </div>
@@ -394,15 +440,15 @@ function SectionList({
   }
 
   return (
-    <section className="rounded-md border border-slate-200 bg-slate-50 p-3">
-      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">
+    <section className="rounded-md border border-[#e4dfd4] bg-[#fbfaf7] p-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
         {title}
       </p>
       <ul className="mt-2 grid gap-2">
         {items.map((item, index) => (
           <li
             key={`${item}-${index}`}
-            className="text-sm leading-6 text-slate-800"
+            className="text-sm leading-6 text-[#3f3b35]"
           >
             {item}
           </li>

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import {
-  useEffect,
-  useMemo,
-  useState,
-  type FormEvent,
-  type ReactNode,
-} from "react";
+  BarChart3,
+  ChevronDown,
+  GitBranch,
+  KeyRound,
+  Loader2,
+  Lock,
+  Play,
+} from "lucide-react";
 
 import {
   AnalyzeRepositoryResponseSchema,
@@ -19,7 +22,6 @@ import {
   OpenRouterModelIdSchema,
 } from "../../infrastructure/llm/openrouter-config";
 import {
-  clearBrowserLocalSession,
   defaultBrowserRepositoryForm,
   loadBrowserAnalysisSession,
   saveBrowserAnalysisSession,
@@ -216,85 +218,125 @@ export function AnalyzeRepositoryPanel() {
     }
   }
 
-  function resetSavedSession() {
-    clearBrowserLocalSession(window.localStorage);
-    setRepositoryForm(defaultBrowserRepositoryForm());
-    setApiKey("");
-    setLatestReport(null);
-    setStatus({ kind: "idle" });
-  }
-
   return (
-    <div className="min-h-screen bg-stone-50 text-slate-950">
-      <section className="border-b border-slate-200 bg-white px-4 py-5 print:hidden sm:px-6">
-        <div className="mx-auto max-w-7xl">
-          <div className="flex flex-wrap items-end justify-between gap-4">
+    <main className="min-h-screen bg-[#f6f5f1] text-[#161616]">
+      <section className="border-b border-[#d9d5ca] bg-[#fbfaf7] print:hidden">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-5 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div>
-              <p className="text-sm font-semibold text-emerald-700">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#146c60]">
                 Repository Quality
               </p>
-              <h1 className="mt-1 text-3xl font-semibold text-slate-950">
+              <h1 className="mt-2 text-3xl font-semibold tracking-normal text-[#111111] sm:text-4xl">
                 Report Card
               </h1>
             </div>
-            <button
-              type="button"
-              onClick={resetSavedSession}
-              className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-            >
-              Reset
-            </button>
+            {latestReport === null ? null : (
+              <div className="flex items-center gap-3 text-sm text-[#5f5b53]">
+                <Lock className="h-4 w-4" aria-hidden="true" />
+                <span>
+                  {latestReport.reportCard.reviewerMetadata.modelName ??
+                    latestReport.reportCard.reviewerMetadata.name}
+                </span>
+              </div>
+            )}
           </div>
 
           <form
+            data-1p-ignore
+            data-lpignore="true"
+            autoComplete="off"
             noValidate
             onSubmit={analyzeRepository}
-            className="mt-5 grid gap-3 lg:grid-cols-[minmax(240px,1fr)_minmax(220px,320px)_auto]"
+            className="grid gap-3"
           >
-            <Field label="GitHub repository URL">
-              <input
-                type="url"
-                inputMode="url"
-                autoComplete="url"
-                value={repositoryForm.repoUrl}
-                onChange={(event) =>
-                  updateRepositoryForm((current) => ({
-                    ...current,
-                    repoUrl: event.target.value,
-                  }))
-                }
-                placeholder="https://github.com/owner/repo"
-                className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1.4fr)_minmax(260px,0.8fr)_auto]">
+              <label
+                className="flex min-w-0 items-center gap-3 border border-[#cfc9bb] bg-white px-3 py-2"
+                data-testid="repo-url-control"
+              >
+                <GitBranch
+                  className="h-5 w-5 shrink-0 text-[#146c60]"
+                  aria-hidden="true"
+                />
+                <span className="sr-only">GitHub repository URL</span>
+                <input
+                  name="repository-url"
+                  type="url"
+                  inputMode="url"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  autoComplete="off"
+                  spellCheck={false}
+                  value={repositoryForm.repoUrl}
+                  onChange={(event) =>
+                    updateRepositoryForm((current) => ({
+                      ...current,
+                      repoUrl: event.target.value,
+                    }))
+                  }
+                  placeholder="https://github.com/owner/repo"
+                  className="h-10 min-w-0 flex-1 bg-transparent text-sm text-[#161616] outline-none placeholder:text-[#8f887b]"
+                  disabled={status.kind === "loading"}
+                />
+              </label>
+
+              <label
+                className="flex min-w-0 items-center gap-3 border border-[#cfc9bb] bg-white px-3 py-2"
+                data-testid="api-key-control"
+              >
+                <KeyRound
+                  className="h-5 w-5 shrink-0 text-[#3b5bdb]"
+                  aria-hidden="true"
+                />
+                <span className="sr-only">OpenRouter API key</span>
+                <input
+                  name="openrouter-api-token"
+                  type="password"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  autoComplete="new-password"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  spellCheck={false}
+                  value={apiKey}
+                  onChange={(event) => setApiKey(event.target.value)}
+                  placeholder="OpenRouter API key"
+                  className="h-10 min-w-0 flex-1 bg-transparent text-sm text-[#161616] outline-none placeholder:text-[#8f887b]"
+                  disabled={status.kind === "loading"}
+                />
+              </label>
+
+              <button
+                type="submit"
                 disabled={status.kind === "loading"}
-              />
-            </Field>
+                className="inline-flex h-14 items-center justify-center gap-2 rounded-md bg-[#111111] px-5 text-sm font-semibold text-white transition hover:bg-[#333333] disabled:cursor-not-allowed disabled:bg-[#77736a]"
+                title="Analyze repository"
+              >
+                {status.kind === "loading" ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="h-4 w-4" />
+                )}
+                {status.kind === "loading" ? "Analyzing" : "Analyze"}
+              </button>
+            </div>
 
-            <Field label="OpenRouter API key">
-              <input
-                type="password"
-                autoComplete="off"
-                value={apiKey}
-                onChange={(event) => setApiKey(event.target.value)}
-                className="h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
-                disabled={status.kind === "loading"}
-              />
-            </Field>
-
-            <button
-              type="submit"
-              disabled={status.kind === "loading"}
-              className="h-11 rounded-md bg-slate-950 px-5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-            >
-              {status.kind === "loading" ? "Analyzing" : "Analyze"}
-            </button>
-
-            <details className="lg:col-span-3">
-              <summary className="cursor-pointer text-sm font-semibold text-slate-800">
-                Advanced
+            <details className="group border border-[#d8d2c5] bg-white">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 text-sm font-semibold text-[#3f3b35]">
+                <span>Advanced</span>
+                <ChevronDown
+                  className="h-4 w-4 text-[#7b7468] transition group-open:rotate-180"
+                  aria-hidden="true"
+                />
               </summary>
-              <div className="mt-3 grid gap-3 rounded-md border border-slate-200 bg-slate-50 p-3 sm:grid-cols-[minmax(220px,420px)_auto_auto]">
-                <Field label="OpenRouter Model">
+              <div className="grid gap-3 border-t border-[#e4dfd4] p-4 md:grid-cols-[minmax(0,1fr)_auto_auto] md:items-end">
+                <label className="grid gap-2">
+                  <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
+                    OpenRouter Model
+                  </span>
                   <input
+                    name="openrouter-model-id"
                     value={repositoryForm.selectedModel}
                     onChange={(event) =>
                       updateRepositoryForm((current) => ({
@@ -302,10 +344,15 @@ export function AnalyzeRepositoryPanel() {
                         selectedModel: event.target.value,
                       }))
                     }
-                    className="h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
+                    placeholder={OpenRouterDefaultModelId}
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    autoComplete="off"
+                    spellCheck={false}
+                    className="h-11 border border-[#cfc9bb] bg-[#fbfaf7] px-3 text-sm outline-none focus:border-[#146c60]"
                     disabled={status.kind === "loading"}
                   />
-                </Field>
+                </label>
                 <button
                   type="button"
                   onClick={() =>
@@ -315,7 +362,7 @@ export function AnalyzeRepositoryPanel() {
                     }))
                   }
                   disabled={status.kind === "loading"}
-                  className="h-10 self-end rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                  className="h-11 border border-[#cfc9bb] px-4 text-sm font-semibold text-[#3f3b35] transition hover:bg-[#f6f5f1] disabled:cursor-not-allowed disabled:text-[#8f887b]"
                 >
                   Use GPT-5 Mini
                 </button>
@@ -328,7 +375,7 @@ export function AnalyzeRepositoryPanel() {
                     }))
                   }
                   disabled={status.kind === "loading"}
-                  className="h-10 self-end rounded-md border border-slate-300 bg-white px-4 text-sm font-medium text-slate-800 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+                  className="h-11 border border-[#cfc9bb] px-4 text-sm font-semibold text-[#3f3b35] transition hover:bg-[#f6f5f1] disabled:cursor-not-allowed disabled:text-[#8f887b]"
                 >
                   Use Free Router
                 </button>
@@ -337,14 +384,17 @@ export function AnalyzeRepositoryPanel() {
           </form>
 
           {status.kind === "error" ? (
-            <p role="alert" className="mt-3 text-sm font-medium text-red-700">
+            <div
+              role="alert"
+              className="border border-[#be123c] bg-[#fff1f2] px-4 py-3 text-sm text-[#9f1239]"
+            >
               {status.message}
-            </p>
+            </div>
           ) : null}
         </div>
       </section>
 
-      <main className="mx-auto min-w-0 max-w-7xl px-4 py-6 sm:px-6">
+      <section className="mx-auto min-w-0 max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
         {reportContent.kind === "loaded" ? (
           <ReportCardView
             analysis={reportContent.analysis}
@@ -354,58 +404,67 @@ export function AnalyzeRepositoryPanel() {
         ) : reportContent.kind === "loading" ? (
           <AnalysisLoadingState phase={reportContent.phase} />
         ) : (
-          <section className="flex min-h-[520px] items-center justify-center rounded-md border border-dashed border-slate-300 bg-white p-6 text-center">
+          <section className="grid min-h-[54vh] place-items-center border border-dashed border-[#cfc9bb] bg-[#fbfaf7] p-5 text-center sm:p-8">
             <div>
-              <h2 className="text-lg font-semibold text-slate-950">
+              <BarChart3
+                className="mx-auto h-10 w-10 text-[#146c60]"
+                aria-hidden="true"
+              />
+              <h2 className="mt-5 text-xl font-semibold text-[#161616]">
                 No report loaded
               </h2>
-              <p className="mt-2 max-w-md text-sm leading-6 text-slate-700">
+              <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-[#7b7468]">
                 Enter a repository URL to begin.
               </p>
             </div>
           </section>
         )}
-      </main>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  children,
-}: {
-  readonly label: string;
-  readonly children: ReactNode;
-}) {
-  return (
-    <label className="block">
-      <span className="mb-1 block text-sm font-medium text-slate-700">
-        {label}
-      </span>
-      {children}
-    </label>
+      </section>
+    </main>
   );
 }
 
 function AnalysisLoadingState({ phase }: { readonly phase: LoadingPhase }) {
   return (
-    <section className="flex min-h-[520px] items-center justify-center rounded-md border border-dashed border-slate-300 bg-white p-6 text-center">
+    <section className="grid min-h-[54vh] place-items-center border border-dashed border-[#cfc9bb] bg-[#fbfaf7] p-5 text-center sm:p-8">
       <div className="w-full max-w-md">
-        <p className="text-sm font-medium uppercase text-emerald-700">
+        <BarChart3
+          className="mx-auto h-10 w-10 text-[#146c60]"
+          aria-hidden="true"
+        />
+        <p className="mt-5 text-xs font-semibold uppercase tracking-[0.12em] text-[#146c60]">
           Analysis in progress
         </p>
-        <h2 className="mt-3 text-lg font-semibold text-slate-950">
+        <h2 className="mt-3 text-xl font-semibold text-[#161616]">
           {phase.title}
         </h2>
-        <p className="mt-2 text-sm leading-6 text-slate-700">{phase.detail}</p>
+        <p className="mt-2 text-sm leading-6 text-[#7b7468]">{phase.detail}</p>
         <div
-          className="mt-5 h-2 overflow-hidden rounded-full bg-slate-200"
+          className="mt-6 border border-[#d8d2c5] bg-white p-4 text-left"
           aria-label={`Analysis ${phase.progress}% complete`}
         >
-          <div
-            className="h-full rounded-full bg-emerald-600 transition-[width]"
-            style={{ width: `${phase.progress}%` }}
+          <div className="flex items-center justify-between gap-4 text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
+            <span>Progress</span>
+            <span>{phase.progress}%</span>
+          </div>
+          <div className="mt-3 h-3 overflow-hidden bg-[#ebe6db]">
+            <div
+              className="h-full bg-[#146c60] transition-all duration-700 ease-out"
+              style={{ width: `${phase.progress}%` }}
+            />
+          </div>
+        </div>
+        <div className="mt-4 flex items-start gap-3 border border-[#d8d2c5] bg-white p-4 text-left">
+          <Loader2
+            className="mt-0.5 h-5 w-5 shrink-0 animate-spin text-[#d97706]"
+            aria-hidden="true"
           />
+          <div
+            aria-hidden="true"
+            className="min-w-0 text-sm leading-6 text-[#3f3b35]"
+          >
+            {phase.detail}
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/report/print-report-button.tsx
+++ b/src/components/report/print-report-button.tsx
@@ -8,7 +8,7 @@ export function PrintReportButton() {
   return (
     <button
       type="button"
-      className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 print:hidden"
+      className="rounded-md border border-[#cfc9bb] bg-white px-3 py-2 text-sm font-semibold text-[#3f3b35] transition hover:bg-[#f6f5f1] print:hidden"
       onClick={triggerPrint}
     >
       Download PDF

--- a/src/components/report/report-card-view.tsx
+++ b/src/components/report/report-card-view.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import {
+  BarChart3,
+  Boxes,
+  FileText,
+  MessageSquare,
+  Send,
+  ShieldCheck,
+  TestTube2,
+  Wrench,
+} from "lucide-react";
 import { z } from "zod";
 
 import { buildReportDashboardViewModel } from "../../application/report-dashboard/report-dashboard-view-model";
@@ -29,6 +39,14 @@ import { FollowUpSlideout } from "../chat/follow-up-slideout";
 import { PrintReportButton } from "./print-report-button";
 import { ScoreRing } from "./score-ring";
 import { Sparkline } from "./sparkline";
+
+const sectionIcons = {
+  maintainability: Wrench,
+  testing: TestTube2,
+  security: ShieldCheck,
+  architecture: Boxes,
+  documentation: FileText,
+} satisfies Record<ReportDashboardSectionId, typeof Wrench>;
 
 export function ReportCardView({
   apiKey = "",
@@ -193,46 +211,34 @@ export function ReportCardView({
   }
 
   return (
-    <section className="space-y-5" aria-labelledby="report-title">
-      <header className="flex flex-wrap items-start justify-between gap-4 print:hidden">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700">
-            Repository Quality
-          </p>
-          <h2
-            id="report-title"
-            className="mt-1 text-3xl font-semibold text-slate-950"
-          >
-            Report Card
-          </h2>
-        </div>
-        <PrintReportButton />
-      </header>
-
+    <section className="space-y-5" aria-labelledby="overview-title">
       <section
         aria-labelledby="overview-title"
         className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto]"
       >
-        <div className="rounded-md border border-slate-200 bg-white p-5">
+        <div className="border border-[#d8d2c5] bg-white p-5">
           <div className="flex flex-wrap items-start justify-between gap-5">
             <div className="min-w-0">
-              <p className="break-words text-sm font-medium text-slate-600">
+              <p className="break-words text-sm font-medium text-[#5f5b53]">
                 {dashboard.overview.repositoryLabel}
               </p>
               <h3
                 id="overview-title"
-                className="mt-2 text-2xl font-semibold text-slate-950"
+                className="mt-1 text-2xl font-semibold tracking-normal text-[#111111]"
               >
                 Evidence-backed report
               </h3>
-              <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-700">
+              <p className="mt-5 max-w-3xl text-sm leading-6 text-[#3f3b35]">
                 {dashboard.overview.summary}
               </p>
             </div>
-            <ScoreRing
-              score={dashboard.overview.overallScore}
-              grade={dashboard.overview.grade}
-            />
+            <div className="flex flex-col items-end gap-4">
+              <PrintReportButton />
+              <ScoreRing
+                score={dashboard.overview.overallScore}
+                grade={dashboard.overview.grade}
+              />
+            </div>
           </div>
 
           <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
@@ -248,9 +254,9 @@ export function ReportCardView({
           </dl>
         </div>
 
-        <div className="rounded-md border border-slate-200 bg-white p-5 lg:w-72">
-          <p className="text-sm font-semibold text-slate-950">Reviewer</p>
-          <p className="mt-2 text-sm leading-6 text-slate-700">
+        <div className="border border-[#d8d2c5] bg-white p-5 lg:w-72">
+          <p className="text-sm font-semibold text-[#111111]">Reviewer</p>
+          <p className="mt-2 text-sm leading-6 text-[#3f3b35]">
             {dashboard.overview.reviewerNote}
           </p>
         </div>
@@ -287,8 +293,8 @@ export function ReportCardView({
         ))}
       </section>
 
-      <details className="rounded-md border border-slate-200 bg-white p-4">
-        <summary className="cursor-pointer text-sm font-semibold text-slate-900">
+      <details className="rounded-md border border-[#d8d2c5] bg-white p-4">
+        <summary className="cursor-pointer text-sm font-semibold text-[#25221e]">
           Evidence, Caveats, And Suggested Follow-Ups
         </summary>
         <div className="mt-4 grid gap-4 lg:grid-cols-3">
@@ -347,12 +353,12 @@ function BigNumberTile({
   readonly bigNumber: ReportDashboardBigNumber;
 }) {
   return (
-    <div className="rounded-md border border-slate-200 bg-white p-4">
-      <p className="text-sm font-medium text-slate-600">{bigNumber.label}</p>
-      <p className="mt-2 break-words text-3xl font-semibold text-slate-950">
+    <div className="border border-[#d8d2c5] bg-white p-5">
+      <p className="text-sm font-medium text-[#5f5b53]">{bigNumber.label}</p>
+      <p className="mt-3 break-words text-4xl font-semibold tracking-normal text-[#111111]">
         {bigNumber.value}
       </p>
-      <p className="mt-1 text-sm leading-5 text-slate-600">
+      <p className="mt-2 text-sm leading-5 text-[#7b7468]">
         {bigNumber.detail}
       </p>
     </div>
@@ -369,38 +375,35 @@ function LanguageMixPanel({
   return (
     <section
       aria-labelledby="language-mix-title"
-      className="rounded-md border border-slate-200 bg-white p-5"
+      className="border border-[#d8d2c5] bg-white p-5"
     >
-      <p className="text-sm font-medium uppercase text-emerald-700">
-        Static evidence
-      </p>
-      <h3
-        id="language-mix-title"
-        className="mt-1 text-lg font-semibold text-slate-950"
-      >
-        Language Mix
-      </h3>
+      <div className="flex items-center gap-2">
+        <BarChart3 className="h-5 w-5 text-[#146c60]" aria-hidden="true" />
+        <h3 id="language-mix-title" className="text-lg font-semibold">
+          Language Mix
+        </h3>
+      </div>
 
       {emptyMessage === undefined ? (
         <div className="mt-5 grid gap-4">
           {languageSlices.map((slice) => (
             <div key={slice.language}>
               <div className="flex items-center justify-between gap-3 text-sm">
-                <span className="font-medium text-slate-900">
+                <span className="font-medium text-[#3f3b35]">
                   {slice.language}
                 </span>
-                <span className="text-slate-600">{slice.percentOfCode}%</span>
+                <span className="text-[#7b7468]">{slice.percentOfCode}%</span>
               </div>
-              <div className="mt-2 h-3 overflow-hidden rounded-full bg-slate-200">
+              <div className="mt-2 h-3 overflow-hidden bg-[#ebe6db]">
                 <div
-                  className="h-full rounded-full"
+                  className="h-full"
                   style={{
                     width: `${Math.max(slice.percentOfCode, 3)}%`,
                     backgroundColor: slice.color,
                   }}
                 />
               </div>
-              <p className="mt-2 text-xs text-slate-600">
+              <p className="mt-2 text-xs text-[#7b7468]">
                 {formatNumber(slice.fileCount)} files,{" "}
                 {formatNumber(slice.codeLineCount)} code lines
               </p>
@@ -408,7 +411,7 @@ function LanguageMixPanel({
           ))}
         </div>
       ) : (
-        <p className="mt-5 text-sm leading-6 text-slate-700">{emptyMessage}</p>
+        <p className="mt-5 text-sm leading-6 text-[#3f3b35]">{emptyMessage}</p>
       )}
     </section>
   );
@@ -422,27 +425,24 @@ function ReviewerNotesPanel({
   return (
     <section
       aria-labelledby="reviewer-notes-title"
-      className="rounded-md border border-slate-200 bg-white p-5"
+      className="border border-[#d8d2c5] bg-white p-5"
     >
-      <p className="text-sm font-medium uppercase text-emerald-700">
-        Reviewer assessment
-      </p>
-      <h3
-        id="reviewer-notes-title"
-        className="mt-1 text-lg font-semibold text-slate-950"
-      >
-        Reviewer Notes
-      </h3>
+      <div className="flex items-center gap-2">
+        <MessageSquare className="h-5 w-5 text-[#3b5bdb]" aria-hidden="true" />
+        <h3 id="reviewer-notes-title" className="text-lg font-semibold">
+          Reviewer Notes
+        </h3>
+      </div>
       {notes.length === 0 ? (
-        <p className="mt-5 text-sm leading-6 text-slate-700">
+        <p className="mt-5 text-sm leading-6 text-[#3f3b35]">
           No reviewer notes were available.
         </p>
       ) : (
-        <ul className="mt-5 divide-y divide-slate-200">
+        <ul className="mt-5 divide-y divide-[#e4dfd4]">
           {notes.map((note, index) => (
             <li key={`${note.tone}-${index}`} className="py-3 first:pt-0">
-              <p className="text-sm leading-6 text-slate-800">{note.text}</p>
-              <p className="mt-1 text-xs font-semibold uppercase text-slate-500">
+              <p className="text-sm leading-6 text-[#3f3b35]">{note.text}</p>
+              <p className="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
                 {note.tone}
               </p>
             </li>
@@ -463,35 +463,32 @@ function ReportSectionPanel({
   readonly section: ReportDashboardSection;
 }) {
   const signals = [...section.highlights, ...section.risks, ...section.caveats];
+  const Icon = sectionIcons[section.id];
 
   return (
-    <article className="rounded-md border border-slate-200 bg-white p-5">
-      <div className="grid gap-5 xl:grid-cols-[170px_minmax(0,1fr)_minmax(220px,300px)]">
+    <article className="border border-[#d8d2c5] bg-white">
+      <div className="grid gap-5 p-5 lg:grid-cols-[240px_minmax(0,1fr)_minmax(260px,0.72fr)]">
         <div>
-          <div className="flex flex-wrap items-center gap-2">
-            <h4 className="text-lg font-semibold text-slate-950">
+          <div className="flex items-center gap-2">
+            <Icon className="h-5 w-5 text-[#d97706]" aria-hidden="true" />
+            <h4 className="text-lg font-semibold text-[#161616]">
               {section.title}
             </h4>
-            <span className="rounded border border-slate-300 bg-slate-50 px-2 py-1 text-xs font-semibold uppercase text-slate-700">
-              {formatRating(section.rating)}
-            </span>
           </div>
-          <div className="mt-4">
+          <div className="mt-5 flex items-center gap-4">
             <ScoreRing
               score={section.score}
               grade={formatRating(section.rating)}
             />
-          </div>
-          <p className="mt-4 text-sm font-medium text-slate-900">
-            {section.confidenceLabel}
-          </p>
-          <div className="mt-4">
             <Sparkline points={section.chartPoints} />
           </div>
+          <p className="mt-4 text-sm font-medium text-[#3f3b35]">
+            {section.confidenceLabel}
+          </p>
         </div>
 
         <div className="min-w-0">
-          <p className="text-sm leading-6 text-slate-700">{section.summary}</p>
+          <p className="text-sm leading-6 text-[#3f3b35]">{section.summary}</p>
           <div className="mt-5 grid gap-3 sm:grid-cols-3">
             {section.metrics.map((metric) => (
               <MetricTile key={metric.label} metric={metric} />
@@ -539,17 +536,17 @@ function SectionAskBox({
   }
 
   return (
-    <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
+    <div className="border-t border-[#e4dfd4] pt-5 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
       <label className="block">
-        <span className="text-sm font-semibold text-slate-900">
+        <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
           Ask About {sectionTitle}
         </span>
         <textarea
           aria-label={`Ask About ${sectionTitle}`}
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
-          className="mt-2 h-24 w-full resize-none rounded-md border border-slate-300 bg-white p-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500"
-          placeholder={`Ask about ${sectionTitle.toLowerCase()}...`}
+          className="mt-3 min-h-28 w-full resize-y border border-[#cfc9bb] bg-[#fbfaf7] p-3 text-sm text-[#161616] outline-none focus:border-[#146c60]"
+          placeholder="What should we fix first?"
           disabled={loading}
         />
       </label>
@@ -557,8 +554,10 @@ function SectionAskBox({
         type="button"
         onClick={handleOpenChat}
         disabled={loading}
-        className="mt-3 h-10 w-full rounded-md bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800"
+        className="mt-3 inline-flex h-10 items-center justify-center gap-2 bg-[#146c60] px-4 text-sm font-semibold text-white transition hover:bg-[#0f554b] disabled:cursor-not-allowed disabled:bg-[#8aa7a0]"
+        title="Ask follow-up"
       >
+        <Send className="h-4 w-4" aria-hidden="true" />
         {loading ? "Opening" : "Open Chat"}
       </button>
     </div>
@@ -571,14 +570,14 @@ function MetricTile({
   readonly metric: ReportDashboardSection["metrics"][number];
 }) {
   return (
-    <div className="border-t border-slate-200 pt-3">
-      <p className="text-xs font-semibold uppercase text-slate-500">
+    <div className="border-t border-[#e4dfd4] pt-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
         {metric.label}
       </p>
-      <p className="mt-1 break-words text-2xl font-semibold text-slate-950">
+      <p className="mt-1 break-words text-2xl font-semibold tracking-normal text-[#161616]">
         {metric.value}
       </p>
-      <p className="mt-1 text-xs leading-5 text-slate-600">{metric.detail}</p>
+      <p className="mt-1 text-xs leading-5 text-[#7b7468]">{metric.detail}</p>
     </div>
   );
 }
@@ -594,15 +593,15 @@ function TextList({
 }) {
   return (
     <section>
-      <h5 className="text-sm font-semibold text-slate-950">{title}</h5>
+      <h5 className="text-sm font-semibold text-[#161616]">{title}</h5>
       {items.length === 0 ? (
-        <p className="mt-2 text-sm leading-6 text-slate-600">{emptyMessage}</p>
+        <p className="mt-2 text-sm leading-6 text-[#7b7468]">{emptyMessage}</p>
       ) : (
-        <ul className="mt-2 space-y-2 text-sm leading-6 text-slate-700">
+        <ul className="mt-2 space-y-2 text-sm leading-5 text-[#3f3b35]">
           {items.map((item, index) => (
             <li
               key={`${item}-${index}`}
-              className="rounded-md bg-slate-50 px-3 py-2"
+              className="border border-[#e4dfd4] bg-[#fbfaf7] px-3 py-2"
             >
               {item}
             </li>
@@ -628,9 +627,9 @@ function DetailList({
 }) {
   return (
     <section>
-      <h4 className="text-sm font-semibold text-slate-950">{title}</h4>
+      <h4 className="text-sm font-semibold text-[#161616]">{title}</h4>
       {items.length === 0 ? (
-        <p className="mt-2 text-sm leading-6 text-slate-600">{emptyMessage}</p>
+        <p className="mt-2 text-sm leading-6 text-[#7b7468]">{emptyMessage}</p>
       ) : (
         <ul className="mt-2 space-y-2">
           {items.map((item, index) => (
@@ -638,10 +637,10 @@ function DetailList({
               key={`${item.title}-${item.detail}-${index}`}
               className="text-sm"
             >
-              <p className="font-medium text-slate-950">{item.title}</p>
-              <p className="mt-1 leading-6 text-slate-700">{item.detail}</p>
+              <p className="font-medium text-[#161616]">{item.title}</p>
+              <p className="mt-1 leading-6 text-[#3f3b35]">{item.detail}</p>
               {item.meta === undefined || item.meta === "" ? null : (
-                <p className="mt-1 break-words text-xs text-slate-500">
+                <p className="mt-1 break-words text-xs text-[#7b7468]">
                   {item.meta}
                 </p>
               )}
@@ -791,10 +790,10 @@ function MetadataItem({
 }) {
   return (
     <div>
-      <dt className="text-xs font-semibold uppercase text-slate-500">
+      <dt className="text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7468]">
         {label}
       </dt>
-      <dd className="mt-1 break-words font-medium text-slate-950">{value}</dd>
+      <dd className="mt-1 break-words font-medium text-[#161616]">{value}</dd>
     </div>
   );
 }

--- a/src/components/report/score-ring.tsx
+++ b/src/components/report/score-ring.tsx
@@ -15,20 +15,20 @@ export function ScoreRing({
     <div
       role="img"
       aria-label={ariaLabel}
-      className="grid size-28 shrink-0 place-items-center rounded-full border border-slate-200 bg-white"
+      className="grid size-28 shrink-0 place-items-center rounded-full"
       style={{
         background:
           score === undefined
-            ? "conic-gradient(#cbd5e1 0deg, #e2e8f0 0deg)"
-            : `conic-gradient(#047857 ${Math.round(score * 3.6)}deg, #e2e8f0 0deg)`,
+            ? "conic-gradient(#d8d2c5 0deg, #e4dfd4 0deg)"
+            : `conic-gradient(#146c60 ${Math.round(score * 3.6)}deg, #e4dfd4 0deg)`,
       }}
     >
       <div className="grid size-20 place-items-center rounded-full bg-white text-center">
         <div>
-          <p className="text-2xl font-semibold leading-none text-slate-950">
+          <p className="text-2xl font-semibold leading-none tracking-normal text-[#111111]">
             {scoreLabel}
           </p>
-          <p className="mt-1 text-xs font-semibold uppercase text-slate-600">
+          <p className="mt-1 text-xs font-semibold uppercase text-[#146c60]">
             {grade}
           </p>
         </div>

--- a/src/components/report/sparkline.tsx
+++ b/src/components/report/sparkline.tsx
@@ -10,7 +10,7 @@ export function Sparkline({
 }) {
   if (points.length === 0) {
     return (
-      <div className="grid h-16 place-items-center rounded-md border border-dashed border-slate-300 text-xs font-medium text-slate-500">
+      <div className="grid h-16 place-items-center border border-dashed border-[#d8d2c5] text-xs font-medium text-[#7b7468]">
         No chart data
       </div>
     );
@@ -34,10 +34,11 @@ export function Sparkline({
         aria-label="Section signal trend"
       >
         <title>Section signal trend</title>
+        <path d="M 1 98 H 99" stroke="#e4dfd4" strokeWidth="1" />
         <polyline
           points={polylinePoints}
           fill="none"
-          stroke="#047857"
+          stroke="#d97706"
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="5"


### PR DESCRIPTION
## Summary

Closes #122.

- Align the app shell, report dashboard, empty/loading states, and chat slideout with red's warm off-white surface, tan borders, Geist font stack, compact spacing, and icon-backed controls.
- Keep Green's intentional accent difference by using green for headings/actions/charts where red uses its red/orange accent.
- Add `lucide-react` for the same icon system red uses and tighten red-parity Playwright assertions for visual tokens and controls.

## Intentional departures

- PDF export remains as the approved net-new Green feature.
- Green accent color replaces red/orange for the primary brand text and score/chart/action accents.

## Screenshots

Captured fresh local desktop and mobile first-screen screenshots against red and this branch under `test-results/red-parity-122/` before opening this PR. They are local verification artifacts, not committed product assets.

## Verification

- `npx -y node@24 $(command -v pnpm) exec vitest run src/components/report/analyze-repository-panel.test.tsx src/components/report/report-card-view.test.tsx src/components/report/report-card-view.chat.test.tsx src/components/report/score-ring.test.tsx src/components/report/sparkline.test.tsx`
- `RED_UI_PARITY=1 npx -y node@24 $(command -v pnpm) exec playwright test e2e/red-ui-parity.spec.ts`
- `npx -y node@24 $(command -v pnpm) check`
- `npx -y node@24 $(command -v pnpm) build`
- `npx -y node@24 $(command -v pnpm) test:e2e`
- `RED_UI_PARITY=1 npx -y node@24 $(command -v pnpm) test:e2e:red-parity`

Issue: #122