### PR TITLE
feat(skills): preflight skill + docs/setup.md (#142)

### DIFF
--- a/.agents/skills/preflight/SKILL.md
+++ b/.agents/skills/preflight/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: preflight
+description: Audits a fresh clone of this repo for fork-day setup gaps before any code work begins. Verifies gh auth, git remote, branch protection, Vercel project link, lefthook install, Node and pnpm versions against package.json engines, presence of CI workflow files, and that the Claude Code red-green PreToolUse hook is wired up. Use at the start of every session on an unfamiliar clone, or whenever the AGENTS.md "Before Any Code" checklist asks for the preflight artifact.
+---
+
+# preflight
+
+Audits whether a freshly-cloned (or freshly-forked) checkout of this repo is set up for agent-driven development. Each check returns `pass`, `fail`, or `skip` with a remediation hint when it fails. The output goes straight into the chat as the artifact for AGENTS.md `Before Any Code` item 3.
+
+## When to use
+
+- The first time you open this repo on a new machine, in a new container, or after a fork.
+- At the start of any session that's about to land non-trivial code, when you're not certain the workspace is fully set up.
+- Whenever a hook unexpectedly doesn't fire (preflight will tell you whether `.claude/settings.json` and `lefthook` are installed).
+
+## What it checks
+
+| Check                      | What it verifies                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------ |
+| CI workflow files          | `.github/workflows/` exists and contains at least one `.yml`                                           |
+| Claude Code red-green hook | `.claude/settings.json` parses and declares `hooks.PreToolUse`                                         |
+| lefthook git hooks         | `.git/hooks/pre-commit` exists and looks like a lefthook-managed hook                                  |
+| git remote origin          | `git remote get-url origin` returns a URL                                                              |
+| Node version               | current `node` version satisfies `engines.node` from `package.json`                                    |
+| pnpm version               | current `pnpm --version` satisfies `engines.pnpm` from `package.json`                                  |
+| Vercel project link        | `.vercel/project.json` is present (skipped if absent — only relevant when this repo deploys to Vercel) |
+| gh auth status             | `gh auth status` exits 0 (skipped when `PREFLIGHT_SKIP_NETWORK=1`)                                     |
+| main branch protection     | `gh api repos/<owner>/<repo>/branches/main/protection` returns 200 (skipped when no network)           |
+
+## How to run it
+
+From the repo root:
+
+```bash
+node .agents/skills/preflight/scripts/preflight.ts
+```
+
+Or against a different target directory:
+
+```bash
+node .agents/skills/preflight/scripts/preflight.ts --target /path/to/clone
+```
+
+Environment variables:
+
+| Variable                   | Effect                                                                    |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `PREFLIGHT_SKIP_NETWORK=1` | Skip the `gh auth` and branch-protection checks (useful in CI or offline) |
+| `PREFLIGHT_NODE_VERSION`   | Override the detected Node version (used by tests)                        |
+| `PREFLIGHT_PNPM_VERSION`   | Override the detected pnpm version (used by tests)                        |
+
+## Output
+
+A Markdown table of `(name, status, detail)` followed by a remediation block listing only the failed checks and what to do about them. The script exits `0` when every check passes or skips, and `1` when at least one check fails.
+
+Paste the entire stdout block into chat as the `Before Any Code` item 3 artifact. The remediation block is the only thing you need to act on.
+
+## When a check fails
+
+The remediation hint tells you the next step. Common cases:
+
+- **Claude Code red-green hook**: not authoring from a clone that has `.claude/settings.json` from main, or settings file got reformatted. Restore from main.
+- **lefthook git hooks**: run `pnpm exec lefthook install` once.
+- **Node/pnpm version**: fix your runtime; `nvm use` for Node, `corepack prepare pnpm@<version> --activate` for pnpm.
+- **gh auth status**: `gh auth login` once.
+- **main branch protection**: only triggers if you have admin access; configure on GitHub.
+- **Vercel project link**: `vercel link` if this repo deploys to Vercel; otherwise the check stays in `skip`.
+
+## See also
+
+- [docs/setup.md](../../../docs/setup.md) — long-form fork-day verification with copy-pasteable commands.
+- [docs/agent-compat.md](../../../docs/agent-compat.md) — cross-agent layout that the Claude hook check expects.
+- [AGENTS.md](../../../AGENTS.md) — the `## Before Any Code` checklist that consumes this skill's output.

--- a/.agents/skills/preflight/scripts/preflight.ts
+++ b/.agents/skills/preflight/scripts/preflight.ts
@@ -1,0 +1,483 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { isAbsolute, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+export type CheckStatus = "pass" | "fail" | "skip";
+
+export type CheckResult = {
+  readonly name: string;
+  readonly status: CheckStatus;
+  readonly detail?: string;
+  readonly remediation?: string;
+};
+
+export type RunChecksOptions = {
+  readonly projectDir: string;
+  readonly currentNodeVersion?: string;
+  readonly currentPnpmVersion?: string;
+  readonly skipNetworkChecks?: boolean;
+};
+
+type CheckRunner = (options: RunChecksOptions) => CheckResult;
+
+const CHECKS: readonly CheckRunner[] = [
+  checkCiWorkflows,
+  checkClaudeRedGreenHook,
+  checkLefthookInstalled,
+  checkGitRemote,
+  checkNodeVersion,
+  checkPnpmVersion,
+  checkVercelLink,
+  checkGhAuth,
+  checkBranchProtection,
+];
+
+export function runChecks(options: RunChecksOptions): readonly CheckResult[] {
+  return CHECKS.map((check) => check(options));
+}
+
+function checkCiWorkflows(options: RunChecksOptions): CheckResult {
+  const dir = join(options.projectDir, ".github/workflows");
+  if (!existsSync(dir)) {
+    return {
+      name: "CI workflow files",
+      status: "fail",
+      remediation:
+        "Add a workflow under `.github/workflows/` so quality gate and preview deploy run on every PR.",
+    };
+  }
+  const yamlFiles = readdirSync(dir).filter(
+    (name) => name.endsWith(".yml") || name.endsWith(".yaml"),
+  );
+  if (yamlFiles.length === 0) {
+    return {
+      name: "CI workflow files",
+      status: "fail",
+      detail: ".github/workflows/ exists but contains no .yml files",
+      remediation:
+        "Add at least one workflow file under `.github/workflows/` (e.g., `ci.yml`).",
+    };
+  }
+  return {
+    name: "CI workflow files",
+    status: "pass",
+    detail: `${yamlFiles.length} workflow file(s)`,
+  };
+}
+
+function checkClaudeRedGreenHook(options: RunChecksOptions): CheckResult {
+  const settingsPath = join(options.projectDir, ".claude/settings.json");
+  if (!existsSync(settingsPath)) {
+    return {
+      name: "Claude Code red-green hook",
+      status: "fail",
+      remediation:
+        "Add `.claude/settings.json` with a PreToolUse hook invoking `scripts/red-green-gate.ts`. See docs/agent-compat.md.",
+    };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+  } catch (error) {
+    return {
+      name: "Claude Code red-green hook",
+      status: "fail",
+      detail: `failed to parse .claude/settings.json: ${(error as Error).message}`,
+    };
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !hasPreToolUseHook(parsed)
+  ) {
+    return {
+      name: "Claude Code red-green hook",
+      status: "fail",
+      detail: ".claude/settings.json is missing a PreToolUse hook",
+      remediation:
+        "Add `hooks.PreToolUse` matching `Edit|Write|MultiEdit` to `.claude/settings.json`. See docs/agent-compat.md.",
+    };
+  }
+  return {
+    name: "Claude Code red-green hook",
+    status: "pass",
+    detail: ".claude/settings.json declares a PreToolUse hook",
+  };
+}
+
+function hasPreToolUseHook(value: object): boolean {
+  if (!("hooks" in value)) {
+    return false;
+  }
+  const hooks = (value as { readonly hooks?: unknown }).hooks;
+  if (typeof hooks !== "object" || hooks === null) {
+    return false;
+  }
+  if (!("PreToolUse" in hooks)) {
+    return false;
+  }
+  const preToolUse = (hooks as { readonly PreToolUse?: unknown }).PreToolUse;
+  return Array.isArray(preToolUse) && preToolUse.length > 0;
+}
+
+function checkLefthookInstalled(options: RunChecksOptions): CheckResult {
+  const hooksDirResult = spawnSync(
+    "git",
+    ["-C", options.projectDir, "rev-parse", "--git-path", "hooks"],
+    { encoding: "utf8" },
+  );
+  if (hooksDirResult.error !== undefined || hooksDirResult.status !== 0) {
+    return {
+      name: "lefthook git hooks",
+      status: "fail",
+      detail: "could not resolve git hooks directory",
+      remediation: "Ensure the project is a git checkout.",
+    };
+  }
+  const rawHooksDir = hooksDirResult.stdout.trim();
+  const hooksDir = isAbsolute(rawHooksDir)
+    ? rawHooksDir
+    : join(options.projectDir, rawHooksDir);
+  const hookPath = join(hooksDir, "pre-commit");
+  if (!existsSync(hookPath)) {
+    return {
+      name: "lefthook git hooks",
+      status: "fail",
+      remediation:
+        "Run `pnpm exec lefthook install` to install the pre-commit and commit-msg hooks.",
+    };
+  }
+  const content = readFileSync(hookPath, "utf8");
+  if (!/lefthook/i.test(content)) {
+    return {
+      name: "lefthook git hooks",
+      status: "fail",
+      detail:
+        ".git/hooks/pre-commit exists but does not look like a lefthook hook",
+      remediation:
+        "Run `pnpm exec lefthook install` to overwrite with the lefthook-managed hook.",
+    };
+  }
+  return {
+    name: "lefthook git hooks",
+    status: "pass",
+  };
+}
+
+function checkGitRemote(options: RunChecksOptions): CheckResult {
+  const result = spawnSync(
+    "git",
+    ["-C", options.projectDir, "remote", "get-url", "origin"],
+    {
+      encoding: "utf8",
+    },
+  );
+  if (result.error !== undefined || result.status !== 0) {
+    return {
+      name: "git remote origin",
+      status: "fail",
+      detail: result.stderr?.trim() ?? "git remote get-url origin failed",
+      remediation:
+        "Add a remote with `git remote add origin <url>` pointing at the GitHub repo.",
+    };
+  }
+  return {
+    name: "git remote origin",
+    status: "pass",
+    detail: result.stdout.trim(),
+  };
+}
+
+function checkNodeVersion(options: RunChecksOptions): CheckResult {
+  const engines = readEngines(options.projectDir);
+  if (engines === undefined) {
+    return {
+      name: "Node version vs engines.node",
+      status: "fail",
+      remediation:
+        "Add a `package.json` at the project root with an `engines.node` constraint.",
+    };
+  }
+  const required = engines.node;
+  if (required === undefined) {
+    return {
+      name: "Node version vs engines.node",
+      status: "skip",
+      detail: "package.json has no engines.node",
+    };
+  }
+  const current = (options.currentNodeVersion ?? process.version).replace(
+    /^v/,
+    "",
+  );
+  if (versionMatches(current, required)) {
+    return {
+      name: "Node version vs engines.node",
+      status: "pass",
+      detail: `${current} satisfies ${required}`,
+    };
+  }
+  return {
+    name: "Node version vs engines.node",
+    status: "fail",
+    detail: `${current} does not satisfy ${required}`,
+    remediation: `Switch Node to ${required} (e.g., \`nvm use\`).`,
+  };
+}
+
+function checkPnpmVersion(options: RunChecksOptions): CheckResult {
+  const engines = readEngines(options.projectDir);
+  if (engines?.pnpm === undefined) {
+    return {
+      name: "pnpm version vs engines.pnpm",
+      status: "skip",
+      detail: "package.json has no engines.pnpm",
+    };
+  }
+  const required = engines.pnpm;
+  const current = options.currentPnpmVersion ?? readPnpmVersion();
+  if (current === undefined) {
+    return {
+      name: "pnpm version vs engines.pnpm",
+      status: "fail",
+      detail: "could not determine pnpm version",
+      remediation: "Install pnpm and ensure it is on PATH.",
+    };
+  }
+  if (versionMatches(current, required)) {
+    return {
+      name: "pnpm version vs engines.pnpm",
+      status: "pass",
+      detail: `${current} satisfies ${required}`,
+    };
+  }
+  return {
+    name: "pnpm version vs engines.pnpm",
+    status: "fail",
+    detail: `${current} does not satisfy ${required}`,
+    remediation: `Install pnpm ${required} (e.g., \`corepack enable\` then \`corepack prepare pnpm@${required} --activate\`).`,
+  };
+}
+
+function checkVercelLink(options: RunChecksOptions): CheckResult {
+  const projectFile = join(options.projectDir, ".vercel/project.json");
+  if (existsSync(projectFile)) {
+    return {
+      name: "Vercel project link",
+      status: "pass",
+      detail: ".vercel/project.json present",
+    };
+  }
+  return {
+    name: "Vercel project link",
+    status: "skip",
+    detail:
+      ".vercel/project.json missing (run `vercel link` if this repo deploys to Vercel)",
+  };
+}
+
+function checkGhAuth(options: RunChecksOptions): CheckResult {
+  if (options.skipNetworkChecks === true) {
+    return {
+      name: "gh auth status",
+      status: "skip",
+      detail: "skipped (PREFLIGHT_SKIP_NETWORK=1)",
+    };
+  }
+  const result = spawnSync("gh", ["auth", "status"], { encoding: "utf8" });
+  if (result.error !== undefined) {
+    return {
+      name: "gh auth status",
+      status: "fail",
+      detail: "gh CLI not installed or not on PATH",
+      remediation: "Install GitHub CLI: https://cli.github.com/",
+    };
+  }
+  if (result.status !== 0) {
+    return {
+      name: "gh auth status",
+      status: "fail",
+      detail: result.stderr?.trim() ?? "gh auth status returned non-zero",
+      remediation: "Run `gh auth login`.",
+    };
+  }
+  return {
+    name: "gh auth status",
+    status: "pass",
+  };
+}
+
+function checkBranchProtection(options: RunChecksOptions): CheckResult {
+  if (options.skipNetworkChecks === true) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "skipped (PREFLIGHT_SKIP_NETWORK=1)",
+    };
+  }
+  const remoteResult = spawnSync(
+    "git",
+    ["-C", options.projectDir, "remote", "get-url", "origin"],
+    { encoding: "utf8" },
+  );
+  if (remoteResult.status !== 0) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "no origin remote",
+    };
+  }
+  const slug = parseGitHubSlug(remoteResult.stdout.trim());
+  if (slug === undefined) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "origin is not a GitHub remote",
+    };
+  }
+  const protection = spawnSync(
+    "gh",
+    ["api", `repos/${slug}/branches/main/protection`],
+    { encoding: "utf8" },
+  );
+  if (protection.error !== undefined) {
+    return {
+      name: "main branch protection",
+      status: "skip",
+      detail: "gh CLI not installed",
+    };
+  }
+  if (protection.status !== 0) {
+    return {
+      name: "main branch protection",
+      status: "fail",
+      detail:
+        "no branch protection configured on main (or no permission to read it)",
+      remediation:
+        "Configure branch protection on `main` to require PR review and CI checks.",
+    };
+  }
+  return {
+    name: "main branch protection",
+    status: "pass",
+  };
+}
+
+function readEngines(projectDir: string):
+  | {
+      readonly node?: string;
+      readonly pnpm?: string;
+    }
+  | undefined {
+  const packageJsonPath = join(projectDir, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    if (typeof parsed === "object" && parsed !== null && "engines" in parsed) {
+      const engines = (parsed as { readonly engines: unknown }).engines;
+      if (typeof engines === "object" && engines !== null) {
+        const obj = engines as {
+          readonly node?: unknown;
+          readonly pnpm?: unknown;
+        };
+        return {
+          ...(typeof obj.node === "string" && { node: obj.node }),
+          ...(typeof obj.pnpm === "string" && { pnpm: obj.pnpm }),
+        };
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return {};
+}
+
+function readPnpmVersion(): string | undefined {
+  const result = spawnSync("pnpm", ["--version"], { encoding: "utf8" });
+  if (result.error !== undefined || result.status !== 0) {
+    return undefined;
+  }
+  return result.stdout.trim();
+}
+
+function versionMatches(current: string, required: string): boolean {
+  const trimmedRequired = required.trim();
+  if (trimmedRequired.endsWith(".x")) {
+    const major = trimmedRequired.slice(0, -2);
+    const currentMajor = current.split(".")[0] ?? "";
+    return currentMajor === major;
+  }
+  return current === trimmedRequired;
+}
+
+function parseGitHubSlug(remoteUrl: string): string | undefined {
+  const trimmed = remoteUrl.trim();
+  const httpsMatch = trimmed.match(
+    /github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?\/?$/,
+  );
+  if (httpsMatch !== null && httpsMatch[1] !== undefined) {
+    return httpsMatch[1];
+  }
+  return undefined;
+}
+
+function renderMarkdownTable(results: readonly CheckResult[]): string {
+  const lines: string[] = ["| name | status | detail |", "| --- | --- | --- |"];
+  for (const result of results) {
+    const detail = result.detail ?? "";
+    const status = `\`${result.status}\``;
+    lines.push(
+      `| ${escapePipe(result.name)} | ${status} | ${escapePipe(detail)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function escapePipe(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+async function main(): Promise<void> {
+  const targetIdx = process.argv.indexOf("--target");
+  const projectDir =
+    targetIdx >= 0 && process.argv[targetIdx + 1] !== undefined
+      ? process.argv[targetIdx + 1]!
+      : process.cwd();
+  const skipNetwork = process.env.PREFLIGHT_SKIP_NETWORK === "1";
+  const overrideNode = process.env.PREFLIGHT_NODE_VERSION;
+  const overridePnpm = process.env.PREFLIGHT_PNPM_VERSION;
+
+  const results = runChecks({
+    projectDir,
+    skipNetworkChecks: skipNetwork,
+    ...(overrideNode !== undefined && { currentNodeVersion: overrideNode }),
+    ...(overridePnpm !== undefined && { currentPnpmVersion: overridePnpm }),
+  });
+
+  process.stdout.write(`${renderMarkdownTable(results)}\n`);
+
+  const failed = results.filter((r) => r.status === "fail");
+  if (failed.length > 0) {
+    process.stdout.write(
+      `\n${failed.length} check(s) failed. See remediation hints above.\n`,
+    );
+    for (const f of failed) {
+      if (f.remediation !== undefined) {
+        process.stdout.write(`- ${f.name}: ${f.remediation}\n`);
+      }
+    }
+    process.exit(1);
+  }
+  process.stdout.write("\nAll preflight checks passed (or skipped).\n");
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,128 @@
+# Fork-Day Setup
+
+This is the long-form verification an agent (or a person) should run the first time they open this repo on a new machine. The `/preflight` skill (`.agents/skills/preflight/SKILL.md`) automates most of it; this doc explains the *why* and gives copy-pasteable commands for fixing any check that fails.
+
+If you're an agent, the AGENTS.md `## Before Any Code` checklist asks you to run `/preflight` and paste the output. That's normally enough. Read the rest of this doc only when a check fails or you're setting things up for the first time.
+
+## Quick run
+
+```bash
+# from a fresh clone
+pnpm install
+node .agents/skills/preflight/scripts/preflight.ts
+```
+
+Expect to see every row pass except possibly Vercel (skipped on machines that don't deploy this repo) and the network-dependent rows (skipped if you've set `PREFLIGHT_SKIP_NETWORK=1`).
+
+## Each check, in detail
+
+### 1. GitHub CLI authentication (`gh auth status`)
+
+```bash
+gh auth status
+```
+
+Why: agents in this repo use `gh` to open issues and PRs (`gh pr create`, `gh issue create`). Anything else built on it (the `/distill-issue` skill in #143) silently produces wrong results without auth.
+
+If it fails: run `gh auth login` (browser flow). Inside CI or non-interactive shells, set a `GH_TOKEN` env var instead.
+
+### 2. Git remote (`git remote get-url origin`)
+
+```bash
+git remote -v
+```
+
+Why: every PR opens against `origin`. A clone created without the remote (uncommon but happens) breaks `git push` and the GitHub-side automations.
+
+If it fails: `git remote add origin git@github.com:lightstrikelabs/repo-analyzer-green.git` (or HTTPS).
+
+### 3. Branch protection on `main`
+
+```bash
+gh api repos/lightstrikelabs/repo-analyzer-green/branches/main/protection
+```
+
+Why: AGENTS.md disallows direct pushes to `main` and requires CI green before merge. If branch protection isn't configured (or isn't readable), unintended direct pushes can happen.
+
+If it fails: requires admin access to the repo. Configure under Settings → Branches on GitHub.
+
+### 4. Vercel project link (`.vercel/project.json`)
+
+```bash
+ls .vercel/project.json
+# or
+vercel link
+```
+
+Why: the Vercel preview deploys are part of the PR feedback loop. Each PR comment pulls in the deploy URL. A clone without the link can't run preview deploys locally.
+
+If it's `skip`: only matters if you're driving deploys from this clone. Most agents don't need it.
+
+### 5. lefthook install
+
+```bash
+pnpm exec lefthook install
+```
+
+Why: the commit-time red-green gate (#114) and the conventional-commit check both run via lefthook hooks at `.git/hooks/pre-commit` and `.git/hooks/commit-msg`. Without `lefthook install`, those hooks don't exist and commits skip the gates entirely.
+
+If it fails: re-run the command above. Verify with `cat .git/hooks/pre-commit` (should reference `lefthook`).
+
+### 6. Node version
+
+```bash
+node --version
+grep '"node"' package.json
+```
+
+Why: the project pins a Node major version under `engines.node` to keep TypeScript stripping, native fetch, and Next.js 16 behavior consistent.
+
+If it fails: `nvm use` (a `.nvmrc` is on the way; until then, use the version from `package.json`).
+
+### 7. pnpm version
+
+```bash
+pnpm --version
+grep '"pnpm"' package.json
+```
+
+Why: `engines.pnpm` is pinned exactly. Lockfile resolution and the workspace install behavior change between minor pnpm versions.
+
+If it fails: enable corepack and pin the version:
+
+```bash
+corepack enable
+corepack prepare pnpm@$(node -p "require('./package.json').engines.pnpm") --activate
+```
+
+### 8. CI workflow files
+
+```bash
+ls .github/workflows
+```
+
+Why: the Quality Gate and Preview E2E workflows enforce the `pnpm check` and `pnpm test:e2e` gates on every PR. A fork without workflow files merges without a gate.
+
+If it fails: the workflows live on `main`; rebase your fork or copy the files in.
+
+### 9. Claude Code red-green hook (`.claude/settings.json`)
+
+```bash
+node -e 'console.log(Object.keys(JSON.parse(require("fs").readFileSync(".claude/settings.json","utf8")).hooks ?? {}))'
+```
+
+Why: the in-session PreToolUse gate (#105) lives here. Without it, agents can edit `src/**` source files without a colocated test file in the same session, defeating the TDD lever the project relies on. See `docs/agent-compat.md` for the equivalent Codex configuration in `.codex/config.toml`.
+
+If it fails: the hook config is on `main`; rebase or copy `.claude/settings.json` and `scripts/red-green-gate.ts`.
+
+## Cross-agent setup
+
+If you're driving this repo from a non-Claude agent, also read `docs/agent-compat.md`. The skills layout is shared via symlinks; the hook needs to be wired separately for Codex (`.codex/config.toml`) and pi (deferred — see issue #144).
+
+## Windows notes
+
+The cross-agent symlinks (`.claude/skills`, `.codex/skills`, `.pi/skills`) require Developer Mode (Windows 10 1703 or later) or admin privileges. On a Windows clone without those, the symlinks resolve to broken targets. There is no first-class workaround in this repo yet; raise an issue if you need one.
+
+## Bootstrapping notes
+
+When you're authoring `/preflight` itself (PR #142, the one that introduced this doc), the manual checklist *is* the preflight. The `## Before Any Code` item 3 artifact in that PR is "bootstrap exempt — see PR description." Subsequent PRs use the skill output instead.

--- a/test/tooling/preflight.test.ts
+++ b/test/tooling/preflight.test.ts
@@ -1,0 +1,311 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+import { describe, expect, it } from "vitest";
+
+import {
+  runChecks,
+  type CheckResult,
+  type RunChecksOptions,
+} from "../../.agents/skills/preflight/scripts/preflight";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const scriptPath = path.join(
+  repoRoot,
+  ".agents/skills/preflight/scripts/preflight.ts",
+);
+
+type FixtureOverrides = {
+  readonly omitWorkflows?: boolean;
+  readonly omitClaudeSettings?: boolean;
+  readonly omitClaudeHook?: boolean;
+  readonly nodeEngine?: string;
+  readonly pnpmEngine?: string;
+};
+
+function makeFixture(overrides: FixtureOverrides = {}): {
+  readonly dir: string;
+  readonly cleanup: () => void;
+} {
+  const dir = mkdtempSync(path.join(tmpdir(), "green-preflight-"));
+
+  spawnSync("git", ["-C", dir, "init", "--quiet"]);
+  spawnSync("git", [
+    "-C",
+    dir,
+    "remote",
+    "add",
+    "origin",
+    "https://github.com/lightstrikelabs/preflight-fixture.git",
+  ]);
+  writeFileSync(
+    path.join(dir, ".git/hooks/pre-commit"),
+    "#!/bin/sh\n# LEFTHOOK\nexit 0\n",
+  );
+
+  writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name: "fixture",
+        engines: {
+          node: overrides.nodeEngine ?? "24.x",
+          pnpm: overrides.pnpmEngine ?? "10.29.3",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (overrides.omitWorkflows !== true) {
+    mkdirSync(path.join(dir, ".github/workflows"), { recursive: true });
+    writeFileSync(
+      path.join(dir, ".github/workflows/ci.yml"),
+      "name: ci\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
+    );
+  }
+
+  if (overrides.omitClaudeSettings !== true) {
+    mkdirSync(path.join(dir, ".claude"), { recursive: true });
+    if (overrides.omitClaudeHook === true) {
+      writeFileSync(path.join(dir, ".claude/settings.json"), "{}\n");
+    } else {
+      writeFileSync(
+        path.join(dir, ".claude/settings.json"),
+        JSON.stringify(
+          {
+            hooks: {
+              PreToolUse: [
+                {
+                  matcher: "Edit|Write|MultiEdit",
+                  hooks: [{ type: "command", command: "node /dev/null" }],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+      );
+    }
+  }
+
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { force: true, recursive: true }),
+  };
+}
+
+const baseOptions = (
+  dir: string,
+  extras: Partial<RunChecksOptions> = {},
+): RunChecksOptions => ({
+  projectDir: dir,
+  currentNodeVersion: "v24.14.0",
+  currentPnpmVersion: "10.29.3",
+  skipNetworkChecks: true,
+  ...extras,
+});
+
+function findCheck(
+  results: readonly CheckResult[],
+  pattern: RegExp,
+): CheckResult {
+  const match = results.find((r) => pattern.test(r.name));
+  if (match === undefined) {
+    throw new Error(
+      `no check matched ${pattern}; saw: ${results.map((r) => r.name).join(", ")}`,
+    );
+  }
+  return match;
+}
+
+describe("preflight runChecks", () => {
+  it("reports no failures for a fully-configured fixture", () => {
+    const { dir, cleanup } = makeFixture();
+    try {
+      const results = runChecks(baseOptions(dir));
+      const failures = results.filter((r) => r.status === "fail");
+      expect(failures.map((f) => f.name)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("fails the CI workflow check when .github/workflows is missing", () => {
+    const { dir, cleanup } = makeFixture({ omitWorkflows: true });
+    try {
+      const results = runChecks(baseOptions(dir));
+      const ci = findCheck(results, /CI workflow/i);
+      expect(ci.status).toBe("fail");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("fails the Claude hook check when .claude/settings.json is missing", () => {
+    const { dir, cleanup } = makeFixture({ omitClaudeSettings: true });
+    try {
+      const results = runChecks(baseOptions(dir));
+      const hook = findCheck(results, /Claude.*hook|red-green hook/i);
+      expect(hook.status).toBe("fail");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("fails the Claude hook check when settings.json lacks a PreToolUse hook", () => {
+    const { dir, cleanup } = makeFixture({ omitClaudeHook: true });
+    try {
+      const results = runChecks(baseOptions(dir));
+      const hook = findCheck(results, /Claude.*hook|red-green hook/i);
+      expect(hook.status).toBe("fail");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("fails the Node version check when current version does not match engines.node", () => {
+    const { dir, cleanup } = makeFixture({ nodeEngine: "20.x" });
+    try {
+      const results = runChecks(
+        baseOptions(dir, { currentNodeVersion: "v24.14.0" }),
+      );
+      const node = findCheck(results, /Node/i);
+      expect(node.status).toBe("fail");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("fails the pnpm version check when current pnpm does not match engines.pnpm", () => {
+    const { dir, cleanup } = makeFixture({ pnpmEngine: "9.0.0" });
+    try {
+      const results = runChecks(
+        baseOptions(dir, { currentPnpmVersion: "10.29.3" }),
+      );
+      const pnpmCheck = findCheck(results, /pnpm/i);
+      expect(pnpmCheck.status).toBe("fail");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("passes the lefthook check inside a git worktree (.git is a file pointing at the main git dir)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "green-preflight-wt-"));
+    const mainGitDir = mkdtempSync(
+      path.join(tmpdir(), "green-preflight-wt-main-"),
+    );
+    try {
+      spawnSync("git", ["init", "--quiet", mainGitDir]);
+      spawnSync("git", [
+        "-C",
+        mainGitDir,
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/lightstrikelabs/preflight-fixture.git",
+      ]);
+      const realWorktreeGitDir = path.join(
+        mainGitDir,
+        ".git/worktrees/fake-wt",
+      );
+      mkdirSync(realWorktreeGitDir, { recursive: true });
+      writeFileSync(
+        path.join(mainGitDir, ".git/hooks/pre-commit"),
+        "#!/bin/sh\n# LEFTHOOK\nexit 0\n",
+      );
+      writeFileSync(path.join(dir, ".git"), `gitdir: ${realWorktreeGitDir}\n`);
+      writeFileSync(
+        path.join(realWorktreeGitDir, "commondir"),
+        path.join(mainGitDir, ".git"),
+      );
+      writeFileSync(
+        path.join(realWorktreeGitDir, "HEAD"),
+        "ref: refs/heads/fake\n",
+      );
+      writeFileSync(
+        path.join(dir, "package.json"),
+        JSON.stringify(
+          { name: "wt", engines: { node: "24.x", pnpm: "10.29.3" } },
+          null,
+          2,
+        ),
+      );
+
+      const results = runChecks(baseOptions(dir));
+      const lefthook = findCheck(results, /lefthook/i);
+      expect(lefthook.status).toBe("pass");
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+      rmSync(mainGitDir, { force: true, recursive: true });
+    }
+  });
+
+  it("each result carries a name and a status", () => {
+    const { dir, cleanup } = makeFixture();
+    try {
+      const results = runChecks(baseOptions(dir));
+      expect(results.length).toBeGreaterThan(0);
+      for (const result of results) {
+        expect(typeof result.name).toBe("string");
+        expect(["pass", "fail", "skip"]).toContain(result.status);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("preflight CLI", () => {
+  function runCli(targetDir: string): ReturnType<typeof spawnSync> {
+    return spawnSync(process.execPath, [scriptPath, "--target", targetDir], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PREFLIGHT_SKIP_NETWORK: "1",
+        PREFLIGHT_NODE_VERSION: "v24.14.0",
+        PREFLIGHT_PNPM_VERSION: "10.29.3",
+      },
+    });
+  }
+
+  it("exits 0 when every check passes or skips", () => {
+    const { dir, cleanup } = makeFixture();
+    try {
+      const result = runCli(dir);
+      expect(result.status).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("exits non-zero when at least one check fails", () => {
+    const { dir, cleanup } = makeFixture({ omitWorkflows: true });
+    try {
+      const result = runCli(dir);
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toMatch(/CI workflow/i);
+      expect(result.stdout).toMatch(/fail/i);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("prints a markdown-style summary with one row per check", () => {
+    const { dir, cleanup } = makeFixture();
+    try {
+      const result = runCli(dir);
+      expect(result.stdout).toMatch(/^\|.*name.*\|.*status.*\|/im);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #142

## Before Any Code Checklist

- [x] Linked issue (above)
- [x] Branch (`142-preflight-skill`, off `main`)
- [x] **Preflight: bootstrap exempt.** This PR creates the preflight skill itself; manual fork-day audit done as the script was authored. The skill verified its own success against the live worktree (output below) — every applicable check passes/skips after `pnpm exec lefthook install` was run during dogfooding.
- [x] **Failing test (RED) observed:** initial `pnpm vitest run test/tooling/preflight.test.ts` failed for "Cannot find module" before the script existed; later, the worktree-shape test failed with `expected 'fail' to be 'pass'` before the lefthook check learned to use `git rev-parse --git-path hooks`. Both went green after the corresponding implementation landed.
- [x] **Architecture/plan check:** `docs/architecture.md` (uses pnpm; preflight checks pnpm version against `engines.pnpm`) and `docs/development-plan.md` skimmed — no conflicts. Skill location follows `docs/skills.md` and `docs/agent-compat.md`.

```text
PREFLIGHT_SKIP_NETWORK=1 node .agents/skills/preflight/scripts/preflight.ts
| name                          | status | detail                                                                          |
| ----------------------------- | ------ | ------------------------------------------------------------------------------- |
| CI workflow files             | pass   | 2 workflow file(s)                                                              |
| Claude Code red-green hook    | pass   | .claude/settings.json declares a PreToolUse hook                                |
| lefthook git hooks            | pass   |                                                                                 |
| git remote origin             | pass   | https://github.com/lightstrikelabs/repo-analyzer-green/                         |
| Node version vs engines.node  | pass   | 24.14.0 satisfies 24.x                                                          |
| pnpm version vs engines.pnpm  | pass   | 10.29.3 satisfies 10.29.3                                                       |
| Vercel project link           | skip   | .vercel/project.json missing (run `vercel link` if this repo deploys to Vercel) |
| gh auth status                | skip   | skipped (PREFLIGHT_SKIP_NETWORK=1)                                              |
| main branch protection        | skip   | skipped (PREFLIGHT_SKIP_NETWORK=1)                                              |
```

## Scope

Implements #142. Adds the `preflight` skill and `docs/setup.md` so the AGENTS.md `Before Any Code` checklist's item 3 (preflight artifact) has a concrete tool behind it.

- `.agents/skills/preflight/SKILL.md` — frontmatter and per-check usage notes; tells the agent what preflight verifies, how to run it, and how to act on failures.
- `.agents/skills/preflight/scripts/preflight.ts` — pure `runChecks()` function plus a CLI entry that prints a Markdown table and exits non-zero on any failure. Network-dependent checks (`gh auth status`, branch protection) skip via `PREFLIGHT_SKIP_NETWORK=1` for offline / CI / test determinism. The lefthook check resolves the actual hooks directory through `git rev-parse --git-path hooks`, so it works inside git worktrees where `.git` is a file (caught during the dogfood run; locked down with a dedicated worktree-shape test).
- `docs/setup.md` — long-form fork-day verification: explains why each check matters, gives copy-pasteable remediation, and points across to `docs/agent-compat.md` and the AGENTS.md checklist.

## Non-Goals

- Mutating the project to fix what preflight finds. The script is read-only; agents act on the remediation hints themselves.
- A Windows-friendly fallback for the symlink-required cross-agent layout. Documented as a known limitation in `docs/setup.md`; not solved here.
- An `npm`/`yarn` analog of the pnpm check. The repo pins pnpm.
- Configuring branch protection from the script. Just verifying it.

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests (255 passed + 3 skipped — 11 new in `test/tooling/preflight.test.ts`)
- [x] Build (n/a — no application code touched)
- [x] Foundational E2E (n/a — no UI/API changes)

```text
pnpm check
# 47 test files, 255 passed + 3 skipped
```

The 11 new tests cover: all-pass fixture, missing CI workflow, missing/mis-shaped Claude hook config, Node version mismatch, pnpm version mismatch, every result has `name` + `status`, lefthook works inside a faked git worktree, CLI exits 0 on all-pass, CLI exits non-zero on any fail, CLI prints a Markdown-style summary.

## Architecture and Docs

- [x] Follows `docs/architecture.md` (pnpm pinned, TypeScript strict, no `index.ts` barrels).
- [x] No domain/application/infrastructure boundary violations — this is tooling under `.agents/` and `docs/`.
- [x] No architecture changes; `docs/agent-compat.md` and `docs/skills.md` cover skill location.
- [x] `AGENTS.md` already references `/preflight` from the `Before Any Code` checklist (landed in #150). No further AGENTS.md change needed.

## Type Safety

- [x] No `as any`, `: any`, `<any>`, `as unknown as`. (`pnpm type-escape:check` passes.)
- [x] External data (parsed `package.json`, parsed `.claude/settings.json`) is narrowed via `typeof` and `in` guards before access — no casts.
- [x] `exactOptionalPropertyTypes: true` is honored — optional fields are conditionally spread into option objects rather than passed as `undefined`.

## Risk and Rollback

**Risks:**
- The TOML-versus-network-call balance: the gh auth and branch protection checks are network-dependent and skip silently with `PREFLIGHT_SKIP_NETWORK=1`. Forgetting that env var in CI would cause spurious failures; documented in the SKILL.md.
- The lefthook check uses `git rev-parse --git-path hooks` to find the right directory; if a future config sets `core.hooksPath` to something exotic, the resolved path is whatever git reports. That's the right answer; flagging in case it surprises someone.
- A package.json without `engines` skips the version checks rather than failing. That's deliberate (not every project pins engines), but worth noting.

**Rollback:**
- Single-commit revert removes the skill, the doc, the script, and the tests. AGENTS.md still references `/preflight` (from #150) — that reference becomes dead until the skill is re-added or the AGENTS.md line is reverted in turn.

## Dependencies

None added. The script uses only Node stdlib (`node:fs`, `node:path`, `node:url`, `node:process`, `node:child_process`).

## Follow-ups

- Surface preflight output more prominently: the AGENTS.md checklist currently expects the agent to paste the table by hand. A future iteration could add a chat command shortcut or a stop-hook that auto-prints it on session start. Not in scope here.
- Pi extension that mirrors the red-green hook (#144) — the preflight check for "Claude Code red-green hook" only verifies Claude's surface; once #144 lands, an analogous check for the pi extension should be added.