### PR TITLE
fix(chat): stabilize OpenRouter follow-up answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Full local CI-equivalent check:
 pnpm run ci
 ```
 
+Opt-in OpenRouter live contract checks are documented in [docs/how-tos/openrouter-e2e.md](docs/how-tos/openrouter-e2e.md). They are not part of the deterministic default test suite.
+
 The scaffold intentionally contains only the application shell, architecture folders, and tooling. Repository analysis, reviewer assessment, durable persistence, auth, and deployment integrations are tracked as separate issues.
 
 ## Local Persistence

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -14,6 +14,14 @@ When `PLAYWRIGHT_BASE_URL` is unset, Playwright starts the local Next.js dev ser
 
 The foundational E2E test must avoid paid model calls, external repository availability, production databases, and authentication. Use fixtures and fake adapters for the core repository-analysis workflow.
 
+Current foundational coverage:
+
+- `e2e/app-shell.spec.ts` verifies the repository-analysis UI flow with a mocked `/api/analyze` response, report rendering, local report persistence, and reload behavior.
+- `e2e/app-shell.spec.ts` verifies follow-up chat UI wiring with mocked `/api/follow-up`, including API key entry, model persistence, opening a targeted thread, rendering evidence-backed answer content, closing the slideout, and restoring recent thread state after reload.
+- `e2e/red-ui-parity.spec.ts` is opt-in visual parity coverage for the deployed red and green top sections. It does not exercise model behavior.
+
+The foundational Playwright suite does not call OpenRouter. Live model behavior is covered by opt-in contract tests so normal CI remains deterministic.
+
 ## Preview E2E
 
 Vercel preview E2E runs against pull request preview deployments when Vercel reports a successful deployment URL.
@@ -32,11 +40,11 @@ VERCEL_AUTOMATION_BYPASS_SECRET
 
 Do not store or print the secret value in files, issues, PRs, commit messages, screenshots, or logs. See [How To Run Preview E2E Against Protected Vercel Deployments](how-tos/vercel-preview-e2e.md) for setup and rotation steps.
 
-## Live-Provider E2E
+## Live-Provider Contracts
 
-Live-provider E2E should be separate from the required deterministic path. Use it only for explicitly scoped checks that need real provider behavior.
+Live-provider checks should be separate from the required deterministic path. Use them only for explicitly scoped checks that need real provider behavior.
 
-Future OpenRouter-backed E2E should read:
+OpenRouter-backed live checks should read:
 
 ```text
 OPENROUTER_API_KEY
@@ -47,10 +55,15 @@ E2E_TEST_REPOSITORY_URL
 
 The test should pass provider credentials only through server-side environment variables or request-scoped configuration. Do not expose provider keys to browser localStorage, rendered HTML, screenshots, traces, or client-side logs.
 
+Current live-provider coverage:
+
+- `test/infrastructure/llm/openrouter-live-contract.test.ts` verifies that configured OpenRouter models can return parseable JSON content.
+- `test/app/follow-up-live-contract.test.ts` verifies that `/api/follow-up` can return a validated follow-up answer through the route boundary.
+
 See [How To Configure OpenRouter For E2E Tests](how-tos/openrouter-e2e.md) for the full setup.
 
 ## CI Expectations
 
 `pnpm run ci` runs the foundational E2E suite after linting, formatting checks, type checking, unit tests, and build.
 
-Preview and live-provider E2E should fail with clear missing-configuration messages when intentionally invoked without required secrets or variables. They should not silently fall back to behavior that gives false confidence.
+Preview and live-provider checks should fail with clear missing-configuration messages when intentionally invoked without required secrets or variables. They should not silently fall back to behavior that gives false confidence.

--- a/docs/how-tos/openrouter-e2e.md
+++ b/docs/how-tos/openrouter-e2e.md
@@ -1,8 +1,8 @@
 # How To Configure OpenRouter For E2E Tests
 
-This guide documents the GitHub Actions configuration for future E2E tests that exercise OpenRouter-backed reviewer or follow-up behavior.
+This guide documents the GitHub Actions configuration for E2E and live contract tests that exercise OpenRouter-backed reviewer or follow-up behavior.
 
-The foundational E2E test should stay deterministic and fake-backed. Live-provider E2E should be added as a separate, explicitly scoped workflow or job so ordinary product checks do not depend on paid/network model calls unless that dependency is intentional.
+The foundational E2E test should stay deterministic and fake-backed. Live-provider checks should stay in separate, explicitly scoped workflows or jobs so ordinary product checks do not depend on paid/network model calls unless that dependency is intentional.
 
 ## GitHub Actions Secret
 
