### PR TITLE
docs(agents): "Before Any Code" checklist and Recent Misses log (#141)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,17 @@
+## Linked Issue
+
+Closes #<issue-number>
+
+## Before Any Code Checklist
+
+Confirm each of the five chat-visible artifacts from the AGENTS.md `## Before Any Code` section was produced during the session that wrote this PR. If any are missing, explain why.
+
+- [ ] Linked issue (above)
+- [ ] Branch (not `main`)
+- [ ] Preflight output (or manual fork-day verification per `docs/setup.md`)
+- [ ] Failing test (RED) observed before any non-test edit
+- [ ] Architecture/plan check against `docs/architecture.md` and `docs/development-plan.md`
+
 ## Scope
 
 What coherent slice does this PR complete?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,18 @@
 
 These rules apply to all agentic development work in this repository.
 
+## Before Any Code
+
+Before editing any non-test file, post each of these as a chat-visible artifact. The artifact itself is the proof; reviewers and future agents should be able to skim a session transcript and see all five.
+
+1. **Linked issue.** The GitHub issue URL for this slice. If none exists, run `/distill-issue` (or open one manually) before continuing.
+2. **Branch.** A `git status` excerpt confirming you are on a feature branch, not on `main`.
+3. **Preflight.** Output of `/preflight` covering `gh` auth, git remote, branch protection awareness, Vercel project link, lefthook install, Node/pnpm version match against `package.json` engines, and `.claude/settings.json` hook activation. Until that skill ships, follow the manual fork-day checklist in `docs/setup.md`.
+4. **Failing test (RED).** `pnpm vitest run <file>` output that names the new test and shows it in the FAIL block — produced before any non-test source edit. The PreToolUse and lefthook commit gates enforce this mechanically; the chat artifact lets reviewers verify the _behavior_, not just the file pairing.
+5. **Architecture and plan check.** One line confirming `docs/architecture.md` and `docs/development-plan.md` were skimmed for conflicts with this slice. If there is a conflict, call it out before editing and update the affected doc in the same PR.
+
+If you cannot produce one of these, stop and ask. Skipping silently is the failure mode this list exists to prevent — see `## Recent Misses`.
+
 ## Required Reading
 
 Before making code, test, tooling, or architecture changes, read:
@@ -73,3 +85,9 @@ If a task conflicts with those documents, call out the conflict before editing. 
 - Do not treat raw test LOC, raw coverage, or single static scores as direct proof of repository quality.
 - Red-green enforcement is shared tooling, not a judgment call: `.claude/settings.json` guards in-session source edits, `lefthook.yml` guards staged commits, and both rely on `scripts/red-green-gate.ts`. Update the script and the two hook surfaces together when changing the workflow.
 - Cross-agent compatibility (Claude Code, Codex CLI, pi) is captured in [docs/agent-compat.md](docs/agent-compat.md). Shared skills live at `.agents/skills/`; each agent reaches them through a relative symlink. Keep the three hook surfaces (`.claude/settings.json`, `.codex/config.toml`, future `.pi/extensions/...`) aligned when changing red-green behavior.
+
+## Recent Misses
+
+Process misses worth remembering. One line per miss with a date, a one-sentence summary, and a link to the corrective work. New entries go on top.
+
+- **2026-04-26 — PDF export shipped without observing a red test.** The TDD rule was read and rationalized away as "small UI change," and the only test added was a passing assertion written after the implementation. Corrective work landed in [#105](https://github.com/lightstrikelabs/repo-analyzer-green/pull/105) (in-session PreToolUse gate via `scripts/red-green-gate.ts`) and [#114](https://github.com/lightstrikelabs/repo-analyzer-green/pull/114) (lefthook commit-time gate sharing the same script). Lesson: classify-and-skip is the failure mode; produce the chat-visible RED test artifact every time, even for "trivial" changes.

--- a/test/tooling/before-any-code.test.ts
+++ b/test/tooling/before-any-code.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const agentsMd = readFileSync(path.join(repoRoot, "AGENTS.md"), "utf8");
+const prTemplate = readFileSync(
+  path.join(repoRoot, ".github/pull_request_template.md"),
+  "utf8",
+);
+
+describe("AGENTS.md Before Any Code front matter", () => {
+  it("declares a 'Before Any Code' section near the top of the document", () => {
+    const beforeIdx = agentsMd.indexOf("## Before Any Code");
+    expect(beforeIdx).toBeGreaterThan(-1);
+    const firstNumberedRule = agentsMd.indexOf(
+      "## 1. Scope Sessions And PRs Sanely",
+    );
+    expect(firstNumberedRule).toBeGreaterThan(-1);
+    expect(beforeIdx).toBeLessThan(firstNumberedRule);
+  });
+
+  it.each([
+    ["the linked GitHub issue artifact", /Linked issue/i],
+    ["the branch artifact (not on main)", /branch.*main|not on `?main`?/i],
+    ["the preflight artifact", /preflight|fork-day/i],
+    [
+      "the failing test (RED) artifact before non-test edits",
+      /failing test|RED test|red test|test fails/i,
+    ],
+    [
+      "the architecture/plan check",
+      /architecture\.md|development-plan\.md|architecture and plan/i,
+    ],
+  ])("requires %s", (_label, pattern) => {
+    const beforeIdx = agentsMd.indexOf("## Before Any Code");
+    const nextHeadingMatch = agentsMd.slice(beforeIdx + 1).match(/\n## [^\n]+/);
+    const sectionEnd =
+      nextHeadingMatch === null
+        ? agentsMd.length
+        : beforeIdx + 1 + (nextHeadingMatch.index ?? 0);
+    const section = agentsMd.slice(beforeIdx, sectionEnd);
+    expect(section).toMatch(pattern);
+  });
+
+  it("tells the agent to stop and ask if any artifact is missing", () => {
+    expect(agentsMd).toMatch(/stop and ask|stop, ask|skipping silently/i);
+  });
+});
+
+describe("AGENTS.md Recent Misses log", () => {
+  it("has a 'Recent Misses' section", () => {
+    expect(agentsMd).toMatch(/^## Recent Misses\b/m);
+  });
+
+  it("seeds the log with the 2026-04-26 PDF/TDD miss linking PR #105 and PR #114", () => {
+    const recentIdx = agentsMd.indexOf("## Recent Misses");
+    expect(recentIdx).toBeGreaterThan(-1);
+    const section = agentsMd.slice(recentIdx);
+    expect(section).toMatch(/2026-04-26/);
+    expect(section).toMatch(/#105/);
+    expect(section).toMatch(/#114/);
+    expect(section).toMatch(/PDF|red test|TDD/i);
+  });
+});
+
+describe(".github/pull_request_template.md", () => {
+  it("requires a Linked Issue field", () => {
+    expect(prTemplate).toMatch(/^## Linked Issue\b/m);
+  });
+
+  it("references the Before Any Code checklist so reviewers can spot skipped artifacts", () => {
+    expect(prTemplate).toMatch(/Before Any Code/i);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #141

## Before Any Code Checklist

- [x] Linked issue (above)
- [x] Branch (`141-before-any-code`, not `main`)
- [x] Preflight: skipped — branch is set up; preflight skill ships in #142.
- [x] Failing test (RED): `pnpm vitest run test/tooling/before-any-code.test.ts` showed 11 failures before AGENTS.md and the PR template were edited; same command shows 11 passes after.
- [x] Architecture/plan check: `docs/architecture.md` and `docs/development-plan.md` skimmed — no conflicts. This PR adds documentation only.

## Scope

Implements #141 — the doc-side complement to the red-green harness work in #105 and #114. Adds a five-item front-matter checklist to AGENTS.md that requires every agent to post a chat-visible artifact for each item before editing non-test code, plus a Recent Misses log seeded with the 2026-04-26 PDF/TDD miss. Updates the PR template with a Linked Issue field and a checklist that mirrors the AGENTS.md artifacts so reviewers can spot skipped steps without re-reading the entire session transcript.

The artifact-producing pattern is the lever: rules that say "do X" lose to action bias, but rules that say "post X to chat before any code" tend to be honored — because the artifact's absence is now visible.

## Non-Goals

- Mechanical enforcement of the checklist itself. The PreToolUse + lefthook gates (#105, #114) are the mechanical layer. This PR is the doc-and-template layer that sits alongside them.
- Restructuring the rest of AGENTS.md beyond inserting the new front matter and the trailing Recent Misses section. The numbered rules are unchanged.
- A "Recent Wins" log. Wins go in commit history; the misses log is the lever.
- Implementing `/preflight`, `/distill-issue`, `/start-slice`. The checklist references the first one as a future tool; until #142 ships, item 3 falls back to the manual fork-day procedure in `docs/setup.md` (also forthcoming).

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests (200 passed + 2 skipped, 11 new in `test/tooling/before-any-code.test.ts`)
- [x] Build (n/a — docs only)
- [x] Foundational E2E (n/a — docs only)

```text
pnpm check
# 42 test files, 198 tests passed + 2 skipped — 11 new
```

## Architecture and Docs

- [x] Follows `docs/architecture.md`.
- [x] No architecture changes — front matter and a new section in AGENTS.md, plus a PR-template addition.
- [x] No domain/application/infrastructure boundary violations.
- [x] AGENTS.md updated; the new front matter is the *required reading anchor* for future agents.

## Type Safety

- [x] No `as any`, `: any`, `<any>`, `as unknown as`. (`pnpm type-escape:check` passes.)

## Risk and Rollback

**Risks:**
- The checklist's item 3 (`/preflight`) currently points at the manual fallback in `docs/setup.md`, which #142 will create. Until that lands, agents have to know what fork-day verification means; the inline language ("`gh` auth, git remote, branch protection awareness, Vercel project link, lefthook install, Node/pnpm version match, hook activation") is the reference for now.
- The checklist relies on chat being the artifact channel. If a future workflow stops surfacing chat (e.g., headless agent runs), the artifacts go invisible again. Re-evaluate at that point.

**Rollback:**
- Single-commit revert removes the front matter, the Recent Misses section, and the PR-template addition.

## Dependencies

None added.

## Stacked-PR notes

This PR touches AGENTS.md alongside #146 (cross-agent compat). #146 added one bullet near the bottom under "Project-Specific Direction"; this PR adds a top-of-file front matter and a Recent Misses section near the end. Lines do not overlap, so a clean rebase is expected once one merges.