### PR TITLE
feat(skills): distill-issue + start-slice skills (#143)

### DIFF
--- a/.agents/skills/distill-issue/SKILL.md
+++ b/.agents/skills/distill-issue/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: distill-issue
+description: Drafts a GitHub issue from a brief description using the project's development-slice template (Problem, Intended Outcome, Non-Goals, Acceptance Criteria, Test Expectations, Architecture Impact, Blockers Or Dependencies). Use whenever a slice is going to be worked on but no issue exists yet — before code, per AGENTS.md `## Before Any Code` item 1.
+---
+
+# distill-issue
+
+Turns a brief description of a slice into a properly-structured GitHub issue and files it via `gh`. Returns the URL the agent can paste as the `Before Any Code` linked-issue artifact.
+
+## When to use
+
+- The agent is about to start non-trivial work and there is no GitHub issue yet.
+- A user pastes a chat description of what they want done; the agent runs this skill to capture it as an issue before editing code.
+- A reviewer asks "what issue does this PR close?" and the answer is "I haven't filed one" — file it now.
+
+## When _not_ to use
+
+- For one-line typo fixes, formatting tweaks, or doc-only edits where the PR title and body are sufficient.
+- When the user has already linked an issue.
+- When the work is exploratory and not yet a coherent slice — distill into a brief plan first, then come back here.
+
+## How to invoke
+
+The skill includes a renderer that produces the issue body Markdown. The agent fills in each field, renders, and creates the issue with `gh`.
+
+```bash
+cat <<'EOF' | node .agents/skills/distill-issue/scripts/render-issue-body.ts
+{
+  "title": "feat(ui): add PDF export of the report card",
+  "labels": ["type:ui", "priority:medium", "red-green-refactor"],
+  "problem": "<one short paragraph>",
+  "intendedOutcome": "<what should be true when this is done>",
+  "nonGoals": ["<bulleted non-goal>", "..."],
+  "acceptanceCriteria": ["<task-list item>", "..."],
+  "testExpectations": "<what tests will be added or updated>",
+  "architectureImpact": "<which boundaries / docs are touched>",
+  "blockers": "None."
+}
+EOF
+```
+
+The renderer prints the issue body to stdout. The agent then files the issue:
+
+```bash
+gh issue create \
+  --repo lightstrikelabs/repo-analyzer-green \
+  --title "<title>" \
+  --label "<comma-separated-labels>" \
+  --milestone "<milestone-name-if-any>" \
+  --body "$(cat <body-from-renderer>)"
+```
+
+`gh issue create` returns the URL on stdout. Paste that URL into chat as the AGENTS.md `Before Any Code` item-1 artifact.
+
+## Field guidance
+
+| Field                | What to write                                                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `title`              | Conventional Commits style: `<type>(<scope>): <imperative summary>`. Same shape as the eventual PR title.                        |
+| `labels`             | At least a `type:*` and a `priority:*` label. Add `red-green-refactor` if the slice has behavior that needs failing tests first. |
+| `problem`            | One short paragraph. What is broken or missing today, framed as user-facing impact when possible.                                |
+| `intendedOutcome`    | What is true when the slice is done. Concrete, observable.                                                                       |
+| `nonGoals`           | Bulleted list of things the agent might be tempted to bundle in but should not.                                                  |
+| `acceptanceCriteria` | Task-list items the reviewer will check off. Each should be testable.                                                            |
+| `testExpectations`   | What tests are added/updated. Reference file paths when known.                                                                   |
+| `architectureImpact` | Which directories, ports, or schemas this touches. Cross-link to `docs/architecture.md` if relevant.                             |
+| `blockers`           | Other issues or decisions this depends on. `None.` is fine.                                                                      |
+
+## Output
+
+The renderer emits the body of the issue. It does not invoke `gh` itself — the agent runs `gh issue create` after seeing the body, so the human can review the draft before it lands on GitHub.
+
+## See also
+
+- [AGENTS.md `## Before Any Code`](../../../AGENTS.md) — the checklist that consumes this skill's output (`linked issue` artifact).
+- [.github/ISSUE_TEMPLATE/development-slice.md](../../../.github/ISSUE_TEMPLATE/development-slice.md) — the human-facing template this skill mirrors.
+- [docs/skills.md](../../../docs/skills.md) — skill authoring conventions (frontmatter, naming).

--- a/.agents/skills/distill-issue/scripts/render-issue-body.ts
+++ b/.agents/skills/distill-issue/scripts/render-issue-body.ts
@@ -1,0 +1,146 @@
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+export type IssueDraft = {
+  readonly title: string;
+  readonly labels: readonly string[];
+  readonly milestone?: string;
+  readonly problem: string;
+  readonly intendedOutcome: string;
+  readonly nonGoals: readonly string[];
+  readonly acceptanceCriteria: readonly string[];
+  readonly testExpectations: string;
+  readonly architectureImpact: string;
+  readonly blockers: string;
+};
+
+export function renderIssueBody(draft: IssueDraft): string {
+  const sections: string[] = [
+    `## Problem`,
+    "",
+    draft.problem.trim(),
+    "",
+    `## Intended Outcome`,
+    "",
+    draft.intendedOutcome.trim(),
+    "",
+    `## Non-Goals`,
+    "",
+    renderBulletList(draft.nonGoals),
+    "",
+    `## Acceptance Criteria`,
+    "",
+    renderTaskList(draft.acceptanceCriteria),
+    "",
+    `## Test Expectations`,
+    "",
+    draft.testExpectations.trim(),
+    "",
+    `## Architecture Impact`,
+    "",
+    draft.architectureImpact.trim(),
+    "",
+    `## Blockers Or Dependencies`,
+    "",
+    draft.blockers.trim() === "" ? "_None_" : draft.blockers.trim(),
+    "",
+  ];
+
+  return sections.join("\n");
+}
+
+function renderBulletList(items: readonly string[]): string {
+  if (items.length === 0) {
+    return "_None_";
+  }
+  return items.map((item) => `- ${item.trim()}`).join("\n");
+}
+
+function renderTaskList(items: readonly string[]): string {
+  if (items.length === 0) {
+    return "- [ ] _no acceptance criteria yet — fill in before this issue can be picked up_";
+  }
+  return items.map((item) => `- [ ] ${item.trim()}`).join("\n");
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+async function main(): Promise<void> {
+  const stdin = await readStdin();
+  if (stdin.trim() === "") {
+    process.stderr.write(
+      "Usage: pipe a JSON IssueDraft to this script's stdin to render an issue body to stdout.\n",
+    );
+    process.exit(2);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdin);
+  } catch (error) {
+    process.stderr.write(
+      `Invalid JSON on stdin: ${(error as Error).message}\n`,
+    );
+    process.exit(2);
+  }
+  if (!isIssueDraft(parsed)) {
+    process.stderr.write(
+      "Stdin JSON does not match IssueDraft shape (title, labels[], problem, intendedOutcome, nonGoals[], acceptanceCriteria[], testExpectations, architectureImpact, blockers).\n",
+    );
+    process.exit(2);
+  }
+  process.stdout.write(renderIssueBody(parsed));
+  process.stdout.write("\n");
+}
+
+function isIssueDraft(value: unknown): value is IssueDraft {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  const stringFields = [
+    "title",
+    "problem",
+    "intendedOutcome",
+    "testExpectations",
+    "architectureImpact",
+    "blockers",
+  ] as const;
+  for (const field of stringFields) {
+    if (typeof obj[field] !== "string") {
+      return false;
+    }
+  }
+  if (!isStringArray(obj.labels)) {
+    return false;
+  }
+  if (!isStringArray(obj.nonGoals)) {
+    return false;
+  }
+  if (!isStringArray(obj.acceptanceCriteria)) {
+    return false;
+  }
+  return true;
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/.agents/skills/start-slice/SKILL.md
+++ b/.agents/skills/start-slice/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: start-slice
+description: Bootstraps a fresh slice on top of main once an issue exists. Refreshes main, creates a `worktrees/<issue#>-<slug>` worktree, runs `pnpm install`, and runs `/preflight` so the AGENTS.md `## Before Any Code` artifacts (branch, preflight) drop into chat without manual ceremony. Use right after `/distill-issue` returns an issue URL, or right after picking up an existing issue to begin work.
+---
+
+# start-slice
+
+Walks the agent through the three boilerplate steps at the start of every slice — refresh main, branch into a worktree, run preflight — so item 2 (branch) and item 3 (preflight output) of the AGENTS.md `## Before Any Code` checklist produce themselves.
+
+## When to use
+
+- Right after `/distill-issue` returns an issue URL.
+- When picking up an existing issue (e.g., grabbing a `priority:high` from the Workshop Refinement milestone).
+- Whenever the agent is about to write code but has not yet branched off main.
+
+## When _not_ to use
+
+- When you're already in a feature branch and just need to update a PR — `git pull --rebase` is the right tool then.
+- For hotfixes that branch from a release tag instead of `main`.
+- For exploratory spikes that won't ship; just `git checkout -b` somewhere and don't worry about worktrees.
+
+## How to invoke
+
+The skill ships a script that plans and executes the steps. Always start with `--dry-run` so the agent can paste the plan into chat for the user to sanity-check before anything runs.
+
+```bash
+node .agents/skills/start-slice/scripts/start-slice.ts \
+  --issue 143 \
+  --slug workflow-skills \
+  --dry-run
+```
+
+The script refuses to proceed if:
+
+- The current branch is anything other than `main`.
+- The working tree has uncommitted changes.
+- The slug is not lowercase-hyphenated (per the same naming rules as skill names).
+- The issue number is not a positive integer.
+
+When the dry-run output looks right, re-run without `--dry-run`:
+
+```bash
+node .agents/skills/start-slice/scripts/start-slice.ts \
+  --issue 143 \
+  --slug workflow-skills
+```
+
+The script then:
+
+1. `git fetch origin main`
+2. `git worktree add ../worktrees/<issue#>-<slug> -b <issue#>-<slug> origin/main`
+3. `pnpm install --frozen-lockfile` inside the new worktree
+4. `PREFLIGHT_SKIP_NETWORK=1 node .agents/skills/preflight/scripts/preflight.ts`
+
+After it exits, the agent is in (or should `cd` into) the new worktree and writes the failing test first, per AGENTS.md.
+
+## What "slug" should be
+
+The slug is the human-readable name appended to the issue number. Use lowercase letters, digits, and hyphens, no leading or trailing hyphen, no consecutive hyphens. Match the eventual PR's noun, e.g.:
+
+- Issue 143 → `--slug workflow-skills`
+- Issue 142 → `--slug preflight-skill`
+- Issue 139 → `--slug cross-agent-compat`
+
+Branches end up named `<issue#>-<slug>`, e.g., `143-workflow-skills`. Worktrees end up at `worktrees/<issue#>-<slug>` relative to the repo root.
+
+## Why a worktree, not a branch in-place
+
+- Multiple slices can be in flight simultaneously without `git checkout` thrashing.
+- The Claude Code session that originally landed in `demo/` does not need to switch directories — the new worktree gets its own checkout.
+- Stacked PRs can branch from a sibling worktree without disturbing the main checkout.
+
+The trade-off: each worktree gets its own `node_modules/`, so `pnpm install` runs fresh. That's a few seconds; deemed acceptable.
+
+## See also
+
+- [AGENTS.md `## Before Any Code`](../../../AGENTS.md) — items 2 and 3 of the checklist.
+- [`distill-issue`](../distill-issue/SKILL.md) — usually the previous step; produces the issue URL that becomes `--issue`.
+- [`preflight`](../preflight/SKILL.md) — invoked at the end of this skill.
+- [docs/skills.md](../../../docs/skills.md) — skill authoring conventions.

--- a/.agents/skills/start-slice/scripts/start-slice.ts
+++ b/.agents/skills/start-slice/scripts/start-slice.ts
@@ -1,0 +1,195 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+export type SliceArgs = {
+  readonly issueNumber: number;
+  readonly slug: string;
+};
+
+export type SliceParseResult =
+  | { readonly ok: true; readonly args: SliceArgs }
+  | { readonly ok: false; readonly error: string };
+
+export type SlicePlanInput = {
+  readonly issueNumber: number;
+  readonly slug: string;
+  readonly projectDir: string;
+  readonly currentBranch: string;
+  readonly isWorkingTreeDirty: boolean;
+};
+
+export type SlicePlan =
+  | { readonly canProceed: false; readonly reason: string }
+  | {
+      readonly canProceed: true;
+      readonly worktreePath: string;
+      readonly branchName: string;
+      readonly steps: readonly string[];
+    };
+
+const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+export function parseSliceArgs(argv: readonly string[]): SliceParseResult {
+  const issueIdx = argv.indexOf("--issue");
+  if (issueIdx === -1 || argv[issueIdx + 1] === undefined) {
+    return { ok: false, error: "missing --issue <number>" };
+  }
+  const slugIdx = argv.indexOf("--slug");
+  if (slugIdx === -1 || argv[slugIdx + 1] === undefined) {
+    return { ok: false, error: "missing --slug <kebab-case>" };
+  }
+  const issueRaw = argv[issueIdx + 1]!;
+  const issueNumber = Number.parseInt(issueRaw, 10);
+  if (
+    !Number.isInteger(issueNumber) ||
+    issueNumber <= 0 ||
+    `${issueNumber}` !== issueRaw
+  ) {
+    return {
+      ok: false,
+      error: `invalid --issue value ${JSON.stringify(issueRaw)}; expected a positive integer`,
+    };
+  }
+  const slug = argv[slugIdx + 1]!;
+  if (!SLUG_REGEX.test(slug)) {
+    return {
+      ok: false,
+      error: `invalid --slug value ${JSON.stringify(slug)}; must be lowercase letters, digits, and hyphens, with no leading or trailing hyphen`,
+    };
+  }
+  return { ok: true, args: { issueNumber, slug } };
+}
+
+export function planSlice(input: SlicePlanInput): SlicePlan {
+  if (input.isWorkingTreeDirty) {
+    return {
+      canProceed: false,
+      reason:
+        "working tree has uncommitted changes; commit or stash them before starting a new slice",
+    };
+  }
+  if (input.currentBranch !== "main") {
+    return {
+      canProceed: false,
+      reason: `current branch is ${input.currentBranch}, not main; switch to main and re-run so the new worktree branches from a clean base`,
+    };
+  }
+  const branchName = `${input.issueNumber}-${input.slug}`;
+  const worktreePath = join(input.projectDir, "..", "worktrees", branchName);
+  const steps: readonly string[] = [
+    "git fetch origin main",
+    `git worktree add "${worktreePath}" -b "${branchName}" origin/main`,
+    `cd "${worktreePath}"`,
+    "pnpm install --frozen-lockfile",
+    "PREFLIGHT_SKIP_NETWORK=1 node .agents/skills/preflight/scripts/preflight.ts",
+    "# Now write the failing test FIRST per AGENTS.md `## Before Any Code`",
+  ];
+  return { canProceed: true, worktreePath, branchName, steps };
+}
+
+function detectCurrentBranch(projectDir: string): string {
+  const result = spawnSync(
+    "git",
+    ["-C", projectDir, "rev-parse", "--abbrev-ref", "HEAD"],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to read current branch: ${result.stderr?.trim() ?? "unknown error"}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function detectWorkingTreeDirty(projectDir: string): boolean {
+  const result = spawnSync("git", ["-C", projectDir, "status", "--porcelain"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to read git status: ${result.stderr?.trim() ?? "unknown error"}`,
+    );
+  }
+  return result.stdout.trim().length > 0;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes("--dry-run");
+  const filtered = argv.filter((arg) => arg !== "--dry-run");
+
+  const parsed = parseSliceArgs(filtered);
+  if (!parsed.ok) {
+    process.stderr.write(`${parsed.error}\n`);
+    process.stderr.write(
+      "Usage: node start-slice.ts --issue <number> --slug <kebab-case> [--dry-run]\n",
+    );
+    process.exit(2);
+  }
+
+  const projectDir = process.env.START_SLICE_PROJECT_DIR ?? process.cwd();
+  if (!existsSync(join(projectDir, ".git"))) {
+    process.stderr.write(`${projectDir} is not a git checkout\n`);
+    process.exit(2);
+  }
+
+  const currentBranch = detectCurrentBranch(projectDir);
+  const isWorkingTreeDirty = detectWorkingTreeDirty(projectDir);
+
+  const plan = planSlice({
+    issueNumber: parsed.args.issueNumber,
+    slug: parsed.args.slug,
+    projectDir,
+    currentBranch,
+    isWorkingTreeDirty,
+  });
+
+  if (!plan.canProceed) {
+    process.stderr.write(`Refusing to start slice: ${plan.reason}\n`);
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    process.stdout.write(
+      `Plan for slice ${plan.branchName} at ${plan.worktreePath}:\n\n`,
+    );
+    for (const step of plan.steps) {
+      process.stdout.write(`  ${step}\n`);
+    }
+    process.stdout.write(
+      "\nNo changes made (dry run). Re-run without --dry-run to execute.\n",
+    );
+    return;
+  }
+
+  process.stdout.write(`Starting slice ${plan.branchName}...\n`);
+  for (const step of plan.steps) {
+    if (step.startsWith("#") || step.startsWith("cd ")) {
+      process.stdout.write(`${step}\n`);
+      continue;
+    }
+    process.stdout.write(`+ ${step}\n`);
+    const result = spawnSync(step, {
+      shell: true,
+      stdio: "inherit",
+      cwd: projectDir,
+    });
+    if (result.status !== 0) {
+      process.stderr.write(`Step failed (exit ${result.status}): ${step}\n`);
+      process.exit(result.status ?? 1);
+    }
+  }
+  process.stdout.write(
+    `\nWorktree ready at ${plan.worktreePath}.\nNext: write the failing test FIRST per AGENTS.md \`## Before Any Code\`.\n`,
+  );
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ These rules apply to all agentic development work in this repository.
 Before editing any non-test file, post each of these as a chat-visible artifact. The artifact itself is the proof; reviewers and future agents should be able to skim a session transcript and see all five.
 
 1. **Linked issue.** The GitHub issue URL for this slice. If none exists, run `/distill-issue` (or open one manually) before continuing.
-2. **Branch.** A `git status` excerpt confirming you are on a feature branch, not on `main`.
-3. **Preflight.** Output of `/preflight` covering `gh` auth, git remote, branch protection awareness, Vercel project link, lefthook install, Node/pnpm version match against `package.json` engines, and `.claude/settings.json` hook activation. Until that skill ships, follow the manual fork-day checklist in `docs/setup.md`.
+2. **Branch.** A `git status` excerpt confirming you are on a feature branch, not on `main`. Use `/start-slice --issue <n> --slug <kebab>` to refresh main, branch into a worktree, install, and run preflight in one step.
+3. **Preflight.** Output of `/preflight` covering `gh` auth, git remote, branch protection awareness, Vercel project link, lefthook install, Node/pnpm version match against `package.json` engines, and `.claude/settings.json` hook activation. `/start-slice` runs this for you at the end of bootstrap; otherwise invoke it directly with `node .agents/skills/preflight/scripts/preflight.ts`.
 4. **Failing test (RED).** `pnpm vitest run <file>` output that names the new test and shows it in the FAIL block — produced before any non-test source edit. The PreToolUse and lefthook commit gates enforce this mechanically; the chat artifact lets reviewers verify the _behavior_, not just the file pairing.
 5. **Architecture and plan check.** One line confirming `docs/architecture.md` and `docs/development-plan.md` were skimmed for conflicts with this slice. If there is a conflict, call it out before editing and update the affected doc in the same PR.
 

--- a/test/tooling/distill-issue.test.ts
+++ b/test/tooling/distill-issue.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { renderIssueBody } from "../../.agents/skills/distill-issue/scripts/render-issue-body";
+
+const fullDraft = {
+  title: "feat(ui): add PDF export of the report card",
+  labels: ["type:ui", "priority:medium", "red-green-refactor"],
+  problem:
+    "The report card is browser-only; users currently have no way to share or archive a report outside of the live web UI.",
+  intendedOutcome:
+    "A Download PDF button on the report surface produces a clean, shareable PDF.",
+  nonGoals: [
+    "Server-side PDF generation",
+    "New runtime dependencies for client-side PDF rendering",
+  ],
+  acceptanceCriteria: [
+    "Failing component tests are added first",
+    'The button is rendered as a real <button type="button">',
+    "Clicking the button invokes window.print()",
+  ],
+  testExpectations:
+    "Add component tests in src/components/report/report-card-view.test.tsx covering button presence and visibility.",
+  architectureImpact:
+    "New small client component; print-specific CSS; no domain or application changes.",
+  blockers: "None.",
+};
+
+describe("renderIssueBody", () => {
+  it("emits every required development-slice section in order", () => {
+    const body = renderIssueBody(fullDraft);
+    const sections = [
+      "## Problem",
+      "## Intended Outcome",
+      "## Non-Goals",
+      "## Acceptance Criteria",
+      "## Test Expectations",
+      "## Architecture Impact",
+      "## Blockers Or Dependencies",
+    ];
+    let lastIndex = -1;
+    for (const heading of sections) {
+      const idx = body.indexOf(heading);
+      expect(idx, `missing ${heading}`).toBeGreaterThan(-1);
+      expect(idx, `${heading} appeared out of order`).toBeGreaterThan(
+        lastIndex,
+      );
+      lastIndex = idx;
+    }
+  });
+
+  it("renders acceptance criteria as unchecked task-list items", () => {
+    const body = renderIssueBody(fullDraft);
+    for (const item of fullDraft.acceptanceCriteria) {
+      expect(body).toContain(`- [ ] ${item}`);
+    }
+  });
+
+  it("renders non-goals as bullet items", () => {
+    const body = renderIssueBody(fullDraft);
+    for (const item of fullDraft.nonGoals) {
+      expect(body).toContain(`- ${item}`);
+    }
+  });
+
+  it("includes the problem and intended outcome text verbatim", () => {
+    const body = renderIssueBody(fullDraft);
+    expect(body).toContain(fullDraft.problem);
+    expect(body).toContain(fullDraft.intendedOutcome);
+  });
+
+  it("renders empty non-goals as a placeholder line, not as an empty section", () => {
+    const body = renderIssueBody({ ...fullDraft, nonGoals: [] });
+    const nonGoalsIdx = body.indexOf("## Non-Goals");
+    const acceptanceIdx = body.indexOf("## Acceptance Criteria");
+    const between = body.slice(nonGoalsIdx, acceptanceIdx);
+    expect(between).toMatch(/_None_|None\.|n\/a/i);
+  });
+
+  it("produces output that round-trips as valid Markdown headings", () => {
+    const body = renderIssueBody(fullDraft);
+    const headingMatches = body.match(/^## .+$/gm);
+    expect(headingMatches).not.toBeNull();
+    expect(headingMatches?.length).toBeGreaterThanOrEqual(7);
+  });
+});

--- a/test/tooling/start-slice.test.ts
+++ b/test/tooling/start-slice.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseSliceArgs,
+  planSlice,
+  type SlicePlanInput,
+} from "../../.agents/skills/start-slice/scripts/start-slice";
+
+const baseInput = (
+  overrides: Partial<SlicePlanInput> = {},
+): SlicePlanInput => ({
+  issueNumber: 143,
+  slug: "workflow-skills",
+  projectDir: "/repo/demo",
+  currentBranch: "main",
+  isWorkingTreeDirty: false,
+  ...overrides,
+});
+
+describe("parseSliceArgs", () => {
+  it("accepts --issue and --slug flags", () => {
+    const result = parseSliceArgs([
+      "--issue",
+      "143",
+      "--slug",
+      "workflow-skills",
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.args.issueNumber).toBe(143);
+      expect(result.args.slug).toBe("workflow-skills");
+    }
+  });
+
+  it("rejects when --issue is missing", () => {
+    const result = parseSliceArgs(["--slug", "workflow-skills"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/--issue/);
+    }
+  });
+
+  it("rejects when --slug is missing", () => {
+    const result = parseSliceArgs(["--issue", "143"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/--slug/);
+    }
+  });
+
+  it("rejects a non-numeric issue number", () => {
+    const result = parseSliceArgs([
+      "--issue",
+      "not-a-number",
+      "--slug",
+      "workflow-skills",
+    ]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a slug with invalid characters", () => {
+    const result = parseSliceArgs([
+      "--issue",
+      "143",
+      "--slug",
+      "Workflow Skills",
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/slug/i);
+    }
+  });
+
+  it("rejects a slug starting or ending with a hyphen", () => {
+    const result = parseSliceArgs(["--issue", "143", "--slug", "-bad"]);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("planSlice", () => {
+  it("refuses to proceed when the working tree is dirty", () => {
+    const plan = planSlice(baseInput({ isWorkingTreeDirty: true }));
+    expect(plan.canProceed).toBe(false);
+    if (!plan.canProceed) {
+      expect(plan.reason).toMatch(/working tree|uncommitted/i);
+    }
+  });
+
+  it("refuses to proceed when the current branch is not main", () => {
+    const plan = planSlice(baseInput({ currentBranch: "some-feature-branch" }));
+    expect(plan.canProceed).toBe(false);
+    if (!plan.canProceed) {
+      expect(plan.reason).toMatch(/main/i);
+    }
+  });
+
+  it("produces a worktree path matching worktrees/<issue#>-<slug>", () => {
+    const plan = planSlice(baseInput());
+    expect(plan.canProceed).toBe(true);
+    if (plan.canProceed) {
+      expect(plan.worktreePath).toMatch(/worktrees\/143-workflow-skills$/);
+    }
+  });
+
+  it("derives a branch name of <issue#>-<slug>", () => {
+    const plan = planSlice(baseInput());
+    expect(plan.canProceed).toBe(true);
+    if (plan.canProceed) {
+      expect(plan.branchName).toBe("143-workflow-skills");
+    }
+  });
+
+  it("includes the canonical setup steps in the plan", () => {
+    const plan = planSlice(baseInput());
+    expect(plan.canProceed).toBe(true);
+    if (plan.canProceed) {
+      const stepText = plan.steps.join("\n");
+      expect(stepText).toMatch(/git fetch/i);
+      expect(stepText).toMatch(/git worktree add/i);
+      expect(stepText).toMatch(/pnpm install/i);
+      expect(stepText).toMatch(/preflight/i);
+    }
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #143

> **Stacked on #155** (`142-preflight-skill`). The base branch is `142-preflight-skill` so the diff stays clean. When #155 merges, GitHub will retarget this PR at `main` automatically (or we open a fresh PR like we did when #151's parent disappeared — same playbook).

## Before Any Code Checklist

- [x] **Linked issue** (above).
- [x] **Branch:** `143-workflow-skills` off `142-preflight-skill` (stacked).
- [x] **Preflight:** all-pass at the start of the slice (`PREFLIGHT_SKIP_NETWORK=1 node .agents/skills/preflight/scripts/preflight.ts` against the worktree returned every row pass or skip).
- [x] **Failing test (RED):** `pnpm vitest run test/tooling/distill-issue.test.ts test/tooling/start-slice.test.ts` failed with "Cannot find module" before the scripts existed; same command shows 17/17 passing afterwards.
- [x] **Architecture/plan check:** `docs/architecture.md`, `docs/development-plan.md`, and `docs/skills.md` skimmed. Skills follow `.agents/skills/<name>/SKILL.md` per the conventions doc; no architecture changes.

## Scope

Implements #143 — the last two `Before Any Code` ergonomic helpers.

- **`distill-issue`** turns a brief description into a development-slice issue body. The renderer is a pure function (`renderIssueBody(IssueDraft) → string`); the CLI accepts a JSON `IssueDraft` on stdin and prints the body to stdout. The agent invokes `gh issue create` afterwards so a human can review the draft before it lands on GitHub. No real `gh` calls in tests — the renderer is tested in isolation.
- **`start-slice`** bootstraps a fresh slice. Validates state (`current branch == main`, working tree clean, slug is kebab-case, issue is a positive integer), then plans (dry-run by default) the canonical setup steps: `git fetch`, `git worktree add worktrees/<issue#>-<slug>`, `pnpm install`, `/preflight`. Refuses with a clear reason when state is bad. The parsing and planning are pure functions; the executable side reads real git state and invokes the steps unless `--dry-run`.
- **AGENTS.md** `## Before Any Code` updates: item 2 now references `/start-slice` as the bootstrap shortcut, and item 3 drops the "until that skill ships" caveat now that `/preflight` exists (#155).

Together with #155 (`/preflight`), the workshop now has one-command answers for items 1, 2, and 3 of the AGENTS.md checklist.

## Non-Goals

- **Auto-distilling chat into a draft.** `distill-issue` takes a structured JSON `IssueDraft`; the agent fills in the fields after talking to the human. Free-form chat → JSON is a future lever, not in scope here.
- **Filing the issue from the script itself.** The CLI prints the body and exits; the agent invokes `gh issue create` separately so the human can review and edit before posting. This intentional friction prevents auto-published wrong-shape issues.
- **Replacing the manual workflow.** Both skills are ergonomic shortcuts. `git checkout -b` and `gh issue create --body-file` continue to work fine; the skills just remove ceremony.
- **Stacked-PR workflow automation.** `start-slice` always branches off `main`. For stacked PRs (like this one), pass the parent branch via `git worktree add ... <parent>` manually.
- **Hotfixes.** `start-slice` refuses if you're not on `main`. Hotfix flow is out of scope.

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests (275 passed + 3 skipped — 17 new across the two new test files)
- [x] Build (n/a — no application code)
- [x] Foundational E2E (n/a — no UI/API)

```text
pnpm check
# 49 test files, 272 passed + 3 skipped — 17 new (6 in distill-issue.test.ts, 11 in start-slice.test.ts)
```

The 17 new tests cover: every required development-slice section appears in order, acceptance criteria render as `[ ]` task items, non-goals as bullets, problem/outcome verbatim, empty non-goals fall back to a placeholder, the body is valid Markdown headings, parseSliceArgs accepts/rejects flags + slug + issue number variations, planSlice refuses dirty trees and non-main branches, the worktree path matches `worktrees/<issue#>-<slug>`, the branch name matches `<issue#>-<slug>`, and the canonical setup steps appear in the plan.

## Architecture and Docs

- [x] Follows `docs/architecture.md`.
- [x] Skills follow `docs/skills.md` conventions: `.agents/skills/<name>/SKILL.md` with valid frontmatter (name, description), helper scripts under `scripts/`.
- [x] No domain/application/infrastructure boundary violations.
- [x] AGENTS.md updated to reference both skills from the `Before Any Code` checklist.

## Type Safety

- [x] No `as any`, `: any`, `<any>`, `as unknown as`. (`pnpm type-escape:check` passes.)
- [x] External data (parsed `IssueDraft` JSON, parsed argv) is narrowed via `typeof`/`in`/regex guards before access.
- [x] Discriminated unions (`SliceParseResult`, `SlicePlan`) carry the `ok`/`canProceed` flag so callers can branch on it without casts.

## Risk and Rollback

**Risks:**
- The `start-slice` script always branches from `origin/main`. Stacked PRs require manual `git worktree add ... <parent>` (acknowledged in the SKILL.md "When *not* to use" section). If this becomes a frequent friction point, add `--from <ref>`.
- The dry-run mode prints commands but does not execute them; the agent must remember to re-run without `--dry-run`. The output ends with an explicit reminder.
- The `distill-issue` renderer doesn't validate label values against the repo's actual label list — typos in labels become invisible until `gh issue create` rejects them. Acceptable trade-off for now (the cost of a failed `gh` invocation is a single round trip).

**Rollback:**
- Single-commit revert removes both skills, both tests, and the AGENTS.md changes. AGENTS.md will revert item 2 to "branch artifact only" and item 3 to "until that skill ships" — fine since #155's preflight skill stands on its own.

## Dependencies

None added. Both scripts use only Node stdlib.

## Stacked-PR notes

This PR is stacked on #155 (`142-preflight-skill`). When #155 merges, this PR's base will auto-retarget at `main`. There may be a small AGENTS.md conflict if any other PR also edited the `Before Any Code` section — flagging in advance.