### PR TITLE
docs(skills): establish skill authoring conventions (#140)

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,21 @@
+# `.agents/skills/`
+
+Project-level skills for every agent that runs against this repo (Claude Code, Codex CLI, pi).
+
+Each skill is a directory containing a `SKILL.md` file with YAML frontmatter (`name`, `description`, plus optional fields per the [Agent Skills specification](https://agentskills.io/specification)).
+
+```
+.agents/skills/
+├── README.md              # this file
+└── <skill-name>/
+    ├── SKILL.md           # required entry point
+    ├── scripts/           # optional helper scripts
+    ├── references/        # optional reference docs
+    └── assets/            # optional fixtures, templates, images
+```
+
+Pi reads this directory natively. Claude Code and Codex reach it via relative symlinks at `.claude/skills` and `.codex/skills` (see [docs/agent-compat.md](../../docs/agent-compat.md)).
+
+Don't add skill content under `.claude/skills/`, `.codex/skills/`, or `.pi/skills/` — those are symlinks pointing here; everything goes under `.agents/skills/<name>/`.
+
+For authoring rules, frontmatter fields, naming validation, and a review checklist, see [docs/skills.md](../../docs/skills.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ If a task conflicts with those documents, call out the conflict before editing. 
 - Do not treat raw test LOC, raw coverage, or single static scores as direct proof of repository quality.
 - Red-green enforcement is shared tooling, not a judgment call: `.claude/settings.json` guards in-session source edits, `lefthook.yml` guards staged commits, and both rely on `scripts/red-green-gate.ts`. Update the script and the two hook surfaces together when changing the workflow.
 - Cross-agent compatibility (Claude Code, Codex CLI, pi) is captured in [docs/agent-compat.md](docs/agent-compat.md). Shared skills live at `.agents/skills/`; each agent reaches them through a relative symlink. Keep the three hook surfaces (`.claude/settings.json`, `.codex/config.toml`, future `.pi/extensions/...`) aligned when changing red-green behavior.
+- Skill authoring conventions (frontmatter, naming, validation, review checklist) live in [docs/skills.md](docs/skills.md). Use Anthropic's `skill-creator` to scaffold new skills under `.agents/skills/<name>/`.
 
 ## Recent Misses
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,130 @@
+# Authoring Skills
+
+Skills are self-contained capability packages that a coding agent loads on demand. This repo follows the [Anthropic Agent Skills standard](https://agentskills.io/specification): each skill is a directory whose entry point is a `SKILL.md` file with YAML frontmatter and a Markdown body.
+
+For where skills live and how each agent discovers them, see [docs/agent-compat.md](agent-compat.md).
+
+## Location
+
+All project-level skills live at:
+
+```
+.agents/skills/<name>/SKILL.md
+```
+
+Pi reads `.agents/skills/` natively. Claude Code and Codex CLI reach the same directory through relative symlinks (`.claude/skills`, `.codex/skills`). Don't put skill content under `.claude/skills/`, `.codex/skills/`, or `.pi/skills/` directly — those are symlinks; everything goes in `.agents/skills/`.
+
+A skill's directory may contain helper files alongside `SKILL.md`:
+
+```
+.agents/skills/example/
+├── SKILL.md          # required: frontmatter + instructions
+├── scripts/          # helper scripts the agent may invoke
+├── references/       # detailed docs loaded on demand
+└── assets/           # images, fixtures, templates
+```
+
+Use relative paths from `SKILL.md` to reference helper files.
+
+## SKILL.md format
+
+```markdown
+---
+name: my-skill
+description: One sentence on what this skill does and when to use it. Be specific.
+---
+
+# my-skill
+
+## When to use
+
+...
+
+## Setup
+
+...
+
+## Usage
+
+...
+```
+
+## Frontmatter
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | 1–64 characters, lowercase letters, digits, hyphens. No leading or trailing hyphen, no consecutive hyphens. **Must match the parent directory name.** |
+| `description` | yes | Up to 1024 characters. Describes what the skill does *and when to use it*. The model decides whether to load the skill from this string, so be specific. |
+| `license` | no | License name or reference to a bundled file. |
+| `compatibility` | no | Up to 500 characters. Environment requirements (e.g., `requires Node 24+`). |
+| `metadata` | no | Arbitrary key/value mapping. |
+| `allowed-tools` | no | Space-delimited list of pre-approved tools (experimental, agent-dependent). |
+| `disable-model-invocation` | no | If `true`, hides the skill from the system prompt; users must invoke it explicitly via `/skill:<name>`. |
+
+### Naming rules (validated by every agent that follows the spec)
+
+- Must be lowercase letters, digits, and hyphens only.
+- Must not start or end with a hyphen.
+- Must not contain consecutive hyphens.
+- Must be 1–64 characters.
+- Must match the parent directory name exactly.
+
+### Description guidance
+
+The description is what the model sees in the system prompt. Bad descriptions cause the model to either skip a skill that would have helped or load one that shouldn't have applied.
+
+Good: `Web search and content extraction via the Brave Search API. Use when looking up documentation, current facts, or any web content.`
+
+Bad: `Helps with searches.`
+
+## Validation
+
+Pi (the lenient implementation) warns about violations but still loads the skill. Codex is stricter. Anthropic's `skill-creator` runs the same validations:
+
+- Name does not match parent directory.
+- Name exceeds 64 characters or contains invalid characters.
+- Name starts or ends with a hyphen, or has consecutive hyphens.
+- Description exceeds 1024 characters.
+- Description is missing entirely (this one is a hard load failure across all agents).
+
+## Discovery across agents
+
+| Agent | Discovery path |
+|---|---|
+| Claude Code | `.claude/skills/<name>/SKILL.md` (project) and `~/.claude/skills/` (global) |
+| Codex CLI | `.codex/skills/<name>/SKILL.md` (project, trust-gated) and `~/.codex/skills/` (global) |
+| pi | `.agents/skills/<name>/SKILL.md` (walks up to git root) and `~/.agents/skills/` and `~/.pi/agent/skills/` (global) |
+
+Because of the symlinks established by [docs/agent-compat.md](agent-compat.md), a single skill at `.agents/skills/<name>/SKILL.md` is visible to all three.
+
+## Authoring workflow
+
+Use Anthropic's `skill-creator` skill to scaffold a new skill. From any agent that has it installed, invoke `/skill:skill-creator` and follow its prompts. The output should be placed at `.agents/skills/<name>/`.
+
+If you're authoring by hand:
+
+1. Pick a name following the rules above.
+2. Create `.agents/skills/<name>/SKILL.md` with valid frontmatter.
+3. Add helper scripts under `scripts/`, references under `references/`, etc.
+4. Write a focused, behavior-driven test in `test/tooling/<name>.test.ts` if the skill drives a script with branching logic. Pure prompt skills don't need tests; scripts do.
+5. Verify the skill loads by starting a fresh agent session in the repo and confirming the skill name appears in the available-skills list.
+
+## Review checklist for a new skill
+
+Before merging a skill PR, the reviewer should check:
+
+- [ ] Name matches parent directory and conforms to naming rules.
+- [ ] Description is specific enough that the model knows when to use it.
+- [ ] `SKILL.md` body documents *when to use* the skill near the top, not just *how*.
+- [ ] Helper scripts are under the skill directory, not in `scripts/` at the repo root.
+- [ ] If the skill runs shell commands or scripts, those scripts have tooling tests under `test/tooling/`.
+- [ ] No secrets, tokens, or environment-specific paths checked in.
+- [ ] The skill is invocable from at least Claude Code (since this repo's red-green hook runs there); ideally verified in Codex and pi too if available.
+- [ ] If the skill replaces or supersedes existing tooling, the superseded code is removed in the same PR.
+
+## References
+
+- [Agent Skills specification](https://agentskills.io/specification)
+- [Anthropic Skills repository](https://github.com/anthropics/skills) — document processing, web development, and the `skill-creator` skill.
+- [Pi Skills repository](https://github.com/badlogic/pi-skills) — web search, browser automation, transcription.
+- [docs/agent-compat.md](agent-compat.md) — how the three agents see this directory.

--- a/test/tooling/skill-conventions.test.ts
+++ b/test/tooling/skill-conventions.test.ts
@@ -1,0 +1,75 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+describe("docs/skills.md", () => {
+  const skillsMd = (): string =>
+    readFileSync(path.join(repoRoot, "docs/skills.md"), "utf8");
+
+  it("exists as a regular file", () => {
+    const target = path.join(repoRoot, "docs/skills.md");
+    expect(existsSync(target)).toBe(true);
+    expect(statSync(target).isFile()).toBe(true);
+  });
+
+  it("places skills at the canonical .agents/skills/<name>/SKILL.md path", () => {
+    expect(skillsMd()).toMatch(/\.agents\/skills\/<name>\/SKILL\.md/);
+  });
+
+  it("documents the required frontmatter fields name and description", () => {
+    const content = skillsMd();
+    expect(content).toMatch(/^[-|]\s*\*?\*?name\*?\*?/im);
+    expect(content).toMatch(/^[-|]\s*\*?\*?description\*?\*?/im);
+  });
+
+  it("documents naming rules (lowercase, hyphens, max 64 chars, parent-dir match)", () => {
+    const content = skillsMd();
+    expect(content).toMatch(/lowercase/i);
+    expect(content).toMatch(/hyphen/i);
+    expect(content).toMatch(/64/);
+    expect(content).toMatch(/parent (directory|dir)/i);
+  });
+
+  it("explains how each of the three agents discovers skills", () => {
+    const content = skillsMd();
+    expect(content).toContain("Claude Code");
+    expect(content).toContain("Codex");
+    expect(content).toContain("pi");
+  });
+
+  it("points readers at the Anthropic skill-creator skill for scaffolding", () => {
+    expect(skillsMd()).toMatch(/skill-creator/i);
+  });
+
+  it("links to docs/agent-compat.md for the cross-agent path layout", () => {
+    expect(skillsMd()).toContain("agent-compat.md");
+  });
+
+  it("includes a review checklist for new skills", () => {
+    expect(skillsMd()).toMatch(/review checklist|review.+(skill|new skill)/i);
+  });
+});
+
+describe(".agents/skills/README.md", () => {
+  it("exists and explains the directory's purpose for someone browsing the repo", () => {
+    const target = path.join(repoRoot, ".agents/skills/README.md");
+    expect(existsSync(target)).toBe(true);
+    const content = readFileSync(target, "utf8");
+    expect(content).toContain(".agents/skills");
+    expect(content).toMatch(/SKILL\.md/);
+    expect(content).toMatch(/skills\.md|docs\/skills/i);
+  });
+});
+
+describe("AGENTS.md", () => {
+  it("links to docs/skills.md so future authors can find the convention", () => {
+    const content = readFileSync(path.join(repoRoot, "AGENTS.md"), "utf8");
+    expect(content).toContain("docs/skills.md");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #140

> Replaces #151, which was auto-closed when its parent branch (`139-cross-agent-compat`, now merged via #146) was deleted. Rebased onto current `main`; the diff is unchanged from the previously-reviewed state.

## Before Any Code Checklist

- [x] Linked issue (above)
- [x] Branch (`140-skill-conventions`, off `main`)
- [x] Preflight: skipped — preflight skill ships in #142.
- [x] Failing test (RED): `pnpm vitest run test/tooling/skill-conventions.test.ts` showed 10 failures before docs/skills.md, .agents/skills/README.md, and the AGENTS.md cross-reference were added; same command shows 10 passes after.
- [x] Architecture/plan check: `docs/architecture.md` and `docs/development-plan.md` skimmed — no conflicts. This PR is documentation only.

## Scope

Implements #140 — establishes the project's skill authoring conventions so the planned skills (`/preflight` in #142, `/distill-issue` and `/start-slice` in #143, plus future ones) have one clear place to consult before being added.

- `docs/skills.md` — full convention reference: canonical `.agents/skills/<name>/SKILL.md` location, frontmatter (`name`, `description`, optional fields per the Agent Skills spec), naming rules, validation, per-agent discovery paths, authoring workflow, and a review checklist for new skills.
- `.agents/skills/README.md` — placeholder explaining the directory's purpose for someone browsing the repo, with pointers back to the convention doc and the cross-agent-compat doc.
- `AGENTS.md` — one-line cross-reference under "Project-Specific Direction" so future agents find the convention from the front matter.

The convention stays close to the upstream Anthropic Agent Skills standard rather than inventing a private extension. The reference also points readers at the `skill-creator` skill for scaffolding.

## Non-Goals

- Implementing any concrete skill — that's #142, #143, and #144.
- A Lightstrike-private extension to the Agent Skills specification. If we need extra fields later, add them via the `metadata` frontmatter key per the spec.
- Replacing `.agents/skills/` with a different location (that's #146/#139's territory).

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests (233 passed + 3 skipped — 10 new in `test/tooling/skill-conventions.test.ts`)
- [x] Build (n/a — docs only)
- [x] Foundational E2E (n/a — docs only)

```text
pnpm check
# 45 test files, 233 passed + 3 skipped — 10 new
```

The 10 new tests assert *structural* requirements (canonical path appears, required frontmatter fields are documented, naming rules are documented, all three agents are mentioned, skill-creator is referenced, agent-compat.md is linked, review checklist exists, .agents/skills/README.md exists with the right pointers, AGENTS.md links to docs/skills.md). Wording can change freely without breaking the tests.

## Architecture and Docs

- [x] Follows `docs/architecture.md`.
- [x] No source/architecture changes.
- [x] No domain/application/infrastructure boundary violations.

## Type Safety

- [x] No `as any`, `: any`, `<any>`, `as unknown as`. (`pnpm type-escape:check` passes.)

## Risk and Rollback

**Risks:**
- The convention doc points at `skill-creator` from Anthropic's skills repo. If that skill's API or naming changes upstream, the doc will need a small update. Low risk; no compilation impact.
- The doc takes a position on validation strictness (referencing pi as lenient, Codex as strict). If those positions flip in a future release, update the doc.

**Rollback:**
- Single-commit revert removes `docs/skills.md`, `.agents/skills/README.md`, and the AGENTS.md cross-reference cleanly. No source code or tooling depends on this PR.

## Dependencies

None added.