### PR TITLE
feat(tooling): pi red-green extension mirroring the shared gate (#144)

### DIFF
--- a/.pi/extensions/red-green-gate/index.ts
+++ b/.pi/extensions/red-green-gate/index.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+import { translateToolEvent, type PiToolCallEvent } from "./translator";
+
+type ToolCallResult =
+  | { readonly block: true; readonly reason: string }
+  | undefined;
+
+type ExtensionContext = {
+  readonly cwd: string;
+};
+
+type ToolCallHandler = (
+  event: PiToolCallEvent,
+  ctx: ExtensionContext,
+) => Promise<ToolCallResult> | ToolCallResult;
+
+export type ExtensionAPI = {
+  readonly on: (event: "tool_call", handler: ToolCallHandler) => void;
+};
+
+export default function setupRedGreenExtension(pi: ExtensionAPI): void {
+  pi.on("tool_call", async (event, ctx) => {
+    const invocation = translateToolEvent(event, ctx.cwd);
+    if (invocation === null) {
+      return undefined;
+    }
+
+    const scriptPath = join(ctx.cwd, "scripts/red-green-gate.ts");
+    const result = spawnSync(process.execPath, [scriptPath], {
+      input: JSON.stringify(invocation),
+      encoding: "utf8",
+      cwd: ctx.cwd,
+      env: {
+        ...process.env,
+        CLAUDE_PROJECT_DIR: ctx.cwd,
+      },
+    });
+
+    if (result.status === 2) {
+      const stderr = (result.stderr ?? "").trim();
+      const reason =
+        stderr === ""
+          ? "blocked by red-green gate (no reason provided)"
+          : stderr;
+      return { block: true, reason };
+    }
+    return undefined;
+  });
+}

--- a/.pi/extensions/red-green-gate/translator.ts
+++ b/.pi/extensions/red-green-gate/translator.ts
@@ -1,0 +1,105 @@
+import { isAbsolute, resolve } from "node:path";
+
+export type PiToolCallEvent = {
+  readonly toolName: string;
+  readonly input: Record<string, unknown>;
+};
+
+export type GateInvocation =
+  | {
+      readonly hook_event_name: "PreToolUse";
+      readonly tool_name: "Write";
+      readonly tool_input: {
+        readonly file_path: string;
+        readonly content: string;
+      };
+    }
+  | {
+      readonly hook_event_name: "PreToolUse";
+      readonly tool_name: "MultiEdit";
+      readonly tool_input: {
+        readonly file_path: string;
+        readonly edits: ReadonlyArray<{
+          readonly old_string: string;
+          readonly new_string: string;
+        }>;
+      };
+    };
+
+export function translateToolEvent(
+  event: PiToolCallEvent,
+  projectDir: string,
+): GateInvocation | null {
+  if (event.toolName !== "write" && event.toolName !== "edit") {
+    return null;
+  }
+  const filePath = readPath(event.input);
+  if (filePath === null) {
+    return null;
+  }
+  const absolutePath = isAbsolute(filePath)
+    ? filePath
+    : resolve(projectDir, filePath);
+
+  if (event.toolName === "write") {
+    const content = readString(event.input, "content");
+    if (content === null) {
+      return null;
+    }
+    return {
+      hook_event_name: "PreToolUse",
+      tool_name: "Write",
+      tool_input: { file_path: absolutePath, content },
+    };
+  }
+
+  const edits = readEdits(event.input);
+  if (edits === null) {
+    return null;
+  }
+  return {
+    hook_event_name: "PreToolUse",
+    tool_name: "MultiEdit",
+    tool_input: { file_path: absolutePath, edits },
+  };
+}
+
+function readPath(input: Record<string, unknown>): string | null {
+  const value = input["path"];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readString(
+  input: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = input[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readEdits(input: Record<string, unknown>): ReadonlyArray<{
+  readonly old_string: string;
+  readonly new_string: string;
+}> | null {
+  const raw = input["edits"];
+  if (!Array.isArray(raw)) {
+    return null;
+  }
+  const edits: Array<{
+    readonly old_string: string;
+    readonly new_string: string;
+  }> = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) {
+      return null;
+    }
+    const obj = entry as Record<string, unknown>;
+    const oldText = obj["oldText"];
+    const newText = obj["newText"];
+    if (typeof oldText !== "string" || typeof newText !== "string") {
+      return null;
+    }
+    edits.push({ old_string: oldText, new_string: newText });
+  }
+  return edits;
+}

--- a/docs/agent-compat.md
+++ b/docs/agent-compat.md
@@ -8,7 +8,7 @@ This repo is exercised by three coding-agent CLIs: Claude Code, OpenAI Codex CLI
 |---|---|---|---|---|
 | Claude Code | 2.1.119 | Anthropic Agent Skills (`SKILL.md` + frontmatter) | yes | shell commands in `.claude/settings.json` (`hooks` block) |
 | Codex CLI | 0.125.0 | Anthropic Agent Skills (`SKILL.md` + frontmatter) | yes | shell commands in `.codex/config.toml` (`[hooks.<event>]` blocks); project-local hooks require trust |
-| pi | 0.70.2 (`@mariozechner/pi-coding-agent`) | Anthropic Agent Skills (`SKILL.md` + frontmatter; lenient about violations) | yes (`--no-context-files` to disable) | JS extension API (`pi.on("tool_execution_start", ...)` etc.) — different paradigm, deferred to a follow-up |
+| pi | 0.70.2 (`@mariozechner/pi-coding-agent`) | Anthropic Agent Skills (`SKILL.md` + frontmatter; lenient about violations) | yes (`--no-context-files` to disable) | JS extension API (`pi.on("tool_call", ...)` returning `{ block: true, reason }`); a thin extension at `.pi/extensions/red-green-gate/` wraps the same `scripts/red-green-gate.ts` |
 
 ## Canonical skill store: `.agents/skills/`
 
@@ -31,7 +31,7 @@ Hook compatibility is partial:
 - **Claude Code + Codex** share the same shell-command paradigm with `PreToolUse`/`PostToolUse`/`SessionStart` matchers and a `matcher` regex. The same script (`scripts/red-green-gate.ts`) is invoked from both — only the config file differs:
   - Claude Code: `.claude/settings.json` (`"hooks": { "PreToolUse": [...] }`)
   - Codex CLI: `.codex/config.toml` (`[[hooks.PreToolUse]]` ... `[[hooks.PreToolUse.hooks]]`)
-- **Pi** uses a JS extension API where extensions subscribe to events programmatically. Wiring pi to invoke `scripts/red-green-gate.ts` requires a small JS shim under `.pi/extensions/` and is tracked as a follow-up issue.
+- **Pi** uses a JS extension API where extensions subscribe to events programmatically. The shim lives at `.pi/extensions/red-green-gate/`: a small TypeScript translator turns pi's `tool_call` event into the same JSON payload Claude Code and Codex send to the script via stdin, then `spawnSync`s `scripts/red-green-gate.ts` and translates its exit code back into pi's `{ block: true, reason }` return value. Same script, same ledger, same allowlist.
 
 The hook script (`scripts/red-green-gate.ts`) reads the project root from `$CLAUDE_PROJECT_DIR` if set, otherwise falls back to `process.cwd()`. Codex spawns hooks from the project root, so the fallback works without explicit env wiring; if a future agent needs an explicit override, add it inline in the hook command.
 
@@ -66,4 +66,4 @@ When changing red-green behavior, update all three surfaces together (or documen
 - `.claude/settings.json` — Claude Code's hook entry
 - `.codex/config.toml` — Codex's hook entry
 - `lefthook.yml` — the commit-time gate
-- `.pi/extensions/...` — pi's extension shim (when the follow-up issue lands)
+- `.pi/extensions/red-green-gate/index.ts` and `.pi/extensions/red-green-gate/translator.ts` — pi's extension shim

--- a/scripts/red-green-gate.ts
+++ b/scripts/red-green-gate.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import { dirname, join, relative } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -375,9 +381,22 @@ function readStagedFiles(
   return stagedFiles;
 }
 
-if (
-  process.argv[1] !== undefined &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (process.argv[1] !== undefined && isInvokedAsScript(process.argv[1])) {
   await main();
+}
+
+function isInvokedAsScript(argvPath: string): boolean {
+  const candidate = pathToFileURL(argvPath).href;
+  if (import.meta.url === candidate) {
+    return true;
+  }
+  // macOS symlinks /tmp -> /private/tmp and $TMPDIR -> /private/var/folders/...
+  // process.argv[1] keeps the unresolved path while import.meta.url resolves it.
+  // Compare on real paths so the script also fires when invoked through a symlink.
+  try {
+    const realArgvUrl = pathToFileURL(realpathSync(argvPath)).href;
+    return import.meta.url === realArgvUrl;
+  } catch {
+    return false;
+  }
 }

--- a/test/tooling/pi-red-green-extension.test.ts
+++ b/test/tooling/pi-red-green-extension.test.ts
@@ -1,0 +1,217 @@
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  translateToolEvent,
+  type GateInvocation,
+  type PiToolCallEvent,
+} from "../../.pi/extensions/red-green-gate/translator";
+import setupExtension from "../../.pi/extensions/red-green-gate/index";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+type ToolCallHandler = (
+  event: PiToolCallEvent,
+  ctx: { readonly cwd: string },
+) =>
+  | Promise<{ readonly block: true; readonly reason: string } | undefined>
+  | { readonly block: true; readonly reason: string }
+  | undefined;
+
+function captureToolCallHandler(): {
+  readonly pi: { on: (event: string, handler: unknown) => void };
+  readonly handlers: { tool_call?: ToolCallHandler };
+} {
+  const handlers: { tool_call?: ToolCallHandler } = {};
+  const pi = {
+    on(event: string, handler: unknown): void {
+      if (event === "tool_call") {
+        handlers.tool_call = handler as ToolCallHandler;
+      }
+    },
+  };
+  return { pi, handlers };
+}
+
+function makeFixtureProject(): {
+  readonly dir: string;
+  readonly cleanup: () => void;
+} {
+  const dir = mkdtempSync(path.join(tmpdir(), "green-pi-rg-"));
+  spawnSync("git", ["-C", dir, "init", "--quiet"]);
+  mkdirSync(path.join(dir, "src/components"), { recursive: true });
+  mkdirSync(path.join(dir, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "pi-rg-fixture", type: "module" }),
+  );
+  copyFileSync(
+    path.join(repoRoot, "scripts/red-green-gate.ts"),
+    path.join(dir, "scripts/red-green-gate.ts"),
+  );
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { force: true, recursive: true }),
+  };
+}
+
+describe("translateToolEvent", () => {
+  it("translates a pi `write` event into a Write hook payload with an absolute path", () => {
+    const event: PiToolCallEvent = {
+      toolName: "write",
+      input: {
+        path: "src/foo.tsx",
+        content: "export const a = 1;\n",
+      },
+    };
+    const result = translateToolEvent(event, "/repo");
+    expect(result).not.toBeNull();
+    if (result !== null) {
+      expect(result.tool_name).toBe("Write");
+      expect(result.tool_input).toEqual({
+        file_path: "/repo/src/foo.tsx",
+        content: "export const a = 1;\n",
+      });
+    }
+  });
+
+  it("passes through absolute paths unchanged", () => {
+    const event: PiToolCallEvent = {
+      toolName: "write",
+      input: { path: "/abs/path/foo.tsx", content: "x" },
+    };
+    const result = translateToolEvent(event, "/repo");
+    expect(result?.tool_input.file_path).toBe("/abs/path/foo.tsx");
+  });
+
+  it("translates a pi `edit` event with multiple edits into a MultiEdit payload", () => {
+    const event: PiToolCallEvent = {
+      toolName: "edit",
+      input: {
+        path: "src/foo.tsx",
+        edits: [
+          { oldText: "a", newText: "b" },
+          { oldText: "c", newText: "d" },
+        ],
+      },
+    };
+    const result = translateToolEvent(event, "/repo");
+    expect(result).not.toBeNull();
+    if (result !== null) {
+      expect(result.tool_name).toBe("MultiEdit");
+      expect(result.tool_input).toEqual({
+        file_path: "/repo/src/foo.tsx",
+        edits: [
+          { old_string: "a", new_string: "b" },
+          { old_string: "c", new_string: "d" },
+        ],
+      });
+    }
+  });
+
+  it("returns null for non-edit/write tools", () => {
+    const result = translateToolEvent(
+      { toolName: "bash", input: { command: "ls" } },
+      "/repo",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when input is malformed (missing path)", () => {
+    const result = translateToolEvent(
+      { toolName: "write", input: { content: "x" } },
+      "/repo",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("red-green-gate pi extension wiring", () => {
+  it("subscribes to the tool_call event when loaded", () => {
+    const { pi, handlers } = captureToolCallHandler();
+    setupExtension(pi);
+    expect(handlers.tool_call).toBeDefined();
+  });
+
+  it("returns undefined for tool calls that are neither edit nor write", async () => {
+    const { pi, handlers } = captureToolCallHandler();
+    setupExtension(pi);
+    const result = await handlers.tool_call!(
+      { toolName: "read", input: { path: "/abs/foo.tsx" } },
+      { cwd: repoRoot },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("blocks an edit to a non-test source file when no colocated test was edited recently", async () => {
+    const { pi, handlers } = captureToolCallHandler();
+    setupExtension(pi);
+    const fx = makeFixtureProject();
+    try {
+      const result = await handlers.tool_call!(
+        {
+          toolName: "write",
+          input: {
+            path: path.join(fx.dir, "src/components/foo.tsx"),
+            content: "export const a = 1;\n",
+          },
+        },
+        { cwd: fx.dir },
+      );
+      expect(result).toBeDefined();
+      expect(result?.block).toBe(true);
+      expect(result?.reason).toMatch(/colocated test/i);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("allows an edit to an allowlisted path without a colocated test", async () => {
+    const { pi, handlers } = captureToolCallHandler();
+    setupExtension(pi);
+    const result = await handlers.tool_call!(
+      {
+        toolName: "write",
+        input: {
+          path: path.join(repoRoot, "docs/agent-compat.md"),
+          content: "# notes\n",
+        },
+      },
+      { cwd: repoRoot },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("allows a write whose new content carries the red-green:exempt marker", async () => {
+    const { pi, handlers } = captureToolCallHandler();
+    setupExtension(pi);
+    const result = await handlers.tool_call!(
+      {
+        toolName: "write",
+        input: {
+          path: path.join(repoRoot, "src/components/whatever.tsx"),
+          content:
+            "// red-green:exempt — trivial rename, no behavior change\nexport const x = 1;\n",
+        },
+      },
+      { cwd: repoRoot },
+    );
+    expect(result).toBeUndefined();
+  });
+});
+
+// Type-export reference so editor tooling pulls the type module in.
+type _GateInvocationRef = GateInvocation;


### PR DESCRIPTION
## Linked Issue

Closes #144

## Before Any Code Checklist

- [x] **Linked issue** (above).
- [x] **Branch:** `144-pi-red-green-extension`, off `main`.
- [x] **Preflight:** all-pass (`PREFLIGHT_SKIP_NETWORK=1 node .agents/skills/preflight/scripts/preflight.ts` against the worktree returned every row pass or skip).
- [x] **Failing test (RED):** `pnpm vitest run test/tooling/pi-red-green-extension.test.ts` failed with "Cannot find module" before the translator + extension existed; later, the integration test "blocks an edit to a non-test source file…" went red with `expected undefined to be defined` because the gate script silently bypassed `main()` under macOS symlinks. Both went green after the implementation + the production-bug fix in `scripts/red-green-gate.ts` landed.
- [x] **Architecture/plan check:** `docs/architecture.md` and `docs/agent-compat.md` skimmed. New code lives under `.pi/extensions/` (already allowlisted via `.pi/**`) and `test/tooling/`. No domain or application changes.

## Scope

Implements #144 — closes the cross-agent gap where pi sessions could edit `src/**/*.tsx` source files without the red-green gate firing.

- **`.pi/extensions/red-green-gate/translator.ts`** — pure function that turns pi's `tool_call` event into the JSON payload Claude Code and Codex hooks already send: `write` → `Write` (file_path + content), `edit` → `MultiEdit` (file_path + edits[].{old_string, new_string}). Returns `null` for non-edit/write tools and for malformed inputs.
- **`.pi/extensions/red-green-gate/index.ts`** — thin wiring. Subscribes to pi's `tool_call` event, runs the translator, `spawnSync`s `node scripts/red-green-gate.ts` with the payload on stdin, and translates the script's exit code back into pi's `{ block: true, reason }` return value when the gate refused. Same script, same ledger, same allowlist as Claude Code and Codex.
- **`scripts/red-green-gate.ts`** — one-line bug fix to the script's CLI-detection guard. The original `import.meta.url === pathToFileURL(process.argv[1]).href` check never matched when the script was invoked through a symlinked path. macOS symlinks `/tmp` → `/private/tmp` and `$TMPDIR` → `/private/var/folders/...`, so any test fixture under those paths silently bypassed `main()` (the script just exited 0 — allow). Fixed with a fallback `realpathSync()` comparison; comment explains why.
- **`docs/agent-compat.md`** — pi row, Hooks section, and "Updating the red-green hook surface" checklist now reference the landed extension instead of a deferred follow-up.

## Non-Goals

- **Pi `PostToolUse` analog.** This PR mirrors the `PreToolUse` behavior only. Pi has `tool_execution_end` if a future need arises.
- **Auto-installing the extension.** Pi auto-discovers `.pi/extensions/<name>/index.ts` per its docs; nothing else needs to be wired.
- **Updating `/preflight` to also check for the pi extension.** Worth doing later (currently preflight only verifies the Claude Code hook); leaving as a small follow-up so this PR stays focused.
- **Changing the script's CLI argument shape or stdin protocol.** The translator emits the existing payload format unchanged.

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests (265 passed + 3 skipped — 10 new in `test/tooling/pi-red-green-extension.test.ts`)
- [x] Build (n/a)
- [x] Foundational E2E (n/a)

```text
pnpm check
# 48 test files, 265 passed + 3 skipped — 10 new
```

The 10 new tests cover: `translateToolEvent` for write → Write, edit → MultiEdit, absolute and relative paths, non-edit/write tools, malformed input; extension wiring subscribes to the `tool_call` event; the handler returns undefined for irrelevant tools; the handler returns `{ block: true, reason }` for an unpaired source edit (integration with the real `scripts/red-green-gate.ts`); the handler allows allowlisted paths; the handler honors the inline `// red-green:exempt` marker.

## Architecture and Docs

- [x] Follows `docs/architecture.md`.
- [x] No domain/application/infrastructure boundary violations.
- [x] `docs/agent-compat.md` updated to reflect that pi-hook coverage is now complete.
- [x] No `AGENTS.md` change needed: the cross-agent reference there already pointed at `docs/agent-compat.md`.

## Type Safety

- [x] No `as any`, `: any`, `<any>`, `as unknown as`. (`pnpm type-escape:check` passes.)
- [x] Translator narrows pi's runtime event via discriminated checks rather than casts.
- [x] Extension's `ExtensionAPI` type is defined locally rather than imported from the pi package, so the repo doesn't gain a runtime dependency on `@mariozechner/pi-coding-agent` just to typecheck.

## Risk and Rollback

**Risks:**
- The extension assumes pi's `tool_call` event shape (`toolName`, `input.path`, `input.content`, `input.edits[].oldText`/`newText`). If pi changes that shape across releases, the translator stops translating and the extension silently allows edits. Mitigation: the translator returns `null` instead of throwing on bad input, so a worst-case mismatch reverts to "no enforcement" rather than "broken pi session." Locked-down version 0.70.2 in `docs/agent-compat.md`.
- The script-level realpathSync fix is unconditional. If a future hosting environment has a hooks dir without a real symlink resolution, the fallback might mask other issues; called out in the inline comment.
- The extension calls the script via `node $cwd/scripts/red-green-gate.ts`. If a clone is missing the script, the spawn fails and the handler returns undefined (allow). That's the existing fail-open posture of the red-green system.

**Rollback:**
- Remove `.pi/extensions/red-green-gate/` to disable pi enforcement; the script and the other two hooks are unaffected. The `realpathSync` change is independently revertable.

## Dependencies

None added.

## Stacked-PR notes

This PR is **not stacked** — it targets `main` directly, branched after #155 merged. No dependency on #157 (which is the freshly-opened replacement for the auto-closed #156).