@@ -66,20 +66,37 @@ OpenRouter configuration is parsed at the provider boundary in `src/infrastructu
 
 The OpenRouter chat provider returns typed provider failures instead of throwing provider details into the domain. Missing keys, network failures, non-2xx responses, invalid response shapes, and empty or reasoning-only responses should become user-facing caveats that say OpenRouter output is unavailable. Do not include raw provider error bodies or secret values in user-facing UI, persisted reports, traces, or PR/issue text.
 
-## Local Live Contract Check
+## Local Live Contract Checks
 
 The normal test suite must not depend on live model calls. To verify the OpenRouter request contract locally, run the skipped-by-default live contract test with a request-scoped key:
 
 ```bash
-OPENROUTER_API_KEY="<local key>" RUN_OPENROUTER_LIVE=1 pnpm vitest run test/infrastructure/llm/openrouter-live-contract.test.ts
+OPENROUTER_API_KEY="<local key>" RUN_OPENROUTER_LIVE=1 pnpm exec vitest run test/infrastructure/llm/openrouter-live-contract.test.ts
 ```
 
 This test uses the configured default `openai/gpt-5-mini` and the explicit `openrouter/free` option, requests JSON object output, and asserts that OpenRouter returns parseable JSON content. Do not commit keys, paste keys into issue bodies, or include raw provider responses in logs.
 
+To verify the follow-up route boundary with a live model, run:
+
+```bash
+OPENROUTER_API_KEY="<local key>" RUN_OPENROUTER_LIVE=1 pnpm exec vitest run test/app/follow-up-live-contract.test.ts
+```
+
+This test exercises `/api/follow-up` with a fixture-backed report card and asserts that the route returns a validated chat-answer contract. It does not replace the deterministic Playwright E2E suite and should remain opt-in because it uses a paid/network provider.
+
+When using a local `.env.local`, load it without printing the key:
+
+```bash
+set -a
+. ./.env.local
+set +a
+RUN_OPENROUTER_LIVE=1 pnpm exec vitest run test/app/follow-up-live-contract.test.ts
+```
+
 ## Safety Rules
 
 - Keep the deterministic foundational E2E fake-backed.
-- Put live OpenRouter E2E in its own clearly named job.
+- Put live OpenRouter E2E or live contract checks in their own clearly named jobs.
 - Avoid running live-provider E2E on untrusted fork pull requests unless secrets are unavailable or the job is explicitly guarded.
 - Use a low-cost, structured-output-capable default where possible.
 - Fail with a clear missing-secret message if a live-provider job is manually requested without `OPENROUTER_API_KEY`.

--- a/src/app/api/follow-up/route.test.ts
+++ b/src/app/api/follow-up/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   ChatAnswerSchemaVersion,
@@ -17,6 +17,7 @@ import {
   FollowUpAnswerValidationError,
   FollowUpProviderError,
   handleFollowUpRequest,
+  POST,
   type FollowUpRouteOptions,
 } from "./route";
 
@@ -102,6 +103,42 @@ const reportCard: ReportCard = {
 };
 
 describe("POST /api/follow-up", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses follow-up controls that leave room for reasoning-model answers", async () => {
+    const providerRequests: Request[] = [];
+    vi.stubGlobal("fetch", async (providerRequest: Request) => {
+      providerRequests.push(providerRequest);
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({ answer: answeredContract().answer }),
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const response = await POST(jsonRequest(validStartRequest()));
+
+    expect(response.status).toBe(200);
+    expect(providerRequests).toHaveLength(1);
+    expect(await providerRequests[0]?.json()).toMatchObject({
+      max_tokens: 4_000,
+      reasoning: {
+        effort: "minimal",
+        exclude: true,
+      },
+      response_format: { type: "json_object" },
+    });
+  });
+
   it("starts a live follow-up from a red-style report section target and preserves evidence snippets", async () => {
     const repository = new InMemoryConversationRepository();
     const reviewer = new RecordingChatReviewer(answeredContract());

--- a/src/app/api/follow-up/route.ts
+++ b/src/app/api/follow-up/route.ts
@@ -127,8 +127,12 @@ export async function POST(request: Request): Promise<Response> {
       new OpenRouterChatReviewer({
         config: options.openRouterConfig,
         controls: {
-          maxOutputTokens: 900,
-          temperature: 0.25,
+          maxOutputTokens: 4_000,
+          reasoning: {
+            effort: "minimal",
+            exclude: true,
+          },
+          temperature: 0.2,
         },
       }),
   });

--- a/src/infrastructure/llm/openrouter-chat-provider.ts
+++ b/src/infrastructure/llm/openrouter-chat-provider.ts
@@ -14,8 +14,24 @@ export type OpenRouterChatMessage = {
   readonly content: string;
 };
 
+export type OpenRouterReasoningEffort =
+  | "xhigh"
+  | "high"
+  | "medium"
+  | "low"
+  | "minimal"
+  | "none";
+
+export type OpenRouterReasoningControls = {
+  readonly effort?: OpenRouterReasoningEffort;
+  readonly maxTokens?: number;
+  readonly exclude?: boolean;
+  readonly enabled?: boolean;
+};
+
 export type OpenRouterChatCompletionControls = {
   readonly maxOutputTokens?: number;
+  readonly reasoning?: OpenRouterReasoningControls;
   readonly responseFormat?: "json_object";
   readonly temperature?: number;
 };
@@ -79,6 +95,26 @@ const OpenRouterChatProviderResponseSchema = z
 const OpenRouterChatCompletionControlsSchema = z
   .object({
     maxOutputTokens: z.int().positive().optional(),
+    reasoning: z
+      .object({
+        effort: z
+          .enum(["xhigh", "high", "medium", "low", "minimal", "none"])
+          .optional(),
+        maxTokens: z.int().positive().optional(),
+        exclude: z.boolean().optional(),
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .refine(
+        (reasoning) =>
+          reasoning.effort === undefined || reasoning.maxTokens === undefined,
+        {
+          message:
+            "OpenRouter reasoning controls cannot include both effort and maxTokens.",
+          path: ["maxTokens"],
+        },
+      )
+      .optional(),
     responseFormat: z.literal("json_object").optional(),
     temperature: z.number().min(0).max(2).optional(),
   })
@@ -176,8 +212,6 @@ export class OpenRouterChatCompletionProvider {
       return providerFailure({
         model: request.config.model,
         code: "empty-response",
-        userFacingCaveat:
-          "OpenRouter reviewer output is unavailable because the provider returned no usable message content.",
       });
     }
 
@@ -203,17 +237,33 @@ function requestBodyControls(
   controls: OpenRouterChatCompletionControls | undefined,
 ): {
   readonly max_tokens?: number;
+  readonly reasoning?: {
+    readonly effort?: OpenRouterReasoningEffort;
+    readonly max_tokens?: number;
+    readonly exclude?: boolean;
+    readonly enabled?: boolean;
+  };
   readonly response_format?: { readonly type: "json_object" };
   readonly temperature?: number;
 } {
   const requestControls: {
     max_tokens?: number;
+    reasoning?: {
+      effort?: OpenRouterReasoningEffort;
+      max_tokens?: number;
+      exclude?: boolean;
+      enabled?: boolean;
+    };
     response_format?: { readonly type: "json_object" };
     temperature?: number;
   } = {};
 
   if (controls?.maxOutputTokens !== undefined) {
     requestControls.max_tokens = controls.maxOutputTokens;
+  }
+
+  if (controls?.reasoning !== undefined) {
+    requestControls.reasoning = requestBodyReasoning(controls.reasoning);
   }
 
   if (controls?.responseFormat !== undefined) {
@@ -236,12 +286,46 @@ function parseOpenRouterChatCompletionControls(
     ...(parsedControls.maxOutputTokens === undefined
       ? {}
       : { maxOutputTokens: parsedControls.maxOutputTokens }),
+    ...(parsedControls.reasoning === undefined
+      ? {}
+      : { reasoning: parsedReasoningControls(parsedControls.reasoning) }),
     ...(parsedControls.responseFormat === undefined
       ? {}
       : { responseFormat: parsedControls.responseFormat }),
     ...(parsedControls.temperature === undefined
       ? {}
       : { temperature: parsedControls.temperature }),
+  };
+}
+
+function parsedReasoningControls(
+  reasoning: NonNullable<
+    z.infer<typeof OpenRouterChatCompletionControlsSchema>["reasoning"]
+  >,
+): OpenRouterReasoningControls {
+  return {
+    ...(reasoning.effort === undefined ? {} : { effort: reasoning.effort }),
+    ...(reasoning.maxTokens === undefined
+      ? {}
+      : { maxTokens: reasoning.maxTokens }),
+    ...(reasoning.exclude === undefined ? {} : { exclude: reasoning.exclude }),
+    ...(reasoning.enabled === undefined ? {} : { enabled: reasoning.enabled }),
+  };
+}
+
+function requestBodyReasoning(reasoning: OpenRouterReasoningControls): {
+  readonly effort?: OpenRouterReasoningEffort;
+  readonly max_tokens?: number;
+  readonly exclude?: boolean;
+  readonly enabled?: boolean;
+} {
+  return {
+    ...(reasoning.effort === undefined ? {} : { effort: reasoning.effort }),
+    ...(reasoning.maxTokens === undefined
+      ? {}
+      : { max_tokens: reasoning.maxTokens }),
+    ...(reasoning.exclude === undefined ? {} : { exclude: reasoning.exclude }),
+    ...(reasoning.enabled === undefined ? {} : { enabled: reasoning.enabled }),
   };
 }
 
@@ -312,7 +396,7 @@ function userFacingProviderFailureCaveat(options: {
     case "invalid-response":
       return `OpenRouter reviewer output is unavailable because OpenRouter returned an unexpected response shape for ${options.model}. Retry the request or choose another structured-output-capable model.`;
     case "empty-response":
-      return `OpenRouter reviewer output is unavailable because OpenRouter returned no usable message content for ${options.model}. Retry the request or choose another structured-output-capable model.`;
+      return `OpenRouter reviewer output is unavailable because OpenRouter returned no usable message content for ${options.model}. The selected model may have spent its output budget on reasoning tokens; retry or choose another structured-output-capable model.`;
     case "missing-api-key":
       return "OpenRouter reviewer output is unavailable because OPENROUTER_API_KEY is not configured for this request.";
   }

--- a/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
+++ b/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
@@ -5,10 +5,17 @@ import {
   ChatAnswerContractSchema,
   type ChatAnswerContract,
 } from "../../domain/chat/chat-answer";
+import type { ConversationTarget } from "../../domain/chat/conversation";
 import type {
   ChatReviewer,
   ChatReviewerRequest,
 } from "../../application/follow-up-chat/follow-up-chat";
+import type {
+  DimensionAssessment,
+  ReportCard,
+  ReportCaveat,
+  ReportFinding,
+} from "../../domain/report/report-card";
 import {
   type OpenRouterChatCompletionControls,
   OpenRouterChatCompletionProvider,
@@ -54,7 +61,7 @@ export type OpenRouterChatReviewerOptions = {
   readonly now?: () => Date;
 };
 
-const DefaultFollowUpMaxOutputTokens = 1_200;
+const DefaultFollowUpMaxOutputTokens = 4_000;
 const DefaultFollowUpTemperature = 0.2;
 
 const ProviderChatAnswerResponseSchema = z
@@ -123,7 +130,7 @@ export class OpenRouterChatReviewer implements ChatReviewer {
     }
 
     const parsedAnswer = ProviderChatAnswerResponseSchema.safeParse(
-      parsedJson.value,
+      normalizeChatAnswerResponseInput(parsedJson.value),
     );
     if (!parsedAnswer.success) {
       throw new FollowUpAnswerValidationError(
@@ -159,6 +166,10 @@ function chatControls(
   return {
     maxOutputTokens:
       controls?.maxOutputTokens ?? DefaultFollowUpMaxOutputTokens,
+    reasoning: controls?.reasoning ?? {
+      effort: "minimal",
+      exclude: true,
+    },
     responseFormat: controls?.responseFormat ?? "json_object",
     temperature: controls?.temperature ?? DefaultFollowUpTemperature,
   };
@@ -176,7 +187,10 @@ type JsonParseResult =
 function systemPrompt(): string {
   return [
     "You answer follow-up questions about a repository quality report.",
-    "Return JSON only matching the chat-answer contract.",
+    "Return JSON only matching the chat-answer contract exactly.",
+    "The top-level response must be an object with one answer property.",
+    "Use the key summary for answer text; never use text, message, or answerText.",
+    "Do not include keys outside the requested response shape.",
     "Cite evidence references for every evidence-backed claim.",
     "Use insufficient-context when snippets or report context cannot support an answer.",
   ].join(" ");
@@ -184,17 +198,208 @@ function systemPrompt(): string {
 
 function promptContext(request: ChatReviewerRequest) {
   return {
-    reportCard: request.reportCard,
-    target: request.target,
+    report: compactReportContext(request.reportCard, request.target),
     question: request.question,
     evidence: request.evidence,
     responseShape: {
       answer: {
         schemaVersion: "chat-answer.v1",
-        status: "answered | insufficient-context",
+        status: "answered",
+        summary: "string",
+        evidenceBackedClaims: [
+          {
+            claim: "string",
+            citations: [
+              {
+                evidenceReference:
+                  "copy one exact evidenceReference object from evidence.snippets",
+                quote: "optional short quote from the snippet",
+              },
+            ],
+          },
+        ],
+        assumptions: [],
+        caveats: [
+          {
+            summary: "string",
+            missingEvidence: [],
+          },
+        ],
+        suggestedNextQuestions: [
+          {
+            question: "string",
+            rationale: "string",
+          },
+        ],
+      },
+      insufficientContextAnswer: {
+        schemaVersion: "chat-answer.v1",
+        status: "insufficient-context",
+        summary: "string",
+        missingContext: [
+          {
+            reason: "string",
+            requestedEvidence: "optional string",
+          },
+        ],
+        suggestedNextQuestions: [
+          {
+            question: "string",
+            rationale: "string",
+          },
+        ],
       },
     },
   };
+}
+
+function compactReportContext(
+  reportCard: ReportCard,
+  target: ConversationTarget,
+) {
+  return {
+    id: reportCard.id,
+    schemaVersion: reportCard.schemaVersion,
+    generatedAt: reportCard.generatedAt,
+    repository: reportCard.repository,
+    assessedArchetype: reportCard.assessedArchetype,
+    scoringPolicy: reportCard.scoringPolicy,
+    reviewerMetadata: reportCard.reviewerMetadata,
+    target: compactTargetContext(reportCard, target),
+  };
+}
+
+function compactTargetContext(
+  reportCard: ReportCard,
+  target: ConversationTarget,
+) {
+  switch (target.kind) {
+    case "report":
+      return {
+        kind: "report" as const,
+        dimensions: reportCard.dimensionAssessments.map(compactDimension),
+        caveats: reportCard.caveats.map(compactCaveat),
+        recommendedNextQuestions: reportCard.recommendedNextQuestions,
+      };
+    case "dimension": {
+      const assessment = reportCard.dimensionAssessments.find(
+        (candidate) => candidate.dimension === target.dimension,
+      );
+      return {
+        kind: "dimension" as const,
+        assessment:
+          assessment === undefined ? undefined : compactDimension(assessment),
+        caveats:
+          assessment === undefined
+            ? []
+            : caveatsForDimension(reportCard, assessment).map(compactCaveat),
+      };
+    }
+    case "finding": {
+      const match = findFinding(reportCard, target.findingId);
+      return {
+        kind: "finding" as const,
+        finding:
+          match === undefined ? undefined : compactFinding(match.finding),
+        dimension:
+          match === undefined ? undefined : compactDimension(match.assessment),
+      };
+    }
+    case "caveat": {
+      const caveat = reportCard.caveats.find(
+        (candidate) => candidate.id === target.caveatId,
+      );
+      return {
+        kind: "caveat" as const,
+        caveat: caveat === undefined ? undefined : compactCaveat(caveat),
+        affectedDimensions:
+          caveat === undefined
+            ? []
+            : reportCard.dimensionAssessments
+                .filter((assessment) =>
+                  caveat.affectedDimensions.includes(assessment.dimension),
+                )
+                .map(compactDimension),
+      };
+    }
+    case "evidence":
+      return {
+        kind: "evidence" as const,
+        evidenceReference: target.evidenceReference,
+      };
+  }
+}
+
+function compactDimension(assessment: DimensionAssessment) {
+  return {
+    dimension: assessment.dimension,
+    title: assessment.title,
+    summary: assessment.summary,
+    rating: assessment.rating,
+    ...(assessment.score === undefined ? {} : { score: assessment.score }),
+    confidence: assessment.confidence,
+    evidenceReferences: assessment.evidenceReferences,
+    findings: assessment.findings.map(compactFinding),
+    caveatIds: assessment.caveatIds,
+  };
+}
+
+function compactFinding(finding: ReportFinding) {
+  return {
+    id: finding.id,
+    dimension: finding.dimension,
+    severity: finding.severity,
+    title: finding.title,
+    summary: finding.summary,
+    confidence: finding.confidence,
+    evidenceReferences: finding.evidenceReferences,
+  };
+}
+
+function compactCaveat(caveat: ReportCaveat) {
+  return {
+    id: caveat.id,
+    title: caveat.title,
+    summary: caveat.summary,
+    affectedDimensions: caveat.affectedDimensions,
+    missingEvidence: caveat.missingEvidence,
+  };
+}
+
+function caveatsForDimension(
+  reportCard: ReportCard,
+  assessment: DimensionAssessment,
+): readonly ReportCaveat[] {
+  return reportCard.caveats.filter(
+    (caveat) =>
+      assessment.caveatIds.includes(caveat.id) ||
+      caveat.affectedDimensions.includes(assessment.dimension),
+  );
+}
+
+function findFinding(
+  reportCard: ReportCard,
+  findingId: string,
+):
+  | {
+      readonly assessment: DimensionAssessment;
+      readonly finding: ReportFinding;
+    }
+  | undefined {
+  for (const assessment of reportCard.dimensionAssessments) {
+    const finding = assessment.findings.find(
+      (candidate) => candidate.id === findingId,
+    );
+
+    if (finding !== undefined) {
+      return {
+        assessment,
+        finding,
+      };
+    }
+  }
+
+  return undefined;
 }
 
 function repositoryLabel(request: ChatReviewerRequest): string {
@@ -218,6 +423,113 @@ function parseJson(content: string): JsonParseResult {
       success: false,
     };
   }
+}
+
+function normalizeChatAnswerResponseInput(value: unknown): unknown {
+  if (!isRecord(value) || !isRecord(value.answer)) {
+    return value;
+  }
+
+  return {
+    ...value,
+    answer: normalizeChatAnswerInput(value.answer),
+  };
+}
+
+function normalizeChatAnswerInput(answer: Record<string, unknown>): unknown {
+  return withoutUndefinedEntries({
+    ...answer,
+    summary: normalizeAnswerSummary(answer),
+    evidenceBackedClaims: normalizeEvidenceBackedClaims(
+      answer.evidenceBackedClaims,
+    ),
+    text: undefined,
+    message: undefined,
+    answerText: undefined,
+  });
+}
+
+function normalizeAnswerSummary(answer: Record<string, unknown>): unknown {
+  if (typeof answer.summary === "string" && answer.summary.trim() !== "") {
+    return answer.summary;
+  }
+
+  if (typeof answer.text === "string" && answer.text.trim() !== "") {
+    return answer.text;
+  }
+
+  if (
+    typeof answer.answerText === "string" &&
+    answer.answerText.trim() !== ""
+  ) {
+    return answer.answerText;
+  }
+
+  if (typeof answer.message === "string" && answer.message.trim() !== "") {
+    return answer.message;
+  }
+
+  return answer.summary;
+}
+
+function normalizeEvidenceBackedClaims(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  return value.map((claim) => {
+    if (!isRecord(claim)) {
+      return claim;
+    }
+
+    return {
+      ...claim,
+      citations: normalizeCitations(claim.citations),
+    };
+  });
+}
+
+function normalizeCitations(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  return value.map((citation) => {
+    if (!isRecord(citation)) {
+      return citation;
+    }
+
+    return {
+      ...citation,
+      evidenceReference: normalizeCitationEvidenceReference(
+        citation.evidenceReference,
+      ),
+    };
+  });
+}
+
+function normalizeCitationEvidenceReference(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  if (isRecord(value.evidenceReference)) {
+    return value.evidenceReference;
+  }
+
+  return value;
+}
+
+function withoutUndefinedEntries(
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter((entry) => entry[1] !== undefined),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function toValidationIssue(issue: z.core.$ZodIssue): FollowUpValidationIssue {

--- a/test/app/follow-up-live-contract.test.ts
+++ b/test/app/follow-up-live-contract.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { POST } from "../../src/app/api/follow-up/route";
+import { OpenRouterDefaultModelId } from "../../src/infrastructure/llm/openrouter-config";
+import { analyzeRepositoryResponseFixture } from "../support/analyze-repository-response-fixture";
+
+const shouldRunLiveOpenRouter =
+  process.env.RUN_OPENROUTER_LIVE === "1" &&
+  process.env.OPENROUTER_API_KEY !== undefined &&
+  process.env.OPENROUTER_API_KEY.trim() !== "";
+
+const describeLiveOpenRouter = shouldRunLiveOpenRouter
+  ? describe
+  : describe.skip;
+
+describeLiveOpenRouter("OpenRouter follow-up route live contract", () => {
+  it("returns a validated follow-up answer through the route boundary", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/follow-up", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          reportCard: analyzeRepositoryResponseFixture.reportCard,
+          target: {
+            kind: "dimension",
+            dimension: "verifiability",
+          },
+          question: "Which tests are flaky?",
+          apiKey: requiredOpenRouterKey(),
+          model: OpenRouterDefaultModelId,
+        }),
+      }),
+    );
+    const body: unknown = await response.json();
+
+    expect(response.status, JSON.stringify(body)).toBe(200);
+    expect(body).toMatchObject({
+      answer: {
+        answer: {
+          schemaVersion: "chat-answer.v1",
+        },
+      },
+      conversation: {
+        messages: expect.any(Array),
+      },
+    });
+  }, 60_000);
+});
+
+function requiredOpenRouterKey(): string {
+  const apiKey = process.env.OPENROUTER_API_KEY?.trim();
+
+  if (apiKey === undefined || apiKey === "") {
+    throw new Error(
+      "OPENROUTER_API_KEY is required for live OpenRouter tests.",
+    );
+  }
+
+  return apiKey;
+}

--- a/test/infrastructure/llm/openrouter-chat-provider.test.ts
+++ b/test/infrastructure/llm/openrouter-chat-provider.test.ts
@@ -83,6 +83,10 @@ describe("OpenRouterChatCompletionProvider", () => {
       controls: {
         maxOutputTokens: 1_500,
         responseFormat: "json_object",
+        reasoning: {
+          effort: "minimal",
+          exclude: true,
+        },
         temperature: 0,
       },
     });
@@ -92,6 +96,10 @@ describe("OpenRouterChatCompletionProvider", () => {
       messages: [{ role: "user", content: "Review this evidence." }],
       metadata: { usageContext: "reviewer-assessment" },
       max_tokens: 1_500,
+      reasoning: {
+        effort: "minimal",
+        exclude: true,
+      },
       response_format: { type: "json_object" },
       temperature: 0,
     });
@@ -209,8 +217,7 @@ describe("OpenRouterChatCompletionProvider", () => {
       provider: "openrouter",
       model: OpenRouterDefaultModelId,
       code: "empty-response",
-      userFacingCaveat:
-        "OpenRouter reviewer output is unavailable because the provider returned no usable message content.",
+      userFacingCaveat: `OpenRouter reviewer output is unavailable because OpenRouter returned no usable message content for ${OpenRouterDefaultModelId}. The selected model may have spent its output budget on reasoning tokens; retry or choose another structured-output-capable model.`,
     });
   });
 

--- a/test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts
+++ b/test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,6 +10,7 @@ import {
   type Conversation,
 } from "../../../src/domain/chat/conversation";
 import type { RetrieveEvidenceForFollowUpResult } from "../../../src/domain/chat/evidence-retrieval";
+import type { ReportCard } from "../../../src/domain/report/report-card";
 import type { EvidenceReference } from "../../../src/domain/shared/evidence-reference";
 import type { OpenRouterChatCompletionProvider } from "../../../src/infrastructure/llm/openrouter-chat-provider";
 import {
@@ -26,6 +28,23 @@ const packageEvidence: EvidenceReference = {
   label: "Package manifest",
   path: "package.json",
 };
+
+const PromptContextSchema = z
+  .object({
+    report: z
+      .object({
+        repository: z.object({ name: z.string().min(1) }).passthrough(),
+        target: z.object({ kind: z.string().min(1) }).passthrough(),
+      })
+      .passthrough(),
+    reportCard: z.unknown().optional(),
+    responseShape: z
+      .object({
+        answer: z.object({ summary: z.string().min(1) }).passthrough(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
 
 describe("OpenRouterChatReviewer", () => {
   it("requests structured JSON output with follow-up-safe defaults", async () => {
@@ -69,7 +88,11 @@ describe("OpenRouterChatReviewer", () => {
       generatedAt: "2026-04-26T19:00:00.000Z",
     });
     expect(completionRequests[0]?.controls).toEqual({
-      maxOutputTokens: 1_200,
+      maxOutputTokens: 4_000,
+      reasoning: {
+        effort: "minimal",
+        exclude: true,
+      },
       responseFormat: "json_object",
       temperature: 0.2,
     });
@@ -118,9 +141,136 @@ describe("OpenRouterChatReviewer", () => {
 
     expect(completionRequests[0]?.controls).toEqual({
       maxOutputTokens: 900,
+      reasoning: {
+        effort: "minimal",
+        exclude: true,
+      },
       responseFormat: "json_object",
       temperature: 0.25,
     });
+  });
+
+  it("normalizes common provider JSON drift before validating chat answers", async () => {
+    const reviewer = new OpenRouterChatReviewer({
+      chatProvider: {
+        complete: async () => ({
+          kind: "completed",
+          provider: "openrouter",
+          model: OpenRouterDefaultModelId,
+          content: JSON.stringify({
+            answer: {
+              schemaVersion: "chat-answer.v1",
+              status: "answered",
+              text: "package.json defines a Vitest test script.",
+              evidenceBackedClaims: [
+                {
+                  claim: "The package manifest includes a test script.",
+                  citations: [
+                    {
+                      evidenceReference: {
+                        evidenceReference: packageEvidence,
+                      },
+                      quote: '"test": "vitest"',
+                    },
+                  ],
+                },
+              ],
+              assumptions: [],
+              caveats: [],
+              suggestedNextQuestions: [],
+            },
+          }),
+        }),
+      },
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: OpenRouterDefaultBaseUrl,
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const answer = await reviewer.answer({
+      reportCard,
+      conversation: conversation(),
+      target: { kind: "report" },
+      question: "What should we verify first?",
+      evidence: evidenceResult(),
+    });
+
+    expect(answer.answer).toMatchObject({
+      status: "answered",
+      summary: "package.json defines a Vitest test script.",
+      evidenceBackedClaims: [
+        {
+          citations: [
+            {
+              evidenceReference: packageEvidence,
+              quote: '"test": "vitest"',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("sends compact target report context instead of the full report card", async () => {
+    const completionRequests: Parameters<
+      OpenRouterChatCompletionProvider["complete"]
+    >[0][] = [];
+    const reviewer = new OpenRouterChatReviewer({
+      chatProvider: {
+        complete: async (completionRequest) => {
+          completionRequests.push(completionRequest);
+          return {
+            kind: "completed",
+            provider: "openrouter",
+            model: OpenRouterDefaultModelId,
+            content: JSON.stringify({ answer: answeredChatAnswer() }),
+          };
+        },
+      },
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: OpenRouterDefaultBaseUrl,
+      },
+    });
+    const unrelatedEvidence: EvidenceReference = {
+      id: "evidence:unrelated-large-file",
+      kind: "file",
+      label: "Unrelated large file",
+      path: "src/unrelated-large-file.ts",
+    };
+
+    await reviewer.answer({
+      reportCard: reportCardWithUnrelatedEvidence(unrelatedEvidence),
+      conversation: conversation(),
+      target: { kind: "dimension", dimension: "verifiability" },
+      question: "Which tests are flaky?",
+      evidence: evidenceResult(),
+    });
+
+    const userMessage = completionRequests[0]?.messages.find(
+      (message) => message.role === "user",
+    );
+
+    expect(userMessage?.content).not.toContain("src/unrelated-large-file.ts");
+    const promptContext = PromptContextSchema.parse(
+      JSON.parse(requiredContent(userMessage?.content)),
+    );
+    expect(promptContext.reportCard).toBeUndefined();
+    expect(promptContext.report.repository.name).toBe("minimal-node-library");
+    expect(promptContext.report.target).toMatchObject({
+      kind: "dimension",
+      assessment: {
+        dimension: "verifiability",
+      },
+    });
+    expect(promptContext.responseShape.answer.summary).toBe("string");
+    expect(promptContext.responseShape.answer).not.toHaveProperty("text");
   });
 });
 
@@ -182,4 +332,21 @@ function answeredChatAnswer(): ChatAnswer {
     caveats: [],
     suggestedNextQuestions: [],
   };
+}
+
+function reportCardWithUnrelatedEvidence(
+  unrelatedEvidence: EvidenceReference,
+): ReportCard {
+  return {
+    ...reportCard,
+    evidenceReferences: [...reportCard.evidenceReferences, unrelatedEvidence],
+  };
+}
+
+function requiredContent(content: string | undefined): string {
+  if (content === undefined) {
+    throw new Error("Expected prompt content to be recorded.");
+  }
+
+  return content;
 }


### PR DESCRIPTION
## Summary
- Compact follow-up prompts to targeted report context plus retrieved evidence instead of resending the full report card.
- Add OpenRouter reasoning controls and a larger follow-up output budget for reasoning-capable models.
- Normalize narrow provider JSON drift at the OpenRouter chat reviewer boundary and document live follow-up contract coverage.

## Real Provider Findings
- Production currently reproduces #149: analyze succeeds, then `/api/follow-up` returns `502 empty-response`.
- A direct OpenRouter probe of the old request shape returned `finishReason: length`, no message content, and all completion tokens spent as reasoning tokens.
- The fixed request shape returned usable JSON content with no hidden reasoning tokens; the local fixed route returned `200` for the same analyze plus follow-up flow.

## Verification
- `pnpm exec vitest run test/infrastructure/llm/openrouter-chat-provider.test.ts test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts src/app/api/follow-up/route.test.ts test/app/follow-up-live-contract.test.ts`
- `RUN_OPENROUTER_LIVE=1 pnpm exec vitest run test/app/follow-up-live-contract.test.ts` with local secret loaded from ignored `.env.local`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm check`
- `pnpm build`
- `pnpm test:e2e`

Note: local Node is v25.9.0 while the repo targets Node 24.x; `NODE_OPTIONS=--no-experimental-webstorage` is needed locally so Vitest/jsdom component tests use jsdom localStorage. CI should run on Node 24.x.

Closes #149