### PR TITLE
fix(chat): normalize insufficient-context follow-ups

### DIFF
--- a/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
+++ b/src/infrastructure/reviewer/openrouter-chat-reviewer.ts
@@ -437,16 +437,35 @@ function normalizeChatAnswerResponseInput(value: unknown): unknown {
 }
 
 function normalizeChatAnswerInput(answer: Record<string, unknown>): unknown {
-  return withoutUndefinedEntries({
+  const normalizedAnswer = withoutUndefinedEntries({
     ...answer,
     summary: normalizeAnswerSummary(answer),
-    evidenceBackedClaims: normalizeEvidenceBackedClaims(
-      answer.evidenceBackedClaims,
-    ),
     text: undefined,
     message: undefined,
     answerText: undefined,
   });
+
+  if (answer.status === "insufficient-context") {
+    return withoutUndefinedEntries({
+      ...normalizedAnswer,
+      missingContext: normalizeMissingContext(answer),
+      evidenceBackedClaims: undefined,
+      assumptions: undefined,
+      caveats: undefined,
+    });
+  }
+
+  if (answer.status === "answered") {
+    return withoutUndefinedEntries({
+      ...normalizedAnswer,
+      evidenceBackedClaims: normalizeEvidenceBackedClaims(
+        answer.evidenceBackedClaims,
+      ),
+      missingContext: undefined,
+    });
+  }
+
+  return normalizedAnswer;
 }
 
 function normalizeAnswerSummary(answer: Record<string, unknown>): unknown {
@@ -487,6 +506,57 @@ function normalizeEvidenceBackedClaims(value: unknown): unknown {
       citations: normalizeCitations(claim.citations),
     };
   });
+}
+
+function normalizeMissingContext(
+  answer: Record<string, unknown>,
+): readonly Record<string, unknown>[] | unknown {
+  if (Array.isArray(answer.missingContext)) {
+    return answer.missingContext;
+  }
+
+  const caveatContext = missingContextFromCaveats(answer.caveats);
+  if (caveatContext.length > 0) {
+    return caveatContext;
+  }
+
+  return [
+    {
+      reason:
+        "The model reported insufficient context without specific missing context details.",
+    },
+  ];
+}
+
+function missingContextFromCaveats(
+  value: unknown,
+): readonly Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((caveat) => {
+    if (!isRecord(caveat) || typeof caveat.summary !== "string") {
+      return [];
+    }
+
+    const requestedEvidence = firstString(caveat.missingEvidence);
+
+    return [
+      withoutUndefinedEntries({
+        reason: caveat.summary,
+        requestedEvidence,
+      }),
+    ];
+  });
+}
+
+function firstString(value: unknown): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.find((item): item is string => typeof item === "string");
 }
 
 function normalizeCitations(value: unknown): unknown {

--- a/test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts
+++ b/test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts
@@ -215,6 +215,71 @@ describe("OpenRouterChatReviewer", () => {
     });
   });
 
+  it("normalizes insufficient-context answers with answered-only leftovers", async () => {
+    const reviewer = new OpenRouterChatReviewer({
+      chatProvider: {
+        complete: async () => ({
+          kind: "completed",
+          provider: "openrouter",
+          model: OpenRouterDefaultModelId,
+          content: JSON.stringify({
+            answer: {
+              schemaVersion: "chat-answer.v1",
+              status: "insufficient-context",
+              summary: "No flaky test evidence was available.",
+              evidenceBackedClaims: [
+                {
+                  claim: "The report does not include flaky test evidence.",
+                  citations: [
+                    {
+                      evidenceReference: packageEvidence,
+                    },
+                  ],
+                },
+              ],
+              assumptions: [],
+              caveats: [
+                {
+                  summary: "Historical CI failure data was not provided.",
+                  missingEvidence: ["CI test failure history"],
+                },
+              ],
+              suggestedNextQuestions: [],
+            },
+          }),
+        }),
+      },
+      config: {
+        provider: "openrouter",
+        apiKey: "sk-or-v1-test",
+        model: OpenRouterDefaultModelId,
+        baseUrl: OpenRouterDefaultBaseUrl,
+      },
+      now: () => new Date("2026-04-26T12:00:00-07:00"),
+    });
+
+    const answer = await reviewer.answer({
+      reportCard,
+      conversation: conversation(),
+      target: { kind: "report" },
+      question: "Which tests are flaky?",
+      evidence: evidenceResult(),
+    });
+
+    expect(answer.answer).toEqual({
+      schemaVersion: "chat-answer.v1",
+      status: "insufficient-context",
+      summary: "No flaky test evidence was available.",
+      missingContext: [
+        {
+          reason: "Historical CI failure data was not provided.",
+          requestedEvidence: "CI test failure history",
+        },
+      ],
+      suggestedNextQuestions: [],
+    });
+  });
+
   it("sends compact target report context instead of the full report card", async () => {
     const completionRequests: Parameters<
       OpenRouterChatCompletionProvider["complete"]


### PR DESCRIPTION
## Summary
- Normalize OpenRouter answers that set `status: insufficient-context` but omit `missingContext`.
- Strip answered-only leftovers (`evidenceBackedClaims`, `assumptions`, `caveats`) from insufficient-context answers before domain validation.
- Convert caveat summaries/missing evidence into strict `missingContext` entries.

## Production Finding
After #152 deployed, production no longer failed with empty response content. A follow-up probe still returned `follow-up-answer-malformed` because the provider produced an insufficient-context answer with answered-only fields and no `missingContext`. This PR handles that narrow provider drift at the adapter boundary.

## Verification
- `pnpm exec vitest run test/infrastructure/reviewer/openrouter-chat-reviewer.test.ts test/app/follow-up-live-contract.test.ts`
- `RUN_OPENROUTER_LIVE=1 pnpm exec vitest run test/app/follow-up-live-contract.test.ts` with local secret loaded from ignored `.env.local`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm test`
- `pnpm build`
- `pnpm test:e2e`

Closes #149