### PR TITLE
feat(ui): toggle OpenRouter API key visibility in analyze panel

### DIFF
--- a/src/components/report/analyze-repository-panel.test.tsx
+++ b/src/components/report/analyze-repository-panel.test.tsx
@@ -141,6 +141,25 @@ describe("AnalyzeRepositoryPanel", () => {
     expect(screen.getByText("Scoring quality")).toBeTruthy();
   });
 
+  it("toggles the OpenRouter API key field between hidden and visible", async () => {
+    const user = userEvent.setup();
+
+    render(<AnalyzeRepositoryPanel />);
+
+    const apiKeyInput = screen.getByLabelText("OpenRouter API key");
+    if (!(apiKeyInput instanceof HTMLInputElement)) {
+      throw new Error("Expected the API key field to be an input.");
+    }
+
+    expect(apiKeyInput.type).toBe("password");
+
+    await user.click(screen.getByRole("button", { name: "Show API key" }));
+    expect(apiKeyInput.type).toBe("text");
+
+    await user.click(screen.getByRole("button", { name: "Hide API key" }));
+    expect(apiKeyInput.type).toBe("password");
+  });
+
   it("shows product-focused validation copy for invalid repository URLs", async () => {
     const fetchMock = mockSuccessfulAnalyzeFetch();
     const user = userEvent.setup();

--- a/src/components/report/analyze-repository-panel.tsx
+++ b/src/components/report/analyze-repository-panel.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   BarChart3,
   ChevronDown,
+  Eye,
+  EyeOff,
   GitBranch,
   KeyRound,
   Loader2,
@@ -88,6 +90,7 @@ export function AnalyzeRepositoryPanel() {
     () => defaultBrowserRepositoryForm(),
   );
   const [apiKey, setApiKey] = useState("");
+  const [apiKeyVisible, setApiKeyVisible] = useState(false);
   const [latestReport, setLatestReport] =
     useState<AnalyzeRepositoryResponse | null>(null);
   const [hydrated, setHydrated] = useState(false);
@@ -292,7 +295,7 @@ export function AnalyzeRepositoryPanel() {
                 <span className="sr-only">OpenRouter API key</span>
                 <input
                   name="openrouter-api-token"
-                  type="password"
+                  type={apiKeyVisible ? "text" : "password"}
                   autoCapitalize="none"
                   autoCorrect="off"
                   autoComplete="new-password"
@@ -305,6 +308,19 @@ export function AnalyzeRepositoryPanel() {
                   className="h-10 min-w-0 flex-1 bg-transparent text-sm text-[#161616] outline-none placeholder:text-[#8f887b]"
                   disabled={status.kind === "loading"}
                 />
+                <button
+                  type="button"
+                  onClick={() => setApiKeyVisible((current) => !current)}
+                  disabled={status.kind === "loading"}
+                  aria-label={apiKeyVisible ? "Hide API key" : "Show API key"}
+                  className="grid h-7 w-7 shrink-0 place-items-center text-[#7b7468] transition hover:text-[#161616] disabled:cursor-not-allowed disabled:text-[#bdb6a8]"
+                >
+                  {apiKeyVisible ? (
+                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                  ) : (
+                    <Eye className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </button>
               </label>
 
               <button


### PR DESCRIPTION
## Linked Issue

Closes #159

## Before Any Code Checklist

- [x] Linked issue (above)
- [x] Branch (`159-openrouter-key-visibility-toggle`, not `main`)
- [x] Preflight output (all checks `pass` with `PREFLIGHT_SKIP_NETWORK=1`; lefthook installed in fresh worktree)
- [x] Failing test (RED) observed before any non-test edit — `getByRole("button", { name: "Show API key" })` failed with the toggle absent, then went green after the implementation
- [x] Architecture/plan check against `docs/architecture.md` and `docs/development-plan.md` — UI-only change in `src/components/report/`, consistent with the "thin routes, reusable UI in components" rule and component-test requirement for accessibility-critical interactive controls

## Scope

Add an `Eye`/`EyeOff` toggle button next to the OpenRouter API key input in the analyze-repository panel. The field still defaults to `type=password`; clicking the toggle flips it to `type=text` and back, with the button's accessible name updating to match (`Show API key` ↔ `Hide API key`).

## Non-Goals

- No changes to how the key is stored, transmitted, or validated
- No changes to the analyze API route or any backend code
- No redesign of the surrounding form
- No persistence of the visibility preference across reloads

## Test Evidence

- [x] Lint
- [x] Format check
- [x] Typecheck
- [x] Unit/application tests (273 passed, 3 skipped)
- [ ] Build (not run; UI-only change, CI will exercise it)
- [ ] Foundational E2E (not affected; visibility toggle is new behavior with no existing E2E coverage path)

Commands run:

\`\`\`text
pnpm vitest run src/components/report/analyze-repository-panel.test.tsx   # RED, then GREEN
pnpm check                                                                # all green
\`\`\`

## Architecture And Docs

- [x] This follows `docs/architecture.md`
- [x] Architecture docs were updated, if architecture changed (n/a — no architecture change)
- [x] Development plan was updated, if planning or milestones changed (n/a)
- [x] No domain/application/infrastructure boundary violations were introduced

## Type Safety

- [x] Runtime data is parsed or narrowed instead of cast
- [x] No `as any`, `: any`, `<any>`, or `as unknown as` was introduced
- [x] Any unavoidable type escape uses a documented `type-escape:` marker (n/a — none introduced)

## Risk And Rollback

Low risk: localized state addition (one boolean) and one new button inside the existing form-control wrapper. No effect on key transmission or persistence. Rollback is a single revert.

## Dependencies

None. `Eye` and `EyeOff` come from the already-installed `lucide-react`.